### PR TITLE
firmware/qmk: sync

### DIFF
--- a/firmware/qmk/keyboards/rgoulter/minif4_36/config.h
+++ b/firmware/qmk/keyboards/rgoulter/minif4_36/config.h
@@ -6,30 +6,30 @@
 // RGB Matrix
 #ifdef RGB_MATRIX_ENABLE
 
-#ifdef SPLIT_KEYBOARD
+#    ifdef SPLIT_KEYBOARD
 // 18 + 4 on each side
-#define DRIVER_LED_TOTAL 44
-#define RGB_MATRIX_LED_COUNT 44
-#define RGB_MATRIX_SPLIT { 22,22 }
-#else
-#define DRIVER_LED_TOTAL 22
-#define RGB_MATRIX_LED_COUNT 22
-#endif
+#        define DRIVER_LED_TOTAL 44
+#        define RGB_MATRIX_LED_COUNT 44
+#        define RGB_MATRIX_SPLIT \
+            { 22, 22 }
+#    else
+#        define DRIVER_LED_TOTAL 22
+#        define RGB_MATRIX_LED_COUNT 22
+#    endif
 
-#define RGB_MATRIX_KEYPRESSES
+#    define RGB_MATRIX_KEYPRESSES
 
 #endif
 
 // OLED
 #ifdef OLED_ENABLE
 /* B8, B9 instead of B6, B7 */
-#define I2C1_SCL_PIN B8
-#define I2C1_SDA_PIN B9
+#    define I2C1_SCL_PIN B8
+#    define I2C1_SDA_PIN B9
 #endif
-
 
 #ifdef SPLIT_KEYBOARD
-#ifdef HAPTIC_ENABLE
-#define SPLIT_HAPTIC_ENABLE
-#endif
+#    ifdef HAPTIC_ENABLE
+#        define SPLIT_HAPTIC_ENABLE
+#    endif
 #endif

--- a/firmware/qmk/keyboards/rgoulter/minif4_36/halconf.h
+++ b/firmware/qmk/keyboards/rgoulter/minif4_36/halconf.h
@@ -4,16 +4,16 @@
 #pragma once
 
 #ifdef OLED_ENABLE
-#define HAL_USE_I2C TRUE
+#    define HAL_USE_I2C TRUE
 #endif
 
 #ifdef RGB_MATRIX_ENABLE
-#define HAL_USE_PWM TRUE
+#    define HAL_USE_PWM TRUE
 #endif
 
 #ifdef SPLIT_KEYBOARD
-#define PAL_USE_CALLBACKS TRUE
-#define PAL_USE_WAIT TRUE
+#    define PAL_USE_CALLBACKS TRUE
+#    define PAL_USE_WAIT TRUE
 #endif
 
 #include_next <halconf.h>

--- a/firmware/qmk/keyboards/rgoulter/minif4_36/minif4_36.c
+++ b/firmware/qmk/keyboards/rgoulter/minif4_36/minif4_36.c
@@ -4,7 +4,7 @@
 #include "minif4_36.h"
 
 #ifdef SPLIT_KEYBOARD
-#include "split_util.h"
+#    include "split_util.h"
 #endif
 
 void board_init(void) {

--- a/firmware/qmk/keyboards/rgoulter/minif4_36/minif4_36.h
+++ b/firmware/qmk/keyboards/rgoulter/minif4_36/minif4_36.h
@@ -4,4 +4,3 @@
 #pragma once
 
 #include "quantum.h"
-

--- a/firmware/qmk/keyboards/rgoulter/x_2/config.h
+++ b/firmware/qmk/keyboards/rgoulter/x_2/config.h
@@ -5,22 +5,22 @@
 
 // RGB Lighting
 #ifdef RGBLIGHT_ENABLE
-#define DRIVER_LED_TOTAL 4
-#define RGBLED_NUM 4
-#define RGBLIGHT_LIMIT_VAL 80
-#define RGBLIGHT_DEFAULT_VAL 30
-#define RGBLIGHT_VAL_STEP 8
+#    define DRIVER_LED_TOTAL 4
+#    define RGBLED_NUM 4
+#    define RGBLIGHT_LIMIT_VAL 80
+#    define RGBLIGHT_DEFAULT_VAL 30
+#    define RGBLIGHT_VAL_STEP 8
 #endif
 
 #ifdef RGB_MATRIX_ENABLE
-#define DRIVER_LED_TOTAL 70
-#define RGBLED_NUM 70
-#define RGB_MATRIX_LED_COUNT 70
-#define RGB_MATRIX_KEYPRESSES
+#    define DRIVER_LED_TOTAL 70
+#    define RGBLED_NUM 70
+#    define RGB_MATRIX_LED_COUNT 70
+#    define RGB_MATRIX_KEYPRESSES
 #endif
 
 #ifdef RGB_MATRIX_ENABLE
-#ifdef RGBLIGHT_ENABLE
-#error "rgblight and rgb_matrix both enabled"
-#endif
+#    ifdef RGBLIGHT_ENABLE
+#        error "rgblight and rgb_matrix both enabled"
+#    endif
 #endif

--- a/firmware/qmk/keyboards/rgoulter/x_2/halconf.h
+++ b/firmware/qmk/keyboards/rgoulter/x_2/halconf.h
@@ -4,11 +4,11 @@
 #pragma once
 
 #ifdef RGBLIGHT_ENABLE
-#define HAL_USE_PWM TRUE
+#    define HAL_USE_PWM TRUE
 #endif
 
 #ifdef RGB_MATRIX_ENABLE
-#define HAL_USE_PWM TRUE
+#    define HAL_USE_PWM TRUE
 #endif
 
 #include_next <halconf.h>

--- a/firmware/qmk/layouts/community/ortho_5x12/rgoulter/keymap.c
+++ b/firmware/qmk/layouts/community/ortho_5x12/rgoulter/keymap.c
@@ -3,7 +3,7 @@
 
 #include "raw_hid.h"
 
-#include "rgoulter.h"
+#include "users/rgoulter/rgoulter.h"
 
 extern keymap_config_t keymap_config;
 
@@ -12,41 +12,43 @@ extern keymap_config_t keymap_config;
 // Layer names don't all need to be of the same length, obviously, and you can also skip them
 // entirely and just use numbers.
 enum layers {
-  _DVORAK,
-  _QWERTY,
-  _GAMING,
-  _LOWER,
-  _LOWER2,
-  _RAISE,
-  _RAISE2,
-  _CHILDPROOF,
-  _ADJUST,
-  _FN,
+    _DVORAK,
+    _QWERTY,
+    _GAMING,
+    _TOMB,
+    _LOWER,
+    _LOWER2,
+    _RAISE,
+    _RAISE2,
+    _CHILDPROOF,
+    _ADJUST,
+    _FN,
 };
 
 enum custom_keycodes {
-  U_CUT = NEW_SAFE_RANGE,
-  U_COPY,
-  U_PASTE,
-  U_UNDO,
-  U_REDO,
+    U_CUT = NEW_SAFE_RANGE,
+    U_COPY,
+    U_PASTE,
+    U_UNDO,
+    U_REDO,
 };
 
-#define QWERTY     DF(_QWERTY)
-#define DVORAK     DF(_DVORAK)
-#define GAMING     DF(_GAMING)
+#define QWERTY DF(_QWERTY)
+#define DVORAK DF(_DVORAK)
+#define GAMING DF(_GAMING)
+#define TOMB DF(_TOMB)
 #define CHILDPROOF DF(_CHILDPROOF)
 
-#define LOWER      MO(_LOWER)
-#define LOWER2     MO(_LOWER2)
-#define RAISE      MO(_RAISE)
-#define RAISE2     MO(_RAISE2)
-#define ADJUST     MO(_ADJUST)
-#define FN         MO(_FN)
+#define LOWER MO(_LOWER)
+#define LOWER2 MO(_LOWER2)
+#define RAISE MO(_RAISE)
+#define RAISE2 MO(_RAISE2)
+#define ADJUST MO(_ADJUST)
+#define FN MO(_FN)
 
-#define __SEG12_XXXXXXX__  XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,    XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX
+#define __SEG12_XXXXXXX__ XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX
 
-#define LAYOUT_wrapper(...)            LAYOUT_ortho_5x12(__VA_ARGS__)
+#define LAYOUT_wrapper(...) LAYOUT_ortho_5x12(__VA_ARGS__)
 
 // XXX: Let's ... move the function keys away from LOWER layer.
 
@@ -54,6 +56,7 @@ enum custom_keycodes {
 
 // XXX KC_APP
 
+// clang-format off
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
 // Dvorak, with Home-Row Mods
@@ -95,6 +98,20 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     KC_CAPS,   ___SEG5_QWERTY_LHS_SIMPLE_2___,               ___SEG5_QWERTY_RHS_SIMPLE_2___,   KC_QUOT,
     KC_LSFT,   ___SEG5_QWERTY_LHS_SIMPLE_3___,               ___SEG5_QWERTY_RHS_SIMPLE_3___,   KC_ENT,
     KC_LCTL,   KC_LGUI, KC_LALT, KC_TAB, LWR_ESC, KC_SPC,    KC_BSPC, RSE_ENT, ___SEG4_NAV_LDUR___
+),
+
+// Tomb Raider (Remastered)
+//
+// F1 - toggle gfx
+// F3 - camera mode
+// F5 - open save menu
+// F9 - open load menu
+[_TOMB] = LAYOUT_wrapper( \
+    KC_GRV,    ___SEG5_12345___,                                ___SEG5_67890___,                 KC_BSPC,
+    KC_ESC,  KC_PGDN, KC_UP,   KC_PGUP,   KC_F9,   _______,     KC_NUM,  _______,  _______, _______, _______, _______,
+    KC_LSFT, KC_LEFT, KC_DOWN, KC_RIGHT,  KC_F5,   _______,     KC_KP_0, KC_LCTL,  KC_SPC,  KC_LALT, KC_SLSH, _______,
+    KC_F1,   KC_F3,   _______, _______,   _______, _______,     KC_DOT,  KC_COMMA, _______, _______, _______, _______,
+    NK_ON,   NK_OFF, _______, _______,   KC_END,  KC_LALT,     KC_DOT,  KC_COMMA, _______, _______, GAMING,  DVORAK
 ),
 
 // LOWER
@@ -196,7 +213,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 [_ADJUST] = LAYOUT_wrapper(
     _______,   _______, _______, _______, _______, _______,    _______, _______, _______, _______, _______,   _______,
     _______,   QK_BOOT, _______, _______, _______, _______,    _______, ___SEG3_SYS___,            _______,   _______,
-    KC_CAPS,   DM_REC2, DM_REC1, DM_PLY2, DM_PLY1, DM_RSTP,    _______, QWERTY,  GAMING,  DVORAK,  CHILDPROOF,  _______,
+    KC_CAPS,   DM_REC2, DM_REC1, DM_PLY2, DM_PLY1, DM_RSTP,    _______, QWERTY,  GAMING,  DVORAK,  CHILDPROOF,  TOMB,
     _______,   _______, OSWIN,   OSMACOS, OSLINUX, _______,    _______, _______, KC_BTN1, KC_BTN2, KC_WH_D,   KC_WH_U,
     _______,   _______, _______, _______, XXXXXXX, _______,    _______, XXXXXXX, KC_MS_L, KC_MS_D, KC_MS_U,   KC_MS_R
 ),
@@ -216,94 +233,93 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 )
 
 };
+// clang-format on
 
 layer_state_t layer_state_set_user(layer_state_t state) {
-  return update_tri_layer_state(state, _LOWER, _RAISE, _ADJUST);
+    return update_tri_layer_state(state, _LOWER, _RAISE, _ADJUST);
 }
 
 bool process_record_keymap(uint16_t keycode, keyrecord_t *record) {
-  bool pressed = record->event.pressed;
-  switch (keycode) {
-  case U_CUT:
-    if (pressed) {
-      switch(current_os) {
-        case _OS_LINUX:
-          tap_code16(CODE16_LINUX_CUT);
-          break;
-        case _OS_MACOS:
-          tap_code16(CODE16_MACOS_CUT);
-          break;
-        case _OS_WIN:
-          tap_code16(CODE16_WIN_CUT);
-          break;
-      }
+    bool pressed = record->event.pressed;
+    switch (keycode) {
+        case U_CUT:
+            if (pressed) {
+                switch (current_os) {
+                    case _OS_LINUX:
+                        tap_code16(CODE16_LINUX_CUT);
+                        break;
+                    case _OS_MACOS:
+                        tap_code16(CODE16_MACOS_CUT);
+                        break;
+                    case _OS_WIN:
+                        tap_code16(CODE16_WIN_CUT);
+                        break;
+                }
+            }
+            return false;
+        case U_COPY:
+            if (pressed) {
+                switch (current_os) {
+                    case _OS_LINUX:
+                        tap_code16(CODE16_LINUX_COPY);
+                        break;
+                    case _OS_MACOS:
+                        tap_code16(CODE16_MACOS_COPY);
+                        break;
+                    case _OS_WIN:
+                        tap_code16(CODE16_WIN_COPY);
+                        break;
+                }
+            }
+            return false;
+        case U_PASTE:
+            if (pressed) {
+                switch (current_os) {
+                    case _OS_LINUX:
+                        tap_code16(CODE16_LINUX_PASTE);
+                        break;
+                    case _OS_MACOS:
+                        tap_code16(CODE16_MACOS_PASTE);
+                        break;
+                    case _OS_WIN:
+                        tap_code16(CODE16_WIN_PASTE);
+                        break;
+                }
+            }
+            return false;
+        case U_UNDO:
+            if (pressed) {
+                switch (current_os) {
+                    case _OS_LINUX:
+                        tap_code16(CODE16_LINUX_UNDO);
+                        break;
+                    case _OS_MACOS:
+                        tap_code16(CODE16_MACOS_UNDO);
+                        break;
+                    case _OS_WIN:
+                        tap_code16(CODE16_WIN_UNDO);
+                        break;
+                }
+            }
+            return false;
+        case U_REDO:
+            if (pressed) {
+                switch (current_os) {
+                    case _OS_LINUX:
+                        tap_code16(CODE16_LINUX_REDO);
+                        break;
+                    case _OS_MACOS:
+                        tap_code16(CODE16_MACOS_REDO);
+                        break;
+                    case _OS_WIN:
+                        tap_code16(CODE16_WIN_REDO);
+                        break;
+                }
+            }
+            return false;
     }
-    return false;
-  case U_COPY:
-    if (pressed) {
-      switch(current_os) {
-        case _OS_LINUX:
-          tap_code16(CODE16_LINUX_COPY);
-          break;
-        case _OS_MACOS:
-          tap_code16(CODE16_MACOS_COPY);
-          break;
-        case _OS_WIN:
-          tap_code16(CODE16_WIN_COPY);
-          break;
-      }
-    }
-    return false;
-  case U_PASTE:
-    if (pressed) {
-      switch(current_os) {
-        case _OS_LINUX:
-          tap_code16(CODE16_LINUX_PASTE);
-          break;
-        case _OS_MACOS:
-          tap_code16(CODE16_MACOS_PASTE);
-          break;
-        case _OS_WIN:
-          tap_code16(CODE16_WIN_PASTE);
-          break;
-      }
-    }
-    return false;
-  case U_UNDO:
-    if (pressed) {
-      switch(current_os) {
-        case _OS_LINUX:
-          tap_code16(CODE16_LINUX_UNDO);
-          break;
-        case _OS_MACOS:
-          tap_code16(CODE16_MACOS_UNDO);
-          break;
-        case _OS_WIN:
-          tap_code16(CODE16_WIN_UNDO);
-          break;
-      }
-    }
-    return false;
-  case U_REDO:
-    if (pressed) {
-      switch(current_os) {
-        case _OS_LINUX:
-          tap_code16(CODE16_LINUX_REDO);
-          break;
-        case _OS_MACOS:
-          tap_code16(CODE16_MACOS_REDO);
-          break;
-        case _OS_WIN:
-          tap_code16(CODE16_WIN_REDO);
-          break;
-      }
-    }
-    return false;
-
-  }
-  return true;
+    return true;
 }
-
 
 // RAW_EPSIZE is 32
 void raw_hid_receive(uint8_t *data, uint8_t length) {
@@ -312,10 +328,10 @@ void raw_hid_receive(uint8_t *data, uint8_t length) {
 
 void keyboard_post_init_user(void) {
 #ifdef RGBLIGHT_ENABLE
-  rgblight_mode_noeeprom(RGBLIGHT_MODE_RAINBOW_SWIRL + 4);
+    rgblight_mode_noeeprom(RGBLIGHT_MODE_RAINBOW_SWIRL + 4);
 #endif
 #ifdef RGB_MATRIX_ENABLE
-  rgb_matrix_mode_noeeprom(RGB_MATRIX_CYCLE_PINWHEEL);
+    rgb_matrix_mode_noeeprom(RGB_MATRIX_CYCLE_PINWHEEL);
 #endif
 }
 

--- a/firmware/qmk/layouts/community/planck_mit/rgoulter-pinkieoutercolumn/keymap.c
+++ b/firmware/qmk/layouts/community/planck_mit/rgoulter-pinkieoutercolumn/keymap.c
@@ -3,7 +3,7 @@
 
 #include "raw_hid.h"
 
-#include "rgoulter.h"
+#include "users/rgoulter/rgoulter.h"
 
 extern keymap_config_t keymap_config;
 
@@ -12,41 +12,41 @@ extern keymap_config_t keymap_config;
 // Layer names don't all need to be of the same length, obviously, and you can also skip them
 // entirely and just use numbers.
 enum layers {
-  _DVORAK,
-  _QWERTY,
-  _GAMING,
-  _LOWER,
-  _LOWER2,
-  _RAISE,
-  _RAISE2,
-  _CHILDPROOF,
-  _CHECK,
-  _ADJUST,
-  _FN,
+    _DVORAK,
+    _QWERTY,
+    _GAMING,
+    _LOWER,
+    _LOWER2,
+    _RAISE,
+    _RAISE2,
+    _CHILDPROOF,
+    _CHECK,
+    _ADJUST,
+    _FN,
 };
 
 enum custom_keycodes {
-  U_CUT = NEW_SAFE_RANGE,
-  U_COPY,
-  U_PASTE,
-  U_UNDO,
-  U_REDO,
+    U_CUT = NEW_SAFE_RANGE,
+    U_COPY,
+    U_PASTE,
+    U_UNDO,
+    U_REDO,
 };
 
-#define QWERTY     DF(_QWERTY)
-#define GAMING     DF(_GAMING)
-#define DVORAK     DF(_DVORAK)
+#define QWERTY DF(_QWERTY)
+#define GAMING DF(_GAMING)
+#define DVORAK DF(_DVORAK)
 #define CHILDPROOF DF(_CHILDPROOF)
-#define CHECK      DF(_CHECK)
+#define CHECK DF(_CHECK)
 
-#define LOWER      MO(_LOWER)
-#define LOWER2     MO(_LOWER2)
-#define RAISE      MO(_RAISE)
-#define RAISE2     MO(_RAISE2)
-#define ADJUST     MO(_ADJUST)
-#define FN         MO(_FN)
+#define LOWER MO(_LOWER)
+#define LOWER2 MO(_LOWER2)
+#define RAISE MO(_RAISE)
+#define RAISE2 MO(_RAISE2)
+#define ADJUST MO(_ADJUST)
+#define FN MO(_FN)
 
-#define LAYOUT_wrapper(...)            LAYOUT_planck_mit(__VA_ARGS__)
+#define LAYOUT_wrapper(...) LAYOUT_planck_mit(__VA_ARGS__)
 
 // XXX: Let's ... move the function keys away from LOWER layer.
 
@@ -56,13 +56,14 @@ enum custom_keycodes {
 
 #ifdef CORNER_RESET_ENABLE
 keypos_t boot_keypositions[4] = {
-  { .col = 1, .row = 0 },
-  { .col = 1, .row = MATRIX_ROWS - 2 },
-  { .col = MATRIX_COLS - 2, .row = 0 },
-  { .col = MATRIX_COLS - 2, .row = MATRIX_ROWS - 2 },
+    {.col = 1, .row = 0},
+    {.col = 1, .row = MATRIX_ROWS - 2},
+    {.col = MATRIX_COLS - 2, .row = 0},
+    {.col = MATRIX_COLS - 2, .row = MATRIX_ROWS - 2},
 };
 #endif
 
+// clang-format off
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
 // Dvorak, with Home-Row Mods
@@ -232,94 +233,93 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 )
 
 };
+// clang-format on
 
 layer_state_t layer_state_set_user(layer_state_t state) {
-  return update_tri_layer_state(state, _LOWER, _RAISE, _ADJUST);
+    return update_tri_layer_state(state, _LOWER, _RAISE, _ADJUST);
 }
 
 bool process_record_keymap(uint16_t keycode, keyrecord_t *record) {
-  bool pressed = record->event.pressed;
-  switch (keycode) {
-  case U_CUT:
-    if (pressed) {
-      switch(current_os) {
-        case _OS_LINUX:
-          tap_code16(CODE16_LINUX_CUT);
-          break;
-        case _OS_MACOS:
-          tap_code16(CODE16_MACOS_CUT);
-          break;
-        case _OS_WIN:
-          tap_code16(CODE16_WIN_CUT);
-          break;
-      }
+    bool pressed = record->event.pressed;
+    switch (keycode) {
+        case U_CUT:
+            if (pressed) {
+                switch (current_os) {
+                    case _OS_LINUX:
+                        tap_code16(CODE16_LINUX_CUT);
+                        break;
+                    case _OS_MACOS:
+                        tap_code16(CODE16_MACOS_CUT);
+                        break;
+                    case _OS_WIN:
+                        tap_code16(CODE16_WIN_CUT);
+                        break;
+                }
+            }
+            return false;
+        case U_COPY:
+            if (pressed) {
+                switch (current_os) {
+                    case _OS_LINUX:
+                        tap_code16(CODE16_LINUX_COPY);
+                        break;
+                    case _OS_MACOS:
+                        tap_code16(CODE16_MACOS_COPY);
+                        break;
+                    case _OS_WIN:
+                        tap_code16(CODE16_WIN_COPY);
+                        break;
+                }
+            }
+            return false;
+        case U_PASTE:
+            if (pressed) {
+                switch (current_os) {
+                    case _OS_LINUX:
+                        tap_code16(CODE16_LINUX_PASTE);
+                        break;
+                    case _OS_MACOS:
+                        tap_code16(CODE16_MACOS_PASTE);
+                        break;
+                    case _OS_WIN:
+                        tap_code16(CODE16_WIN_PASTE);
+                        break;
+                }
+            }
+            return false;
+        case U_UNDO:
+            if (pressed) {
+                switch (current_os) {
+                    case _OS_LINUX:
+                        tap_code16(CODE16_LINUX_UNDO);
+                        break;
+                    case _OS_MACOS:
+                        tap_code16(CODE16_MACOS_UNDO);
+                        break;
+                    case _OS_WIN:
+                        tap_code16(CODE16_WIN_UNDO);
+                        break;
+                }
+            }
+            return false;
+        case U_REDO:
+            if (pressed) {
+                switch (current_os) {
+                    case _OS_LINUX:
+                        tap_code16(CODE16_LINUX_REDO);
+                        break;
+                    case _OS_MACOS:
+                        tap_code16(CODE16_MACOS_REDO);
+                        break;
+                    case _OS_WIN:
+                        tap_code16(CODE16_WIN_REDO);
+                        break;
+                }
+            }
+            return false;
     }
-    return false;
-  case U_COPY:
-    if (pressed) {
-      switch(current_os) {
-        case _OS_LINUX:
-          tap_code16(CODE16_LINUX_COPY);
-          break;
-        case _OS_MACOS:
-          tap_code16(CODE16_MACOS_COPY);
-          break;
-        case _OS_WIN:
-          tap_code16(CODE16_WIN_COPY);
-          break;
-      }
-    }
-    return false;
-  case U_PASTE:
-    if (pressed) {
-      switch(current_os) {
-        case _OS_LINUX:
-          tap_code16(CODE16_LINUX_PASTE);
-          break;
-        case _OS_MACOS:
-          tap_code16(CODE16_MACOS_PASTE);
-          break;
-        case _OS_WIN:
-          tap_code16(CODE16_WIN_PASTE);
-          break;
-      }
-    }
-    return false;
-  case U_UNDO:
-    if (pressed) {
-      switch(current_os) {
-        case _OS_LINUX:
-          tap_code16(CODE16_LINUX_UNDO);
-          break;
-        case _OS_MACOS:
-          tap_code16(CODE16_MACOS_UNDO);
-          break;
-        case _OS_WIN:
-          tap_code16(CODE16_WIN_UNDO);
-          break;
-      }
-    }
-    return false;
-  case U_REDO:
-    if (pressed) {
-      switch(current_os) {
-        case _OS_LINUX:
-          tap_code16(CODE16_LINUX_REDO);
-          break;
-        case _OS_MACOS:
-          tap_code16(CODE16_MACOS_REDO);
-          break;
-        case _OS_WIN:
-          tap_code16(CODE16_WIN_REDO);
-          break;
-      }
-    }
-    return false;
-
-  }
-  return true;
+    return true;
 }
-
 
 // RAW_EPSIZE is 32
 void raw_hid_receive(uint8_t *data, uint8_t length) {

--- a/firmware/qmk/layouts/community/planck_mit/rgoulter/keymap.c
+++ b/firmware/qmk/layouts/community/planck_mit/rgoulter/keymap.c
@@ -3,7 +3,7 @@
 
 #include "raw_hid.h"
 
-#include "rgoulter.h"
+#include "users/rgoulter/rgoulter.h"
 
 extern keymap_config_t keymap_config;
 
@@ -12,51 +12,51 @@ extern keymap_config_t keymap_config;
 // Layer names don't all need to be of the same length, obviously, and you can also skip them
 // entirely and just use numbers.
 enum layers {
-  _DVORAK,
-  _QWERTY,
-  _LOWER,
-  _LOWER2,
-  _RAISE,
-  _RAISE2,
-  _CHILDPROOF,
-  _CHECK,
-  _NUMPAD,
-  _ADJUST,
+    _DVORAK,
+    _QWERTY,
+    _LOWER,
+    _LOWER2,
+    _RAISE,
+    _RAISE2,
+    _CHILDPROOF,
+    _CHECK,
+    _NUMPAD,
+    _ADJUST,
 };
 
-#define QWERTY     DF(_QWERTY)
-#define DVORAK     DF(_DVORAK)
+#define QWERTY DF(_QWERTY)
+#define DVORAK DF(_DVORAK)
 #define CHILDPROOF DF(_CHILDPROOF)
 #define CHECK DF(_CHECK)
-#define LOWER   MO(_LOWER)
-#define LOWER2   MO(_LOWER2)
-#define RAISE   MO(_RAISE)
-#define RAISE2   MO(_RAISE2)
-#define NUMPAD  MO(_NUMPAD)
-#define ADJUST  MO(_ADJUST)
+#define LOWER MO(_LOWER)
+#define LOWER2 MO(_LOWER2)
+#define RAISE MO(_RAISE)
+#define RAISE2 MO(_RAISE2)
+#define NUMPAD MO(_NUMPAD)
+#define ADJUST MO(_ADJUST)
 
 #undef ___BASE_BOTTOM_ROW___
-#define ___BASE_BOTTOM_ROW___ \
-  NUMPAD, _______, _______, LWR_TAB, LW2_ESC,    KC_SPC,      RS2_BSP,    RSE_ENT, _______, _______, _______
+#define ___BASE_BOTTOM_ROW___ NUMPAD, _______, _______, LWR_TAB, LW2_ESC, KC_SPC, RS2_BSP, RSE_ENT, _______, _______, _______
 
-#define LAYOUT_wrapper(...)            LAYOUT_planck_mit(__VA_ARGS__)
+#define LAYOUT_wrapper(...) LAYOUT_planck_mit(__VA_ARGS__)
 
+// clang-format off
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
 // XXX: aim for one-handed cursor keys?
 
 [_DVORAK] = LAYOUT_wrapper( \
-  ___SEG5_DVORAK_LHS_1___, KC_TAB,     KC_BSPC, ___SEG5_DVORAK_RHS_1___,    \
-  ___SEG5_DVORAK_LHS_2___, LCTLESC,    RCTLENT, ___SEG5_DVORAK_RHS_2___, \
-  ___SEG5_DVORAK_LHS_3___, _______,    _______, ___SEG5_DVORAK_RHS_3___,      \
-                                           ___BASE_BOTTOM_ROW___ \
+    ___SEG5_DVORAK_LHS_1___, KC_TAB,     KC_BSPC, ___SEG5_DVORAK_RHS_1___,    \
+    ___SEG5_DVORAK_LHS_2___, LCTLESC,    RCTLENT, ___SEG5_DVORAK_RHS_2___, \
+    ___SEG5_DVORAK_LHS_3___, _______,    _______, ___SEG5_DVORAK_RHS_3___,      \
+                            ___BASE_BOTTOM_ROW___ \
 ),
 
 [_QWERTY] = LAYOUT_wrapper( \
-  ___SEG5_QWERTY_LHS_1___, KC_TAB,     KC_BSPC, ___SEG5_QWERTY_RHS_1___,    \
-  ___SEG5_QWERTY_LHS_2___, LCTLESC,    RCTLENT, ___SEG5_QWERTY_RHS_2___, \
-  ___SEG5_QWERTY_LHS_3___, _______,    _______, ___SEG5_QWERTY_RHS_3___,      \
-                                           ___BASE_BOTTOM_ROW___ \
+    ___SEG5_QWERTY_LHS_1___, KC_TAB,     KC_BSPC, ___SEG5_QWERTY_RHS_1___,    \
+    ___SEG5_QWERTY_LHS_2___, LCTLESC,    RCTLENT, ___SEG5_QWERTY_RHS_2___, \
+    ___SEG5_QWERTY_LHS_3___, _______,    _______, ___SEG5_QWERTY_RHS_3___,      \
+                            ___BASE_BOTTOM_ROW___ \
 ),
 
 /*
@@ -74,17 +74,17 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
  */
 
 [_LOWER] = LAYOUT_wrapper( \
-  KC_EXLM, KC_AT,   KC_HASH, KC_DLR,  KC_PERC, KC_TILD, KC_PIPE, KC_CIRC, KC_AMPR, KC_ASTR, KC_LPRN, KC_RPRN, \
-  KC_TILD, _______, _______, _______, _______, KC_INS,  KC_QUES, KC_INS,  KC_UNDS, KC_PLUS, KC_LCBR, KC_RCBR, \
-  KC_QUES, KC_CUT,  KC_COPY, KC_PSTE, KC_PIPE, _______, _______, _______, _______, _______, KC_QUES, KC_PIPE, \
-  _______, _______, _______, XXXXXXX, _______,     _______,      _______, _______, _______, _______, _______ \
+    KC_EXLM, KC_AT,   KC_HASH, KC_DLR,  KC_PERC, KC_TILD, KC_PIPE, KC_CIRC, KC_AMPR, KC_ASTR, KC_LPRN, KC_RPRN, \
+    KC_TILD, _______, _______, _______, _______, KC_INS,  KC_QUES, KC_INS,  KC_UNDS, KC_PLUS, KC_LCBR, KC_RCBR, \
+    KC_QUES, KC_CUT,  KC_COPY, KC_PSTE, KC_PIPE, _______, _______, _______, _______, _______, KC_QUES, KC_PIPE, \
+    _______, _______, _______, XXXXXXX, _______,     _______,      _______, _______, _______, _______, _______ \
 ),
 
 [_LOWER2] = LAYOUT_wrapper( \
-  KC_F12,  KC_F7,   KC_F8,   KC_F9,   KC_PSCR, _______, _______, _______, _______, _______, _______, _______, \
-  KC_F11,  KC_F4,   KC_F5,   KC_F6,   KC_SCRL, _______, _______, ___SEG4_NAV_LDUR___, _______, \
-  KC_F10,  KC_F1,   KC_F2,   KC_F3,   KC_PAUS, _______, _______, ___SEG4_NAV3___,     _______, \
-  _______, _______, _______, _______, XXXXXXX,     _______,      _______, _______, _______, _______, _______ \
+    KC_F12,  KC_F7,   KC_F8,   KC_F9,   KC_PSCR, _______, _______, _______, _______, _______, _______, _______, \
+    KC_F11,  KC_F4,   KC_F5,   KC_F6,   KC_SCRL, _______, _______, ___SEG4_NAV_LDUR___, _______, \
+    KC_F10,  KC_F1,   KC_F2,   KC_F3,   KC_PAUS, _______, _______, ___SEG4_NAV3___,     _______, \
+    _______, _______, _______, _______, XXXXXXX,     _______,      _______, _______, _______, _______, _______ \
 ),
 
 /*
@@ -101,24 +101,24 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
  *       Kitty, or even some programs like Kicad or OpenScad.
  */
 [_RAISE] = LAYOUT_planck_mit( \
-  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_GRV,  KC_BSLS, KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    \
-  KC_GRV,  _______, _______, _______, _______, KC_DEL,  KC_SLSH, KC_DEL,  KC_MINS, KC_EQL,  KC_LBRC, KC_RBRC, \
-  KC_SLSH, KC_CUT,  KC_COPY, KC_PSTE, KC_BSLS, _______, _______, _______, _______, _______, KC_SLSH, KC_BSLS, \
-  _______, _______, _______, _______, _______,    _______,       _______, XXXXXXX, _______, _______, _______ \
+    KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_GRV,  KC_BSLS, KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    \
+    KC_GRV,  _______, _______, _______, _______, KC_DEL,  KC_SLSH, KC_DEL,  KC_MINS, KC_EQL,  KC_LBRC, KC_RBRC, \
+    KC_SLSH, KC_CUT,  KC_COPY, KC_PSTE, KC_BSLS, _______, _______, _______, _______, _______, KC_SLSH, KC_BSLS, \
+    _______, _______, _______, _______, _______,    _______,       _______, XXXXXXX, _______, _______, _______ \
 ),
 
 [_RAISE2] = LAYOUT_wrapper( \
-  _______, _______, _______, _______, _______, _______, _______, _______, KC_BTN1, KC_BTN2, KC_BTN3, _______, \
-  _______, _______, _______, _______, _______, _______, _______, ___SEG4_MOU_MV___,                  _______, \
-  _______, _______, _______, _______, _______, _______, _______, ___SEG4_MOU_WH___,                  _______, \
-  _______, _______, _______, _______, _______,     _______,      XXXXXXX, _______, _______, _______, _______ \
+    _______, _______, _______, _______, _______, _______, _______, _______, KC_BTN1, KC_BTN2, KC_BTN3, _______, \
+    _______, _______, _______, _______, _______, _______, _______, ___SEG4_MOU_MV___,                  _______, \
+    _______, _______, _______, _______, _______, _______, _______, ___SEG4_MOU_WH___,                  _______, \
+    _______, _______, _______, _______, _______,     _______,      XXXXXXX, _______, _______, _______, _______ \
 ),
 
 [_CHILDPROOF] = LAYOUT_planck_mit( \
-  XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, \
-  XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, \
-  XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, \
-  LOWER,   XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,     XXXXXXX,      XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, RAISE \
+    XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, \
+    XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, \
+    XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, \
+    LOWER,   XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX,     XXXXXXX,      XXXXXXX, XXXXXXX, XXXXXXX, XXXXXXX, RAISE \
 ),
 
 // CHECK
@@ -135,23 +135,24 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 ),
 
 [_NUMPAD] = LAYOUT_planck_mit( \
-  _______, KC_7,    KC_8,    KC_9,   _______, _______, _______, _______, _______,    _______,    _______,    _______, \
-  _______, KC_4,    KC_5,    KC_6,   _______, _______, _______, _______, _______,    _______,    _______,    _______, \
-  _______, KC_1,    KC_2,    KC_3,   _______, _______, _______, _______, _______,    _______,    _______,    _______, \
-  XXXXXXX, KC_0,    KC_0,    KC_DOT, _______,     _______,      _______, _______,    _______,    _______,  _______  \
+    _______, KC_7,    KC_8,    KC_9,   _______, _______, _______, _______, _______,    _______,    _______,    _______, \
+    _______, KC_4,    KC_5,    KC_6,   _______, _______, _______, _______, _______,    _______,    _______,    _______, \
+    _______, KC_1,    KC_2,    KC_3,   _______, _______, _______, _______, _______,    _______,    _______,    _______, \
+    XXXXXXX, KC_0,    KC_0,    KC_DOT, _______,     _______,      _______, _______,    _______,    _______,  _______  \
 ),
 
 [_ADJUST] =  LAYOUT_wrapper( \
-  QK_BOOT, RGB_TOG, RGB_MOD, RGB_HUI, RGB_HUD, RGB_SAI, RGB_SAD, RGB_VAI, RGB_VAD, RGB_SPI, RGB_SPD, _______,
-  KC_CAPS, _______, _______, _______, _______, _______, _______, QWERTY,  XXXXXXX, DVORAK,  CHILDPROOF, CHECK, \
-  _______, _______, OSWIN,   OSMACOS, OSLINUX, _______, _______, ___SEG4_MED___, KC_MPLY, \
-  _______, _______, _______, XXXXXXX, _______,     _______,      _______, XXXXXXX, _______, _______, _______ \
+    QK_BOOT, RGB_TOG, RGB_MOD, RGB_HUI, RGB_HUD, RGB_SAI, RGB_SAD, RGB_VAI, RGB_VAD, RGB_SPI, RGB_SPD, _______,
+    KC_CAPS, _______, _______, _______, _______, _______, _______, QWERTY,  XXXXXXX, DVORAK,  CHILDPROOF, CHECK, \
+    _______, _______, OSWIN,   OSMACOS, OSLINUX, _______, _______, ___SEG4_MED___, KC_MPLY, \
+    _______, _______, _______, XXXXXXX, _______,     _______,      _______, XXXXXXX, _______, _______, _______ \
 )
 
 };
+// clang-format on
 
 layer_state_t layer_state_set_user(layer_state_t state) {
-  return update_tri_layer_state(state, _LOWER, _RAISE, _ADJUST);
+    return update_tri_layer_state(state, _LOWER, _RAISE, _ADJUST);
 }
 
 // RAW_EPSIZE is 32
@@ -161,22 +162,21 @@ void raw_hid_receive(uint8_t *data, uint8_t length) {
 
 void matrix_init_kb(void) {
 #ifdef PINKIELESS_LAYOUT
-#ifdef RGB_MATRIX_ENABLE
+#    ifdef RGB_MATRIX_ENABLE
     // Pinky outer column: change the flags
-    g_led_config.flags[0] = 4;
+    g_led_config.flags[0]  = 4;
     g_led_config.flags[11] = 4;
     g_led_config.flags[12] = 4;
     g_led_config.flags[23] = 4;
     g_led_config.flags[24] = 4;
     g_led_config.flags[35] = 4;
 
-    g_led_config.flags[5] = 1;
-    g_led_config.flags[6] = 1;
+    g_led_config.flags[5]  = 1;
+    g_led_config.flags[6]  = 1;
     g_led_config.flags[17] = 1;
     g_led_config.flags[18] = 1;
     g_led_config.flags[29] = 1;
     g_led_config.flags[30] = 1;
-#endif
+#    endif
 #endif
 }
-

--- a/firmware/qmk/layouts/community/split_3x5_3/rgoulter/keymap.c
+++ b/firmware/qmk/layouts/community/split_3x5_3/rgoulter/keymap.c
@@ -18,10 +18,10 @@
 #include "print.h"
 
 #ifdef HAPTIC_ENABLE
-#include "solenoid.h"
+#    include "solenoid.h"
 #endif
 
-#include "rgoulter.h"
+#include "users/rgoulter/rgoulter.h"
 
 // Defines names for use in layer keycodes and the keymap
 enum layers {
@@ -39,19 +39,19 @@ enum layers {
     _GAME_DF,
 };
 
-#define CHECK     DF(_CHECK)
-#define DVORAK     DF(_DVORAK)
-#define QWERTY     DF(_QWERTY)
-#define BASE       DF(_DVORAK)
-#define GAME_AL     DF(_GAME_ALT)
-#define GAME_DF     DF(_GAME_DF)
-#define CHILDPROOF     DF(_CHILDPROOF)
-#define SPC_NAVR  LT(_NAVR, KC_SPC)
-#define TAB_MOUR  LT(_MOUR, KC_TAB)
-#define ESC_MEDR  LT(_MEDR, KC_ESC)
-#define BKSP_NSL   LT(_NSL, KC_BSPC)
-#define ENT_NSSL  LT(_NSSL, KC_ENT)
-#define DEL_FUNL  LT(_FUNL, KC_DEL)
+#define CHECK DF(_CHECK)
+#define DVORAK DF(_DVORAK)
+#define QWERTY DF(_QWERTY)
+#define BASE DF(_DVORAK)
+#define GAME_AL DF(_GAME_ALT)
+#define GAME_DF DF(_GAME_DF)
+#define CHILDPROOF DF(_CHILDPROOF)
+#define SPC_NAVR LT(_NAVR, KC_SPC)
+#define TAB_MOUR LT(_MOUR, KC_TAB)
+#define ESC_MEDR LT(_MEDR, KC_ESC)
+#define BKSP_NSL LT(_NSL, KC_BSPC)
+#define ENT_NSSL LT(_NSSL, KC_ENT)
+#define DEL_FUNL LT(_FUNL, KC_DEL)
 
 #define LAYOUT_wrapper(...) LAYOUT_split_3x5_3(__VA_ARGS__)
 #define LAYOUT_split_3x5_3_wrapper(...) LAYOUT_split_3x5_3(__VA_ARGS__)
@@ -64,91 +64,92 @@ enum layers {
 // e.g. on Pico42 (or when using 3 thumbkeys on ortho5x12),
 // I find it more comfortable to have the 'third key' for RHS be more medial,
 // so that the main two RHS thumb keys are below 'nm'.
-#  define THUMB_ROW TAB_MOUR, ESC_MEDR, SPC_NAVR,    ENT_NSSL, BKSP_NSL, DEL_FUNL
+#    define THUMB_ROW TAB_MOUR, ESC_MEDR, SPC_NAVR, ENT_NSSL, BKSP_NSL, DEL_FUNL
 #else
 // e.g. on X-1, the 'third key' for RHS is more lateral than the others
-#  define THUMB_ROW TAB_MOUR, ESC_MEDR, SPC_NAVR,    BKSP_NSL, ENT_NSSL, DEL_FUNL
+#    define THUMB_ROW TAB_MOUR, ESC_MEDR, SPC_NAVR, BKSP_NSL, ENT_NSSL, DEL_FUNL
 #endif
 
-
+// clang-format off
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 // Different from Miryoku: LHS thumb keys: {Tab, Esc, Spc} instead of {Esc, Spc, Tab}
 // Different from Miryoku: RHS thumb keys: {Tab, Esc, Spc} instead of {Esc, Spc, Tab}
 // Different from Miryoku: Dvorak: retain semicolon, instead of using slash.
 [_DVORAK] = LAYOUT_wrapper( \
-  ___SEG5_DVORAK_LHS_1___,                           ___SEG5_DVORAK_RHS_1___,
-  ___SEG5_DVORAK_LHS_2___,                           ___SEG5_DVORAK_RHS_2___,
-  ___SEG5_DVORAK_LHS_3___,                           ___SEG5_DVORAK_RHS_3___,
-                    THUMB_ROW
+    ___SEG5_DVORAK_LHS_1___,                           ___SEG5_DVORAK_RHS_1___,
+    ___SEG5_DVORAK_LHS_2___,                           ___SEG5_DVORAK_RHS_2___,
+    ___SEG5_DVORAK_LHS_3___,                           ___SEG5_DVORAK_RHS_3___,
+                                    THUMB_ROW
 ),
 
 // Different from Miryoku: LHS thumb keys: {Tab, Esc, Spc} instead of {Esc, Spc, Tab}
 // Different from Miryoku: RHS thumb keys: {Bksp, Ent, Del} instead of {Ent, Bspc, Del}
 [_QWERTY] = LAYOUT_wrapper( \
-  ___SEG5_QWERTY_LHS_1___,                           ___SEG5_QWERTY_RHS_1___,
-  ___SEG5_QWERTY_LHS_2___,                           ___SEG5_QWERTY_RHS_2___,
-  ___SEG5_QWERTY_LHS_3___,                           ___SEG5_QWERTY_RHS_3___,
-                    THUMB_ROW
+    ___SEG5_QWERTY_LHS_1___,                           ___SEG5_QWERTY_RHS_1___,
+    ___SEG5_QWERTY_LHS_2___,                           ___SEG5_QWERTY_RHS_2___,
+    ___SEG5_QWERTY_LHS_3___,                           ___SEG5_QWERTY_RHS_3___,
+                                    THUMB_ROW
 ),
 
 [_CHECK] = LAYOUT_wrapper( \
-  ___SEG5_DVORAK_LHS_1___,                           ___SEG5_DVORAK_RHS_1___,
-  ___SEG5_DVORAK_LHS_2___,                           ___SEG5_DVORAK_RHS_2___,
-  ___SEG5_DVORAK_LHS_3___,                           ___SEG5_DVORAK_RHS_3___,
-                    KC_1, KC_2, KC_3, KC_4, KC_5, KC_6
+    ___SEG5_DVORAK_LHS_1___,                           ___SEG5_DVORAK_RHS_1___,
+    ___SEG5_DVORAK_LHS_2___,                           ___SEG5_DVORAK_RHS_2___,
+    ___SEG5_DVORAK_LHS_3___,                           ___SEG5_DVORAK_RHS_3___,
+                         KC_1, KC_2, KC_3, KC_4, KC_5, KC_6
 ),
 
 // XXX: Different from Miryoku: Nav, RHS, upper: TBI the convenience cut/copy/paste and undo/redo
 [_NAVR] = LAYOUT_wrapper( \
-  _______, _______, _______, _______, _______,    _______, _______, _______, _______, _______,
-  _______, _______, _______, _______, _______,    ___SEG4_NAV2___, CW_TOGG,
-  _______, OSWIN,   OSMACOS, OSLINUX, _______,    ___SEG4_NAV3___, KC_INS,
-                    _______, _______, _______,    _______, _______, _______
+    _______, _______, _______, _______, _______,    _______, _______, _______, _______, _______,
+    _______, _______, _______, _______, _______,    ___SEG4_NAV2___, CW_TOGG,
+    _______, OSWIN,   OSMACOS, OSLINUX, _______,    ___SEG4_NAV3___, KC_INS,
+                      _______, _______, _______,    _______, _______, _______
 ),
 
 [_MOUR] = LAYOUT_wrapper( \
-  _______, _______, _______, _______, _______,    _______, _______, _______, _______, _______,
-  _______, _______, _______, _______, _______,    ___SEG4_MOU_MV___, _______,
-  _______, _______, _______, _______, _______,    ___SEG4_MOU_WH___, _______,
-                    _______, _______, _______,    ___SEG3_MOU_BTN___
+    _______, _______, _______, _______, _______,    _______, _______, _______, _______, _______,
+    _______, _______, _______, _______, _______,    ___SEG4_MOU_MV___, _______,
+    _______, _______, _______, _______, _______,    ___SEG4_MOU_WH___, _______,
+                      _______, _______, _______,    ___SEG3_MOU_BTN___
 ),
 
 // Different from Miryoku: Media layer, RHS, lower: used to swap base layers
 // Different from Miryoku: Media layer, RHS: RGB doesn't follow Nav swap
 // Different from Miryoku: Media layer, RHS, non-nav column: no external power, no Bluetooth
 [_MEDR] = LAYOUT_wrapper( \
-  _______, _______, _______, HF_RST,  _______,    RGB_TOG, RGB_MOD, RGB_HUI, RGB_SAI, RGB_VAI,
-  HF_BUZZ, HF_DWLU, HF_DWLD, HF_TOGG, HF_FDBK,    ___SEG4_MED___, _______,
-  _______, _______, _______, DB_TOGG, _______,    QWERTY,  DVORAK,  GAME_DF, GAME_AL, QK_BOOT,
-                    _______, _______, _______,    KC_MPLY, KC_MSTP, KC_MUTE
+    _______, _______, _______, HF_RST,  _______,    RGB_TOG, RGB_MOD, RGB_HUI, RGB_SAI, RGB_VAI,
+    HF_BUZZ, HF_DWLU, HF_DWLD, HF_TOGG, HF_FDBK,    ___SEG4_MED___, _______,
+    _______, _______, _______, DB_TOGG, _______,    QWERTY,  DVORAK,  GAME_DF, GAME_AL, QK_BOOT,
+                      _______, _______, _______,    KC_MPLY, KC_MSTP, KC_MUTE
 ),
 
 // Different from Miryoku: Number layer, LHS: GRV in middle & slash (rather than semicolon)
 [_NSL] = LAYOUT_wrapper( \
-  KC_LBRC, ___SEG3_789___, KC_RBRC,        _______, _______, _______, _______, _______,
-  KC_GRV,  ___SEG3_456___, KC_EQL,         _______, _______, _______, _______, _______,
-  KC_SLSH, ___SEG3_123___, KC_BSLS,        _______, _______, _______, _______, _______,
-                 KC_DOT, KC_0, KC_MINS,    _______, _______, _______
+    KC_LBRC, ___SEG3_789___, KC_RBRC,        _______, _______, _______, _______, _______,
+    KC_GRV,  ___SEG3_456___, KC_EQL,         _______, _______, _______, _______, _______,
+    KC_SLSH, ___SEG3_123___, KC_BSLS,        _______, _______, _______, _______, _______,
+                   KC_DOT, KC_0, KC_MINS,    _______, _______, _______
 ),
 
 // Different from Miryoku: Number layer, LHS: TILD in middle & slash (rather than colon)
 [_NSSL] = LAYOUT_wrapper( \
-  KC_LCBR, ___SEG3_S789___, KC_RCBR,              _______, _______, _______, _______, _______,
-  KC_TILD, ___SEG3_S456___, KC_PLUS,              _______, _______, _______, _______, _______,
-  KC_QUES, ___SEG3_S123___, KC_PIPE,              _______, _______, _______, _______, _______,
-                    KC_LPRN, KC_RPRN, KC_UNDS,    _______, _______, _______
+    KC_LCBR, ___SEG3_S789___, KC_RCBR,              _______, _______, _______, _______, _______,
+    KC_TILD, ___SEG3_S456___, KC_PLUS,              _______, _______, _______, _______, _______,
+    KC_QUES, ___SEG3_S123___, KC_PIPE,              _______, _______, _______, _______, _______,
+                      KC_LPRN, KC_RPRN, KC_UNDS,    _______, _______, _______
 ),
 
 [_FUNL] = LAYOUT_wrapper( \
-  KC_F12, ___SEG3_F789___,   KC_PSCR,           _______, _______, _______, _______, _______,
-  KC_F11, ___SEG3_F456___,   KC_SCRL,           _______, _______, _______, _______, _______,
-  KC_F10, ___SEG3_F123___,   KC_PAUS,           _______, _______, _______, _______, _______,
-                  _______, _______, _______,    _______, _______, _______
+    KC_F12, ___SEG3_F789___,   KC_PSCR,           _______, _______, _______, _______, _______,
+    KC_F11, ___SEG3_F456___,   KC_SCRL,           _______, _______, _______, _______, _______,
+    KC_F10, ___SEG3_F123___,   KC_PAUS,           _______, _______, _______, _______, _______,
+                    _______, _______, _______,    _______, _______, _______
 ),
 
 #include <game-tomb_raider.inc>
 
 };
+// clang-format on
 
 void keyboard_post_init_user(void) {
 #ifdef RGB_MATRIX_ENABLE
@@ -181,15 +182,17 @@ oled_rotation_t oled_init_user(oled_rotation_t rotation) {
     // If the right-hand board is used as master,
     // the OLEDs are rendered "upside down".
     if (is_keyboard_master()) {
-        return OLED_ROTATION_180;  // flips the display 180 degrees if offhand
+        return OLED_ROTATION_180; // flips the display 180 degrees if offhand
     }
 
     return rotation;
 }
 
-#define TEST_CHAR_COUNT ('~' - '!' + 1)
+#    define TEST_CHAR_COUNT ('~' - '!' + 1)
 
-static char get_test_char(uint8_t char_index) { return char_index + '!'; }
+static char get_test_char(uint8_t char_index) {
+    return char_index + '!';
+}
 
 // Fill the whole screen with distinct characters (if the display is large enough to show more than 94 characters
 // at once, the sequence is repeated the second time with inverted characters).
@@ -210,8 +213,8 @@ static void test_characters(void) {
 }
 
 bool oled_task_user(void) {
-  test_characters();
+    test_characters();
 
-  return false;
+    return false;
 }
 #endif

--- a/firmware/qmk/users/rgoulter/rgoulter.c
+++ b/firmware/qmk/users/rgoulter/rgoulter.c
@@ -1,149 +1,140 @@
 #include "quantum.h"
 
-#include "rgoulter.h"
+#include "users/rgoulter/rgoulter.h"
 
-char quarter_count = 0;
-host_os_t current_os = _OS_LINUX;
+char      quarter_count = 0;
+host_os_t current_os    = _OS_LINUX;
 
 #ifdef CORNER_RESET_ENABLE
-__attribute__ ((weak))
-keypos_t boot_keypositions[4] = {
-  { .col = 0, .row = 0 },
-  { .col = 0, .row = MATRIX_ROWS - 1 },
-  { .col = MATRIX_COLS - 1, .row = 0 },
-  { .col = MATRIX_COLS - 1, .row = MATRIX_ROWS - 1 },
+__attribute__((weak)) keypos_t boot_keypositions[4] = {
+    {.col = 0, .row = 0},
+    {.col = 0, .row = MATRIX_ROWS - 1},
+    {.col = MATRIX_COLS - 1, .row = 0},
+    {.col = MATRIX_COLS - 1, .row = MATRIX_ROWS - 1},
 };
 #endif
 
-__attribute__ ((weak))
-bool process_record_keymap(uint16_t keycode, keyrecord_t *record) {
-  return true;
+__attribute__((weak)) bool process_record_keymap(uint16_t keycode, keyrecord_t *record) {
+    return true;
 }
 
 bool process_record_user(uint16_t keycode, keyrecord_t *record) {
-  switch (keycode) {
-  case OSLINUX:
-    current_os = _OS_LINUX;
-    return false;
-  case OSMACOS:
-    current_os = _OS_MACOS;
-    return false;
-  case OSWIN:
-    current_os = _OS_WIN;
-    return false;
-  }
+    switch (keycode) {
+        case OSLINUX:
+            current_os = _OS_LINUX;
+            return false;
+        case OSMACOS:
+            current_os = _OS_MACOS;
+            return false;
+        case OSWIN:
+            current_os = _OS_WIN;
+            return false;
+    }
 
 #ifdef CORNER_RESET_ENABLE
-  for (int i = 0; i < 4; i += 1) {
-    keypos_t boot_keypos = boot_keypositions[i];
-    if (boot_keypos.col == record->event.key.col && boot_keypos.row == record->event.key.row) {
-      if (record->event.pressed) {
-        quarter_count += 1;
-        if (quarter_count == 4) {
-          reset_keyboard();
+    for (int i = 0; i < 4; i += 1) {
+        keypos_t boot_keypos = boot_keypositions[i];
+        if (boot_keypos.col == record->event.key.col && boot_keypos.row == record->event.key.row) {
+            if (record->event.pressed) {
+                quarter_count += 1;
+                if (quarter_count == 4) {
+                    reset_keyboard();
+                }
+            } else {
+                quarter_count -= 1;
+            }
         }
-      } else {
-        quarter_count -= 1;
-      }
     }
-  }
 #endif
 
-  return process_record_keymap(keycode, record);
+    return process_record_keymap(keycode, record);
 }
 
 #ifdef COMBO_ENABLE
-const uint16_t PROGMEM dsk_lower_left_combo[] = {KC_J, KC_K, COMBO_END};
+const uint16_t PROGMEM dsk_lower_left_combo[]  = {KC_J, KC_K, COMBO_END};
 const uint16_t PROGMEM dsk_lower_right_combo[] = {KC_M, KC_W, COMBO_END};
-const uint16_t PROGMEM dsk_lower_lead_combo[] = {KC_SCLN, KC_Q, COMBO_END};
+const uint16_t PROGMEM dsk_lower_lead_combo[]  = {KC_SCLN, KC_Q, COMBO_END};
 
-__attribute__ ((weak))
-combo_t key_combos[COMBO_COUNT] = {
-  USER_KEY_COMBOS,
+__attribute__((weak)) combo_t key_combos[COMBO_COUNT] = {
+    USER_KEY_COMBOS,
 };
 
-__attribute__ ((weak))
-void process_combo_event_keymap(uint16_t combo_index, bool pressed) {
-}
+__attribute__((weak)) void process_combo_event_keymap(uint16_t combo_index, bool pressed) {}
 
 void process_combo_event(uint16_t combo_index, bool pressed) {
-  switch(combo_index) {
-    case DESKTOP_GO_LEFT:
-      if (pressed) {
-        switch(current_os) {
-          case _OS_LINUX:
-            tap_code16(CODE16_LINUX_DESKTOP_LEFT);
+    switch (combo_index) {
+        case DESKTOP_GO_LEFT:
+            if (pressed) {
+                switch (current_os) {
+                    case _OS_LINUX:
+                        tap_code16(CODE16_LINUX_DESKTOP_LEFT);
+                        break;
+                    case _OS_MACOS:
+                        tap_code16(CODE16_MACOS_DESKTOP_LEFT);
+                        break;
+                    case _OS_WIN:
+                        tap_code16(CODE16_WIN_DESKTOP_LEFT);
+                        break;
+                }
+            }
             break;
-          case _OS_MACOS:
-            tap_code16(CODE16_MACOS_DESKTOP_LEFT);
+        case DESKTOP_GO_RIGHT:
+            if (pressed) {
+                switch (current_os) {
+                    case _OS_LINUX:
+                        tap_code16(CODE16_LINUX_DESKTOP_RIGHT);
+                        break;
+                    case _OS_MACOS:
+                        tap_code16(CODE16_MACOS_DESKTOP_RIGHT);
+                        break;
+                    case _OS_WIN:
+                        tap_code16(CODE16_WIN_DESKTOP_RIGHT);
+                        break;
+                }
+            }
             break;
-          case _OS_WIN:
-            tap_code16(CODE16_WIN_DESKTOP_LEFT);
+        case LEAD:
+            if (pressed) {
+#    ifdef LEADER_ENABLE
+                leader_start();
+#    endif
+            }
             break;
-        }
-      }
-      break;
-    case DESKTOP_GO_RIGHT:
-      if (pressed) {
-        switch(current_os) {
-          case _OS_LINUX:
-            tap_code16(CODE16_LINUX_DESKTOP_RIGHT);
-            break;
-          case _OS_MACOS:
-            tap_code16(CODE16_MACOS_DESKTOP_RIGHT);
-            break;
-          case _OS_WIN:
-            tap_code16(CODE16_WIN_DESKTOP_RIGHT);
-            break;
-        }
-      }
-      break;
-    case LEAD:
-      if (pressed) {
-#ifdef LEADER_ENABLE
-        leader_start();
-#endif
-      }
-      break;
-  }
-  process_combo_event_keymap(combo_index, pressed);
+    }
+    process_combo_event_keymap(combo_index, pressed);
 }
 #endif
 
 #ifdef LEADER_ENABLE
-__attribute__ ((weak))
-void leader_end_keymap(void) {
-}
-void leader_end_user(void) {
-  if (leader_sequence_two_keys(KC_K, KC_C)) { // mnemonic: Kubernetes Ctl
-    SEND_STRING("kubectl");
-  } else if (leader_sequence_two_keys(KC_K, KC_G)) { // mnemonic: Kubernetes Get
-    SEND_STRING("kubectl get");
-  } else if (leader_sequence_three_keys(KC_K, KC_G, KC_P)) { // mnemonic: Kubernetes Get Pods
-    SEND_STRING("kubectl get pods");
-  } else if (leader_sequence_two_keys(KC_N, KC_U)) { // mnemonic: Name, dvorak home row
-    SEND_STRING("rgoulter");
-  } else if (leader_sequence_two_keys(KC_N, KC_E)) { // mnemonic: Name, dvorak home row
-    SEND_STRING("richard.goulter");
-  } else if (leader_sequence_two_keys(KC_N, KC_O)) { // mnemonic: Name, dvorak home row
-    SEND_STRING("richardgoulter");
-  } else if (leader_sequence_two_keys(KC_H, KC_U)) { // mnemonic: Host, dvorak home row
-    SEND_STRING("gaming-pc");
-  } else if (leader_sequence_two_keys(KC_H, KC_E)) { // mnemonic: Host, dvorak home row
-    SEND_STRING("cloud-vm");
-  } else if (leader_sequence_one_key(KC_L)) {
-        switch(current_os) {
-          case _OS_LINUX:
-            tap_code16(CODE16_LINUX_DESKTOP_LOCK);
-            break;
-          case _OS_MACOS:
-            tap_code16(CODE16_MACOS_DESKTOP_LOCK);
-            break;
-          case _OS_WIN:
-            tap_code16(CODE16_WIN_DESKTOP_LOCK);
-            break;
+__attribute__((weak)) void leader_end_keymap(void) {}
+void                       leader_end_user(void) {
+    if (leader_sequence_two_keys(KC_Q, KC_B)) { // mnemonic: QMK Boot
+        reset_keyboard();
+    } else if (leader_sequence_two_keys(KC_C, KC_C)) { // mnemonic: Caps capslock
+        tap_code(KC_CAPS);
+    } else if (leader_sequence_two_keys(KC_C, KC_W)) { // mnemonic: Caps capsWord
+#ifdef CAPS_WORD_ENABLE
+        caps_word_on();
+#endif
+    } else if (leader_sequence_two_keys(KC_O, KC_W)) { // mnemonic: OS Windows
+        current_os = _OS_WIN;
+    } else if (leader_sequence_two_keys(KC_O, KC_L)) { // mnemonic: OS Linux
+        current_os = _OS_LINUX;
+    } else if (leader_sequence_two_keys(KC_O, KC_M)) { // mnemonic: OS MacOS
+        current_os = _OS_MACOS;
+    } else if (leader_sequence_one_key(KC_L)) {
+        switch (current_os) {
+            case _OS_LINUX:
+                tap_code16(CODE16_LINUX_DESKTOP_LOCK);
+                break;
+            case _OS_MACOS:
+                tap_code16(CODE16_MACOS_DESKTOP_LOCK);
+                break;
+            case _OS_WIN:
+                tap_code16(CODE16_WIN_DESKTOP_LOCK);
+                break;
         }
-  }
-  leader_end_keymap();
+    }
+    leader_end_keymap();
 }
 #endif

--- a/firmware/qmk/users/rgoulter/rgoulter.h
+++ b/firmware/qmk/users/rgoulter/rgoulter.h
@@ -43,7 +43,7 @@
 #define ___SEG3_789___ KC_7, KC_8, KC_9
 
 #define ___SEG3_S123___ KC_EXLM, KC_AT, KC_HASH
-#define ___SEG3_S456___ KC_DLR,  KC_PERC, KC_CIRC
+#define ___SEG3_S456___ KC_DLR, KC_PERC, KC_CIRC
 #define ___SEG3_S789___ KC_AMPR, KC_ASTR, KC_LPRN
 
 #define ___SEG3_F123___ KC_F1, KC_F2, KC_F3
@@ -66,13 +66,13 @@
 #define ___SEG5_12345___ KC_1, KC_2, KC_3, KC_4, KC_5
 #define ___SEG5_67890___ KC_6, KC_7, KC_8, KC_9, KC_0
 
-#define ___SEG5_DVORAK_LHS_1___ KC_QUOT, KC_COMM, KC_DOT,  KC_P,    KC_Y
+#define ___SEG5_DVORAK_LHS_1___ KC_QUOT, KC_COMM, KC_DOT, KC_P, KC_Y
 #define ___SEG5_DVORAK_LHS_2___ LALTT_A, LGUIT_O, LCTLT_E, LSFTT_U, KC_I
-#define ___SEG5_DVORAK_LHS_3___ KC_SCLN, KC_Q,    KC_J,    KC_K,    KC_X
+#define ___SEG5_DVORAK_LHS_3___ KC_SCLN, KC_Q, KC_J, KC_K, KC_X
 
-#define ___SEG5_DVORAK_RHS_1___ KC_F,    KC_G,    KC_C,    KC_R,    KC_L
-#define ___SEG5_DVORAK_RHS_2___ KC_D,    RSFTT_H, RCTLT_T, RGUIT_N, RALTT_S
-#define ___SEG5_DVORAK_RHS_3___ KC_B,    KC_M,    KC_W,    KC_V,    KC_Z
+#define ___SEG5_DVORAK_RHS_1___ KC_F, KC_G, KC_C, KC_R, KC_L
+#define ___SEG5_DVORAK_RHS_2___ KC_D, RSFTT_H, RCTLT_T, RGUIT_N, RALTT_S
+#define ___SEG5_DVORAK_RHS_3___ KC_B, KC_M, KC_W, KC_V, KC_Z
 
 /*
  * QWERTY mod: Swap the `'` and `/`.
@@ -88,81 +88,78 @@
  *  so that it also needs `/` on other layers.
  */
 
-#define ___SEG5_QWERTY_LHS_1___ KC_Q,    KC_W,    KC_E,    KC_R,    KC_T
+#define ___SEG5_QWERTY_LHS_1___ KC_Q, KC_W, KC_E, KC_R, KC_T
 #define ___SEG5_QWERTY_LHS_2___ LALTT_A, LGUIT_S, LCTLT_D, LSFTT_F, KC_G
-#define ___SEG5_QWERTY_LHS_3___ KC_Z,    KC_X,    KC_C,    KC_V,    KC_B
+#define ___SEG5_QWERTY_LHS_3___ KC_Z, KC_X, KC_C, KC_V, KC_B
 
-#define ___SEG5_QWERTY_RHS_1___ KC_Y,    KC_U,    KC_I,    KC_O,    KC_P
-#define ___SEG5_QWERTY_RHS_2___ KC_H,    RSFTT_J, RCTLT_K, RGUIT_L, RALTTSC
-#define ___SEG5_QWERTY_RHS_3___ KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_QUOT
+#define ___SEG5_QWERTY_RHS_1___ KC_Y, KC_U, KC_I, KC_O, KC_P
+#define ___SEG5_QWERTY_RHS_2___ KC_H, RSFTT_J, RCTLT_K, RGUIT_L, RALTTSC
+#define ___SEG5_QWERTY_RHS_3___ KC_N, KC_M, KC_COMM, KC_DOT, KC_QUOT
 
-#define ___SEG5_QWERTY_LHS_SIMPLE_1___ KC_Q,    KC_W,    KC_E,    KC_R,    KC_T
-#define ___SEG5_QWERTY_LHS_SIMPLE_2___ KC_A,    KC_S,    KC_D,    KC_F,    KC_G
-#define ___SEG5_QWERTY_LHS_SIMPLE_3___ KC_Z,    KC_X,    KC_C,    KC_V,    KC_B
+#define ___SEG5_QWERTY_LHS_SIMPLE_1___ KC_Q, KC_W, KC_E, KC_R, KC_T
+#define ___SEG5_QWERTY_LHS_SIMPLE_2___ KC_A, KC_S, KC_D, KC_F, KC_G
+#define ___SEG5_QWERTY_LHS_SIMPLE_3___ KC_Z, KC_X, KC_C, KC_V, KC_B
 
-#define ___SEG5_QWERTY_RHS_SIMPLE_1___ KC_Y,    KC_U,    KC_I,    KC_O,    KC_P
-#define ___SEG5_QWERTY_RHS_SIMPLE_2___ KC_H,    KC_J,    KC_K,    KC_L, RALTTSC
-#define ___SEG5_QWERTY_RHS_SIMPLE_3___ KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_QUOT
+#define ___SEG5_QWERTY_RHS_SIMPLE_1___ KC_Y, KC_U, KC_I, KC_O, KC_P
+#define ___SEG5_QWERTY_RHS_SIMPLE_2___ KC_H, KC_J, KC_K, KC_L, RALTTSC
+#define ___SEG5_QWERTY_RHS_SIMPLE_3___ KC_N, KC_M, KC_COMM, KC_DOT, KC_QUOT
 
-#define ___BASE_BOTTOM_ROW___ \
-  _______, _______, _______, LWR_TAB, LW2_ESC,    KC_SPC,      RS2_BSP,    RSE_ENT, _______, _______, _______
+#define ___BASE_BOTTOM_ROW___ _______, _______, _______, LWR_TAB, LW2_ESC, KC_SPC, RS2_BSP, RSE_ENT, _______, _______, _______
 
-#define ___BASE_BOTTOM_ROW_12___ \
-  FN,      _______, _______, LWR_TAB, LW2_ESC,    KC_SPC, KC_SPC,     RS2_BSP,    RSE_ENT, _______, _______, _______
-
+#define ___BASE_BOTTOM_ROW_12___ FN, _______, _______, LWR_TAB, LW2_ESC, KC_SPC, KC_SPC, RS2_BSP, RSE_ENT, _______, _______, _______
 
 // macOS
-#define CODE16_MACOS_DESKTOP_LEFT  LCTL(KC_LEFT)
+#define CODE16_MACOS_DESKTOP_LEFT LCTL(KC_LEFT)
 #define CODE16_MACOS_DESKTOP_RIGHT LCTL(KC_RIGHT)
 
 #define CODE16_MACOS_DESKTOP_LOCK LCTL(LGUI(KC_Q))
 
-#define CODE16_MACOS_CUT   LCMD(KC_X)
-#define CODE16_MACOS_COPY  LCMD(KC_C)
+#define CODE16_MACOS_CUT LCMD(KC_X)
+#define CODE16_MACOS_COPY LCMD(KC_C)
 #define CODE16_MACOS_PASTE LCMD(KC_V)
 
 #define CODE16_MACOS_UNDO SCMD(KC_Z)
 #define CODE16_MACOS_REDO LCMD(KC_Z)
 
 // Linux, Gnome shell
-#define CODE16_LINUX_DESKTOP_LEFT  LCTL(LALT(KC_LEFT))
-#define CODE16_LINUX_DESKTOP_RIGHT LCTL(LALT(KC_RIGHT))
+#define CODE16_LINUX_DESKTOP_LEFT LGUI(KC_PGUP)
+#define CODE16_LINUX_DESKTOP_RIGHT LGUI(KC_PGDN)
 
 #define CODE16_LINUX_DESKTOP_LOCK LGUI(KC_L)
 
 // n.b. these don't always work
-#define CODE16_LINUX_CUT   KC_CUT
-#define CODE16_LINUX_COPY  KC_COPY
+#define CODE16_LINUX_CUT KC_CUT
+#define CODE16_LINUX_COPY KC_COPY
 #define CODE16_LINUX_PASTE KC_PSTE
 
 #define CODE16_LINUX_UNDO KC_UNDO
 #define CODE16_LINUX_REDO KC_AGIN
 
 // Windows 10
-#define CODE16_WIN_DESKTOP_LEFT  LCTL(LGUI(KC_LEFT))
+#define CODE16_WIN_DESKTOP_LEFT LCTL(LGUI(KC_LEFT))
 #define CODE16_WIN_DESKTOP_RIGHT LCTL(LGUI(KC_RIGHT))
 
 #define CODE16_WIN_DESKTOP_LOCK LGUI(KC_L)
 
-#define CODE16_WIN_CUT   C(KC_X)
-#define CODE16_WIN_COPY  C(KC_C)
+#define CODE16_WIN_CUT C(KC_X)
+#define CODE16_WIN_COPY C(KC_C)
 #define CODE16_WIN_PASTE C(KC_V)
 
 #define CODE16_WIN_UNDO C(KC_Y)
 #define CODE16_WIN_REDO C(KC_Z)
 
 enum custom_keycodes_user {
-  QUARTER = SAFE_RANGE,
-  OSLINUX,
-  OSMACOS,
-  OSWIN,
-  NEW_SAFE_RANGE,
+    QUARTER = SAFE_RANGE,
+    OSLINUX,
+    OSMACOS,
+    OSWIN,
+    NEW_SAFE_RANGE,
 };
 
 enum host_os {
-  _OS_LINUX,
-  _OS_MACOS,
-  _OS_WIN,
+    _OS_LINUX,
+    _OS_MACOS,
+    _OS_WIN,
 };
 typedef enum host_os host_os_t;
 
@@ -176,17 +173,14 @@ extern keypos_t boot_keypositions[4];
 extern combo_t key_combos[COMBO_COUNT];
 
 enum combo_events {
-  DESKTOP_GO_LEFT,
-  DESKTOP_GO_RIGHT,
-  LEAD,
+    DESKTOP_GO_LEFT,
+    DESKTOP_GO_RIGHT,
+    LEAD,
 };
 
 extern const uint16_t PROGMEM dsk_lower_left_combo[];
 extern const uint16_t PROGMEM dsk_lower_right_combo[];
 extern const uint16_t PROGMEM dsk_lower_lead_combo[];
 
-#define USER_KEY_COMBOS \
-  [DESKTOP_GO_LEFT] = COMBO_ACTION(dsk_lower_left_combo),   \
-  [DESKTOP_GO_RIGHT] = COMBO_ACTION(dsk_lower_right_combo), \
-  [LEAD] = COMBO_ACTION(dsk_lower_lead_combo)
+#    define USER_KEY_COMBOS [DESKTOP_GO_LEFT] = COMBO_ACTION(dsk_lower_left_combo), [DESKTOP_GO_RIGHT] = COMBO_ACTION(dsk_lower_right_combo), [LEAD] = COMBO_ACTION(dsk_lower_lead_combo)
 #endif


### PR DESCRIPTION
Currently, I have the commits in my `qmk_firmware` branch organised by commit-per-folder. (e.g. 'add userspace' is 1 commit, as is 'add keyboard pykey40').

Syncing, with two changes:

- adjusting the leader-key sequences that I use (defined in userspace `rgoulter.c`). -- I wasn't using the other leader sequences. The new ones are: reboot (`LEAD q b`), capslock/caps word (`LEAD c c`, `LEAD c w`), and setting 'OS' for desktop shortcuts (`LEAD o w`, `LEAD o l`, `LEAD o m`).
  - I made an attempt at "set keymap", but ... the qmk combos (chords) are based on key; so, changing default layer to QWERTY doesn't quite work. Currently, I use `;q` as LEAD (since this is Dvorak bottom row), but QWERTY, the `;` is on a tap-hold key.. and these keys aren't adjacent. -- Might be able to 'hack' this by making use of the default layer callback, to update the chords?
  - Other things which might be useful: managing RGB (toggle/on/off, set to fav. theme, random), managing haptics.

- formatting the C files per the editorconfig / clang format in qmk_firmware.