### PR TITLE
PCB:  CH32X-75-LPR

### DIFF
--- a/pcb/keyboard-ch32x-75.kicad_prl
+++ b/pcb/keyboard-ch32x-75.kicad_prl
@@ -1,0 +1,83 @@
+{
+  "board": {
+    "active_layer": 0,
+    "active_layer_preset": "",
+    "auto_track_width": true,
+    "hidden_netclasses": [],
+    "hidden_nets": [],
+    "high_contrast_mode": 0,
+    "net_color_mode": 1,
+    "opacity": {
+      "images": 0.6,
+      "pads": 1.0,
+      "tracks": 1.0,
+      "vias": 1.0,
+      "zones": 0.6
+    },
+    "selection_filter": {
+      "dimensions": true,
+      "footprints": true,
+      "graphics": true,
+      "keepouts": true,
+      "lockedItems": false,
+      "otherItems": true,
+      "pads": true,
+      "text": true,
+      "tracks": true,
+      "vias": true,
+      "zones": true
+    },
+    "visible_items": [
+      0,
+      1,
+      2,
+      3,
+      4,
+      5,
+      8,
+      9,
+      10,
+      11,
+      12,
+      13,
+      15,
+      16,
+      17,
+      18,
+      19,
+      20,
+      21,
+      22,
+      23,
+      24,
+      25,
+      26,
+      27,
+      28,
+      29,
+      30,
+      32,
+      33,
+      34,
+      35,
+      36,
+      39,
+      40
+    ],
+    "visible_layers": "0001030_80000001",
+    "zone_display_mode": 1
+  },
+  "git": {
+    "repo_password": "",
+    "repo_type": "",
+    "repo_username": "",
+    "ssh_key": ""
+  },
+  "meta": {
+    "filename": "keyboard-ch32x-75.kicad_prl",
+    "version": 3
+  },
+  "project": {
+    "files": []
+  }
+}

--- a/pcb/keyboard-ch32x-75.kicad_pro
+++ b/pcb/keyboard-ch32x-75.kicad_pro
@@ -1,0 +1,653 @@
+{
+  "board": {
+    "3dviewports": [],
+    "design_settings": {
+      "defaults": {
+        "apply_defaults_to_fp_fields": false,
+        "apply_defaults_to_fp_shapes": false,
+        "apply_defaults_to_fp_text": false,
+        "board_outline_line_width": 0.1,
+        "copper_line_width": 0.2,
+        "copper_text_italic": false,
+        "copper_text_size_h": 1.5,
+        "copper_text_size_v": 1.5,
+        "copper_text_thickness": 0.3,
+        "copper_text_upright": false,
+        "courtyard_line_width": 0.05,
+        "dimension_precision": 4,
+        "dimension_units": 3,
+        "dimensions": {
+          "arrow_length": 1270000,
+          "extension_offset": 500000,
+          "keep_text_aligned": true,
+          "suppress_zeroes": false,
+          "text_position": 0,
+          "units_format": 1
+        },
+        "fab_line_width": 0.1,
+        "fab_text_italic": false,
+        "fab_text_size_h": 1.0,
+        "fab_text_size_v": 1.0,
+        "fab_text_thickness": 0.15,
+        "fab_text_upright": false,
+        "other_line_width": 0.15,
+        "other_text_italic": false,
+        "other_text_size_h": 1.0,
+        "other_text_size_v": 1.0,
+        "other_text_thickness": 0.15,
+        "other_text_upright": false,
+        "pads": {
+          "drill": 1.5,
+          "height": 2.2,
+          "width": 2.2
+        },
+        "silk_line_width": 0.15,
+        "silk_text_italic": false,
+        "silk_text_size_h": 1.0,
+        "silk_text_size_v": 1.0,
+        "silk_text_thickness": 0.15,
+        "silk_text_upright": false,
+        "zones": {
+          "min_clearance": 0.508
+        }
+      },
+      "diff_pair_dimensions": [
+        {
+          "gap": 0.0,
+          "via_gap": 0.0,
+          "width": 0.0
+        }
+      ],
+      "drc_exclusions": [],
+      "meta": {
+        "version": 2
+      },
+      "rule_severities": {
+        "annular_width": "error",
+        "clearance": "error",
+        "connection_width": "warning",
+        "copper_edge_clearance": "error",
+        "copper_sliver": "warning",
+        "courtyards_overlap": "error",
+        "diff_pair_gap_out_of_range": "error",
+        "diff_pair_uncoupled_length_too_long": "error",
+        "drill_out_of_range": "error",
+        "duplicate_footprints": "warning",
+        "extra_footprint": "warning",
+        "footprint": "error",
+        "footprint_symbol_mismatch": "warning",
+        "footprint_type_mismatch": "ignore",
+        "hole_clearance": "error",
+        "hole_near_hole": "ignore",
+        "holes_co_located": "warning",
+        "invalid_outline": "error",
+        "isolated_copper": "warning",
+        "item_on_disabled_layer": "error",
+        "items_not_allowed": "error",
+        "length_out_of_range": "error",
+        "lib_footprint_issues": "warning",
+        "lib_footprint_mismatch": "warning",
+        "malformed_courtyard": "error",
+        "microvia_drill_out_of_range": "error",
+        "missing_courtyard": "ignore",
+        "missing_footprint": "warning",
+        "net_conflict": "warning",
+        "npth_inside_courtyard": "ignore",
+        "padstack": "warning",
+        "pth_inside_courtyard": "ignore",
+        "shorting_items": "error",
+        "silk_edge_clearance": "warning",
+        "silk_over_copper": "ignore",
+        "silk_overlap": "warning",
+        "skew_out_of_range": "error",
+        "solder_mask_bridge": "error",
+        "starved_thermal": "error",
+        "text_height": "warning",
+        "text_thickness": "warning",
+        "through_hole_pad_without_hole": "error",
+        "too_many_vias": "error",
+        "track_dangling": "warning",
+        "track_width": "error",
+        "tracks_crossing": "error",
+        "unconnected_items": "error",
+        "unresolved_variable": "error",
+        "via_dangling": "warning",
+        "zones_intersect": "error"
+      },
+      "rules": {
+        "max_error": 0.005,
+        "min_clearance": 0.0,
+        "min_connection": 0.0,
+        "min_copper_edge_clearance": 0.0,
+        "min_hole_clearance": 0.25,
+        "min_hole_to_hole": 0.25,
+        "min_microvia_diameter": 0.2,
+        "min_microvia_drill": 0.1,
+        "min_resolved_spokes": 2,
+        "min_silk_clearance": 0.0,
+        "min_text_height": 0.8,
+        "min_text_thickness": 0.08,
+        "min_through_hole_diameter": 0.3,
+        "min_track_width": 0.0,
+        "min_via_annular_width": 0.1,
+        "min_via_diameter": 0.5,
+        "solder_mask_clearance": 0.0,
+        "solder_mask_min_width": 0.0,
+        "solder_mask_to_copper_clearance": 0.0,
+        "use_height_for_length_calcs": true
+      },
+      "teardrop_options": [
+        {
+          "td_onpadsmd": true,
+          "td_onroundshapesonly": false,
+          "td_ontrackend": false,
+          "td_onviapad": true
+        }
+      ],
+      "teardrop_parameters": [
+        {
+          "td_allow_use_two_tracks": true,
+          "td_curve_segcount": 0,
+          "td_height_ratio": 1.0,
+          "td_length_ratio": 0.5,
+          "td_maxheight": 2.0,
+          "td_maxlen": 1.0,
+          "td_on_pad_in_zone": false,
+          "td_target_name": "td_round_shape",
+          "td_width_to_size_filter_ratio": 0.9
+        },
+        {
+          "td_allow_use_two_tracks": true,
+          "td_curve_segcount": 0,
+          "td_height_ratio": 1.0,
+          "td_length_ratio": 0.5,
+          "td_maxheight": 2.0,
+          "td_maxlen": 1.0,
+          "td_on_pad_in_zone": false,
+          "td_target_name": "td_rect_shape",
+          "td_width_to_size_filter_ratio": 0.9
+        },
+        {
+          "td_allow_use_two_tracks": true,
+          "td_curve_segcount": 0,
+          "td_height_ratio": 1.0,
+          "td_length_ratio": 0.5,
+          "td_maxheight": 2.0,
+          "td_maxlen": 1.0,
+          "td_on_pad_in_zone": false,
+          "td_target_name": "td_track_end",
+          "td_width_to_size_filter_ratio": 0.9
+        }
+      ],
+      "track_widths": [
+        0.0,
+        0.2,
+        0.25,
+        0.5
+      ],
+      "tuning_pattern_settings": {
+        "diff_pair_defaults": {
+          "corner_radius_percentage": 80,
+          "corner_style": 1,
+          "max_amplitude": 1.0,
+          "min_amplitude": 0.2,
+          "single_sided": false,
+          "spacing": 1.0
+        },
+        "diff_pair_skew_defaults": {
+          "corner_radius_percentage": 80,
+          "corner_style": 1,
+          "max_amplitude": 1.0,
+          "min_amplitude": 0.2,
+          "single_sided": false,
+          "spacing": 0.6
+        },
+        "single_track_defaults": {
+          "corner_radius_percentage": 80,
+          "corner_style": 1,
+          "max_amplitude": 1.0,
+          "min_amplitude": 0.2,
+          "single_sided": false,
+          "spacing": 0.6
+        }
+      },
+      "via_dimensions": [
+        {
+          "diameter": 0.0,
+          "drill": 0.0
+        }
+      ],
+      "zones_allow_external_fillets": false
+    },
+    "ipc2581": {
+      "dist": "",
+      "distpn": "",
+      "internal_id": "",
+      "mfg": "",
+      "mpn": ""
+    },
+    "layer_presets": [],
+    "viewports": []
+  },
+  "boards": [],
+  "cvpcb": {
+    "equivalence_files": []
+  },
+  "erc": {
+    "erc_exclusions": [],
+    "meta": {
+      "version": 0
+    },
+    "pin_map": [
+      [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        1,
+        0,
+        0,
+        0,
+        0,
+        2
+      ],
+      [
+        0,
+        2,
+        0,
+        1,
+        0,
+        0,
+        1,
+        0,
+        2,
+        2,
+        2,
+        2
+      ],
+      [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        1,
+        0,
+        1,
+        0,
+        1,
+        2
+      ],
+      [
+        0,
+        1,
+        0,
+        0,
+        0,
+        0,
+        1,
+        1,
+        2,
+        1,
+        1,
+        2
+      ],
+      [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        1,
+        0,
+        0,
+        0,
+        0,
+        2
+      ],
+      [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        2
+      ],
+      [
+        1,
+        1,
+        1,
+        1,
+        1,
+        0,
+        1,
+        1,
+        1,
+        1,
+        1,
+        2
+      ],
+      [
+        0,
+        0,
+        0,
+        1,
+        0,
+        0,
+        1,
+        0,
+        0,
+        0,
+        0,
+        2
+      ],
+      [
+        0,
+        2,
+        1,
+        2,
+        0,
+        0,
+        1,
+        0,
+        2,
+        2,
+        2,
+        2
+      ],
+      [
+        0,
+        2,
+        0,
+        1,
+        0,
+        0,
+        1,
+        0,
+        2,
+        0,
+        0,
+        2
+      ],
+      [
+        0,
+        2,
+        1,
+        1,
+        0,
+        0,
+        1,
+        0,
+        2,
+        0,
+        0,
+        2
+      ],
+      [
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2
+      ]
+    ],
+    "rule_severities": {
+      "bus_definition_conflict": "error",
+      "bus_entry_needed": "error",
+      "bus_to_bus_conflict": "error",
+      "bus_to_net_conflict": "error",
+      "conflicting_netclasses": "error",
+      "different_unit_footprint": "error",
+      "different_unit_net": "error",
+      "duplicate_reference": "error",
+      "duplicate_sheet_names": "error",
+      "endpoint_off_grid": "warning",
+      "extra_units": "error",
+      "global_label_dangling": "warning",
+      "hier_label_mismatch": "error",
+      "label_dangling": "error",
+      "lib_symbol_issues": "warning",
+      "missing_bidi_pin": "warning",
+      "missing_input_pin": "warning",
+      "missing_power_pin": "error",
+      "missing_unit": "warning",
+      "multiple_net_names": "warning",
+      "net_not_bus_member": "warning",
+      "no_connect_connected": "warning",
+      "no_connect_dangling": "warning",
+      "pin_not_connected": "error",
+      "pin_not_driven": "error",
+      "pin_to_pin": "warning",
+      "power_pin_not_driven": "error",
+      "similar_labels": "warning",
+      "simulation_model_issue": "ignore",
+      "unannotated": "error",
+      "unit_value_mismatch": "error",
+      "unresolved_variable": "error",
+      "wire_dangling": "error"
+    }
+  },
+  "libraries": {
+    "pinned_footprint_libs": [],
+    "pinned_symbol_libs": []
+  },
+  "meta": {
+    "filename": "keyboard-ch32x-75.kicad_pro",
+    "version": 1
+  },
+  "net_settings": {
+    "classes": [
+      {
+        "bus_width": 12,
+        "clearance": 0.2,
+        "diff_pair_gap": 0.25,
+        "diff_pair_via_gap": 0.25,
+        "diff_pair_width": 0.2,
+        "line_style": 0,
+        "microvia_diameter": 0.3,
+        "microvia_drill": 0.1,
+        "name": "Default",
+        "pcb_color": "rgba(0, 0, 0, 0.000)",
+        "schematic_color": "rgba(0, 0, 0, 0.000)",
+        "track_width": 0.25,
+        "via_diameter": 0.8,
+        "via_drill": 0.4,
+        "wire_width": 6
+      },
+      {
+        "bus_width": 12,
+        "clearance": 0.2,
+        "diff_pair_gap": 0.25,
+        "diff_pair_via_gap": 0.25,
+        "diff_pair_width": 0.2,
+        "line_style": 0,
+        "microvia_diameter": 0.3,
+        "microvia_drill": 0.1,
+        "name": "Power",
+        "pcb_color": "rgb(221, 133, 0)",
+        "schematic_color": "rgba(0, 0, 0, 0.000)",
+        "track_width": 0.5,
+        "via_diameter": 0.8,
+        "via_drill": 0.4,
+        "wire_width": 6
+      }
+    ],
+    "meta": {
+      "version": 3
+    },
+    "net_colors": null,
+    "netclass_assignments": {
+      "/LED": "Power",
+      "/VDD": "Power"
+    },
+    "netclass_patterns": [
+      {
+        "netclass": "Power",
+        "pattern": "/VDD"
+      },
+      {
+        "netclass": "Power",
+        "pattern": "/GND"
+      },
+      {
+        "netclass": "Power",
+        "pattern": "Net-(L_*_*-A)"
+      }
+    ]
+  },
+  "pcbnew": {
+    "last_paths": {
+      "gencad": "",
+      "idf": "",
+      "netlist": "",
+      "plot": "./pcb-gerber",
+      "pos_files": "./manual-pcba/",
+      "specctra_dsn": "",
+      "step": "",
+      "svg": "",
+      "vrml": ""
+    },
+    "page_layout_descr_file": ""
+  },
+  "schematic": {
+    "annotate_start_num": 0,
+    "bom_export_filename": "bom",
+    "bom_fmt_presets": [],
+    "bom_fmt_settings": {
+      "field_delimiter": ",",
+      "keep_line_breaks": false,
+      "keep_tabs": false,
+      "name": "CSV",
+      "ref_delimiter": ",",
+      "ref_range_delimiter": "",
+      "string_delimiter": "\""
+    },
+    "bom_presets": [],
+    "bom_settings": {
+      "exclude_dnp": false,
+      "fields_ordered": [
+        {
+          "group_by": false,
+          "label": "Reference",
+          "name": "Reference",
+          "show": true
+        },
+        {
+          "group_by": true,
+          "label": "Value",
+          "name": "Value",
+          "show": true
+        },
+        {
+          "group_by": false,
+          "label": "Datasheet",
+          "name": "Datasheet",
+          "show": true
+        },
+        {
+          "group_by": false,
+          "label": "Footprint",
+          "name": "Footprint",
+          "show": true
+        },
+        {
+          "group_by": false,
+          "label": "Qty",
+          "name": "${QUANTITY}",
+          "show": true
+        },
+        {
+          "group_by": true,
+          "label": "DNP",
+          "name": "${DNP}",
+          "show": true
+        },
+        {
+          "group_by": false,
+          "label": "#",
+          "name": "${ITEM_NUMBER}",
+          "show": false
+        },
+        {
+          "group_by": false,
+          "label": "LCSC",
+          "name": "LCSC",
+          "show": false
+        },
+        {
+          "group_by": false,
+          "label": "Description",
+          "name": "Description",
+          "show": false
+        }
+      ],
+      "filter_string": "",
+      "group_symbols": true,
+      "name": "",
+      "sort_asc": true,
+      "sort_field": "Reference"
+    },
+    "connection_grid_size": 50.0,
+    "drawing": {
+      "dashed_lines_dash_length_ratio": 12.0,
+      "dashed_lines_gap_length_ratio": 3.0,
+      "default_line_thickness": 6.0,
+      "default_text_size": 50.0,
+      "field_names": [],
+      "intersheets_ref_own_page": false,
+      "intersheets_ref_prefix": "",
+      "intersheets_ref_short": false,
+      "intersheets_ref_show": false,
+      "intersheets_ref_suffix": "",
+      "junction_size_choice": 3,
+      "label_size_ratio": 0.375,
+      "operating_point_overlay_i_precision": 3,
+      "operating_point_overlay_i_range": "~A",
+      "operating_point_overlay_v_precision": 3,
+      "operating_point_overlay_v_range": "~V",
+      "overbar_offset_ratio": 1.23,
+      "pin_symbol_size": 25.0,
+      "text_offset_ratio": 0.15
+    },
+    "legacy_lib_dir": "",
+    "legacy_lib_list": [],
+    "meta": {
+      "version": 1
+    },
+    "net_format_name": "",
+    "page_layout_descr_file": "",
+    "plot_directory": "",
+    "spice_current_sheet_as_root": false,
+    "spice_external_command": "spice \"%I\"",
+    "spice_model_current_sheet_as_root": true,
+    "spice_save_all_currents": false,
+    "spice_save_all_dissipations": false,
+    "spice_save_all_voltages": false,
+    "subpart_first_id": 65,
+    "subpart_id_separator": 0
+  },
+  "sheets": [
+    [
+      "491af640-c615-48ab-84d8-9b166bc1ab37",
+      "Root"
+    ]
+  ],
+  "text_variables": {}
+}

--- a/pcb/keyboard-ch32x-75.kicad_sch
+++ b/pcb/keyboard-ch32x-75.kicad_sch
@@ -1,0 +1,34788 @@
+(kicad_sch
+	(version 20231120)
+	(generator "eeschema")
+	(generator_version "8.0")
+	(uuid "491af640-c615-48ab-84d8-9b166bc1ab37")
+	(paper "A3")
+	(title_block
+		(title "CH32X-75")
+		(date "2025-02-03")
+		(rev "rev2025.1")
+		(company "Richard Goulter (rgoulter)")
+		(comment 1 "75-key on 5x15 matrix.")
+		(comment 2 "Simple 5x15 ortholinear keyboard using CH32X MCU.")
+		(comment 3 "Project: https://github.com/rgoulter/keyboard-labs")
+	)
+	(lib_symbols
+		(symbol "Connector:USB_C_Receptacle_USB2.0"
+			(pin_names
+				(offset 1.016)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(property "Reference" "J"
+				(at -10.16 19.05 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(justify left)
+				)
+			)
+			(property "Value" "USB_C_Receptacle_USB2.0"
+				(at 19.05 19.05 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(justify right)
+				)
+			)
+			(property "Footprint" ""
+				(at 3.81 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Datasheet" "https://www.usb.org/sites/default/files/documents/usb_type-c.zip"
+				(at 3.81 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Description" "USB 2.0-only Type-C Receptacle connector"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_keywords" "usb universal serial bus type-C USB2.0"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_fp_filters" "USB*C*Receptacle*"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(symbol "USB_C_Receptacle_USB2.0_0_0"
+				(rectangle
+					(start -0.254 -17.78)
+					(end 0.254 -16.764)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start 10.16 -14.986)
+					(end 9.144 -15.494)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start 10.16 -12.446)
+					(end 9.144 -12.954)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start 10.16 -4.826)
+					(end 9.144 -5.334)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start 10.16 -2.286)
+					(end 9.144 -2.794)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start 10.16 0.254)
+					(end 9.144 -0.254)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start 10.16 2.794)
+					(end 9.144 2.286)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start 10.16 7.874)
+					(end 9.144 7.366)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start 10.16 10.414)
+					(end 9.144 9.906)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start 10.16 15.494)
+					(end 9.144 14.986)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "USB_C_Receptacle_USB2.0_0_1"
+				(rectangle
+					(start -10.16 17.78)
+					(end 10.16 -17.78)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type background)
+					)
+				)
+				(arc
+					(start -8.89 -3.81)
+					(mid -6.985 -5.7067)
+					(end -5.08 -3.81)
+					(stroke
+						(width 0.508)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(arc
+					(start -7.62 -3.81)
+					(mid -6.985 -4.4423)
+					(end -6.35 -3.81)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(arc
+					(start -7.62 -3.81)
+					(mid -6.985 -4.4423)
+					(end -6.35 -3.81)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type outline)
+					)
+				)
+				(rectangle
+					(start -7.62 -3.81)
+					(end -6.35 3.81)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type outline)
+					)
+				)
+				(arc
+					(start -6.35 3.81)
+					(mid -6.985 4.4423)
+					(end -7.62 3.81)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(arc
+					(start -6.35 3.81)
+					(mid -6.985 4.4423)
+					(end -7.62 3.81)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type outline)
+					)
+				)
+				(arc
+					(start -5.08 3.81)
+					(mid -6.985 5.7067)
+					(end -8.89 3.81)
+					(stroke
+						(width 0.508)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(circle
+					(center -2.54 1.143)
+					(radius 0.635)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type outline)
+					)
+				)
+				(circle
+					(center 0 -5.842)
+					(radius 1.27)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type outline)
+					)
+				)
+				(polyline
+					(pts
+						(xy -8.89 -3.81) (xy -8.89 3.81)
+					)
+					(stroke
+						(width 0.508)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy -5.08 3.81) (xy -5.08 -3.81)
+					)
+					(stroke
+						(width 0.508)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 0 -5.842) (xy 0 4.318)
+					)
+					(stroke
+						(width 0.508)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 0 -3.302) (xy -2.54 -0.762) (xy -2.54 0.508)
+					)
+					(stroke
+						(width 0.508)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 0 -2.032) (xy 2.54 0.508) (xy 2.54 1.778)
+					)
+					(stroke
+						(width 0.508)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy -1.27 4.318) (xy 0 6.858) (xy 1.27 4.318) (xy -1.27 4.318)
+					)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type outline)
+					)
+				)
+				(rectangle
+					(start 1.905 1.778)
+					(end 3.175 3.048)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type outline)
+					)
+				)
+			)
+			(symbol "USB_C_Receptacle_USB2.0_1_1"
+				(pin passive line
+					(at 0 -22.86 90)
+					(length 5.08)
+					(name "GND"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "A1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 0 -22.86 90)
+					(length 5.08) hide
+					(name "GND"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "A12"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 15.24 15.24 180)
+					(length 5.08)
+					(name "VBUS"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "A4"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 15.24 10.16 180)
+					(length 5.08)
+					(name "CC1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "A5"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 15.24 -2.54 180)
+					(length 5.08)
+					(name "D+"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "A6"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 15.24 2.54 180)
+					(length 5.08)
+					(name "D-"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "A7"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 15.24 -12.7 180)
+					(length 5.08)
+					(name "SBU1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "A8"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 15.24 15.24 180)
+					(length 5.08) hide
+					(name "VBUS"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "A9"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 0 -22.86 90)
+					(length 5.08) hide
+					(name "GND"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "B1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 0 -22.86 90)
+					(length 5.08) hide
+					(name "GND"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "B12"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 15.24 15.24 180)
+					(length 5.08) hide
+					(name "VBUS"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "B4"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 15.24 7.62 180)
+					(length 5.08)
+					(name "CC2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "B5"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 15.24 -5.08 180)
+					(length 5.08)
+					(name "D+"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "B6"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 15.24 0 180)
+					(length 5.08)
+					(name "D-"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "B7"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 15.24 -15.24 180)
+					(length 5.08)
+					(name "SBU2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "B8"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 15.24 15.24 180)
+					(length 5.08) hide
+					(name "VBUS"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "B9"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -7.62 -22.86 90)
+					(length 5.08)
+					(name "SHIELD"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "S1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+		)
+		(symbol "Connector_Generic:Conn_01x02"
+			(pin_names
+				(offset 1.016) hide)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(property "Reference" "J"
+				(at 0 2.54 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "Conn_01x02"
+				(at 0 -5.08 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" ""
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Datasheet" "~"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Description" "Generic connector, single row, 01x02, script generated (kicad-library-utils/schlib/autogen/connector/)"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_keywords" "connector"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_fp_filters" "Connector*:*_1x??_*"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(symbol "Conn_01x02_1_1"
+				(rectangle
+					(start -1.27 -2.413)
+					(end 0 -2.667)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 0.127)
+					(end 0 -0.127)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 1.27)
+					(end 1.27 -3.81)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type background)
+					)
+				)
+				(pin passive line
+					(at -5.08 0 0)
+					(length 3.81)
+					(name "Pin_1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 -2.54 0)
+					(length 3.81)
+					(name "Pin_2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+		)
+		(symbol "Connector_Generic:Conn_01x04"
+			(pin_names
+				(offset 1.016) hide)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(property "Reference" "J"
+				(at 0 5.08 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "Conn_01x04"
+				(at 0 -7.62 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" ""
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Datasheet" "~"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Description" "Generic connector, single row, 01x04, script generated (kicad-library-utils/schlib/autogen/connector/)"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_keywords" "connector"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_fp_filters" "Connector*:*_1x??_*"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(symbol "Conn_01x04_1_1"
+				(rectangle
+					(start -1.27 -4.953)
+					(end 0 -5.207)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 -2.413)
+					(end 0 -2.667)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 0.127)
+					(end 0 -0.127)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 2.667)
+					(end 0 2.413)
+					(stroke
+						(width 0.1524)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(rectangle
+					(start -1.27 3.81)
+					(end 1.27 -6.35)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type background)
+					)
+				)
+				(pin passive line
+					(at -5.08 2.54 0)
+					(length 3.81)
+					(name "Pin_1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 0 0)
+					(length 3.81)
+					(name "Pin_2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 -2.54 0)
+					(length 3.81)
+					(name "Pin_3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 -5.08 0)
+					(length 3.81)
+					(name "Pin_4"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "4"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+		)
+		(symbol "Device:C"
+			(pin_numbers hide)
+			(pin_names
+				(offset 0.254)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(property "Reference" "C"
+				(at 0.635 2.54 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(justify left)
+				)
+			)
+			(property "Value" "C"
+				(at 0.635 -2.54 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(justify left)
+				)
+			)
+			(property "Footprint" ""
+				(at 0.9652 -3.81 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Datasheet" "~"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Description" "Unpolarized capacitor"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_keywords" "cap capacitor"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_fp_filters" "C_*"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(symbol "C_0_1"
+				(polyline
+					(pts
+						(xy -2.032 -0.762) (xy 2.032 -0.762)
+					)
+					(stroke
+						(width 0.508)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy -2.032 0.762) (xy 2.032 0.762)
+					)
+					(stroke
+						(width 0.508)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "C_1_1"
+				(pin passive line
+					(at 0 3.81 270)
+					(length 2.794)
+					(name "~"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 0 -3.81 90)
+					(length 2.794)
+					(name "~"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+		)
+		(symbol "Device:D"
+			(pin_numbers hide)
+			(pin_names
+				(offset 1.016) hide)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(property "Reference" "D"
+				(at 0 2.54 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "D"
+				(at 0 -2.54 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" ""
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Datasheet" "~"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Description" "Diode"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_keywords" "diode"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_fp_filters" "TO-???* *_Diode_* *SingleDiode* D_*"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(symbol "D_0_1"
+				(polyline
+					(pts
+						(xy -1.27 1.27) (xy -1.27 -1.27)
+					)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 1.27 0) (xy -1.27 0)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 1.27 1.27) (xy 1.27 -1.27) (xy -1.27 0) (xy 1.27 1.27)
+					)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "D_1_1"
+				(pin passive line
+					(at -3.81 0 0)
+					(length 2.54)
+					(name "K"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 3.81 0 180)
+					(length 2.54)
+					(name "A"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+		)
+		(symbol "Device:LED"
+			(pin_numbers hide)
+			(pin_names
+				(offset 1.016) hide)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(property "Reference" "D"
+				(at 0 2.54 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "LED"
+				(at 0 -2.54 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" ""
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Datasheet" "~"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Description" "Light emitting diode"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_keywords" "LED diode"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_fp_filters" "LED* LED_SMD:* LED_THT:*"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(symbol "LED_0_1"
+				(polyline
+					(pts
+						(xy -1.27 -1.27) (xy -1.27 1.27)
+					)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy -1.27 0) (xy 1.27 0)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 1.27 -1.27) (xy 1.27 1.27) (xy -1.27 0) (xy 1.27 -1.27)
+					)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy -3.048 -0.762) (xy -4.572 -2.286) (xy -3.81 -2.286) (xy -4.572 -2.286) (xy -4.572 -1.524)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy -1.778 -0.762) (xy -3.302 -2.286) (xy -2.54 -2.286) (xy -3.302 -2.286) (xy -3.302 -1.524)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "LED_1_1"
+				(pin passive line
+					(at -3.81 0 0)
+					(length 2.54)
+					(name "K"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 3.81 0 180)
+					(length 2.54)
+					(name "A"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+		)
+		(symbol "Device:LED_Small"
+			(pin_numbers hide)
+			(pin_names
+				(offset 0.254) hide)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(property "Reference" "D"
+				(at -1.27 3.175 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(justify left)
+				)
+			)
+			(property "Value" "LED_Small"
+				(at -4.445 -2.54 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(justify left)
+				)
+			)
+			(property "Footprint" ""
+				(at 0 0 90)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Datasheet" "~"
+				(at 0 0 90)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Description" "Light emitting diode, small symbol"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_keywords" "LED diode light-emitting-diode"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_fp_filters" "LED* LED_SMD:* LED_THT:*"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(symbol "LED_Small_0_1"
+				(polyline
+					(pts
+						(xy -0.762 -1.016) (xy -0.762 1.016)
+					)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 1.016 0) (xy -0.762 0)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 0.762 -1.016) (xy -0.762 0) (xy 0.762 1.016) (xy 0.762 -1.016)
+					)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 0 0.762) (xy -0.508 1.27) (xy -0.254 1.27) (xy -0.508 1.27) (xy -0.508 1.016)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 0.508 1.27) (xy 0 1.778) (xy 0.254 1.778) (xy 0 1.778) (xy 0 1.524)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "LED_Small_1_1"
+				(pin passive line
+					(at -2.54 0 0)
+					(length 1.778)
+					(name "K"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 2.54 0 180)
+					(length 1.778)
+					(name "A"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+		)
+		(symbol "Device:Q_NMOS_GSD"
+			(pin_names
+				(offset 0) hide)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(property "Reference" "Q"
+				(at 5.08 1.27 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(justify left)
+				)
+			)
+			(property "Value" "Q_NMOS_GSD"
+				(at 5.08 -1.27 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(justify left)
+				)
+			)
+			(property "Footprint" ""
+				(at 5.08 2.54 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Datasheet" "~"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Description" "N-MOSFET transistor, gate/source/drain"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_keywords" "transistor NMOS N-MOS N-MOSFET"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(symbol "Q_NMOS_GSD_0_1"
+				(polyline
+					(pts
+						(xy 0.254 0) (xy -2.54 0)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 0.254 1.905) (xy 0.254 -1.905)
+					)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 0.762 -1.27) (xy 0.762 -2.286)
+					)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 0.762 0.508) (xy 0.762 -0.508)
+					)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 0.762 2.286) (xy 0.762 1.27)
+					)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 2.54 2.54) (xy 2.54 1.778)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 2.54 -2.54) (xy 2.54 0) (xy 0.762 0)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 0.762 -1.778) (xy 3.302 -1.778) (xy 3.302 1.778) (xy 0.762 1.778)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 1.016 0) (xy 2.032 0.381) (xy 2.032 -0.381) (xy 1.016 0)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type outline)
+					)
+				)
+				(polyline
+					(pts
+						(xy 2.794 0.508) (xy 2.921 0.381) (xy 3.683 0.381) (xy 3.81 0.254)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 3.302 0.381) (xy 2.921 -0.254) (xy 3.683 -0.254) (xy 3.302 0.381)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(circle
+					(center 1.651 0)
+					(radius 2.794)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(circle
+					(center 2.54 -1.778)
+					(radius 0.254)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type outline)
+					)
+				)
+				(circle
+					(center 2.54 1.778)
+					(radius 0.254)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type outline)
+					)
+				)
+			)
+			(symbol "Q_NMOS_GSD_1_1"
+				(pin input line
+					(at -5.08 0 0)
+					(length 2.54)
+					(name "G"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 2.54 -5.08 90)
+					(length 2.54)
+					(name "S"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 2.54 5.08 270)
+					(length 2.54)
+					(name "D"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+		)
+		(symbol "Device:R"
+			(pin_numbers hide)
+			(pin_names
+				(offset 0)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(property "Reference" "R"
+				(at 2.032 0 90)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "R"
+				(at 0 0 90)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" ""
+				(at -1.778 0 90)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Datasheet" "~"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Description" "Resistor"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_keywords" "R res resistor"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_fp_filters" "R_*"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(symbol "R_0_1"
+				(rectangle
+					(start -1.016 -2.54)
+					(end 1.016 2.54)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "R_1_1"
+				(pin passive line
+					(at 0 3.81 270)
+					(length 1.27)
+					(name "~"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 0 -3.81 90)
+					(length 1.27)
+					(name "~"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+		)
+		(symbol "Device:R_Small"
+			(pin_numbers hide)
+			(pin_names
+				(offset 0.254) hide)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(property "Reference" "R"
+				(at 0.762 0.508 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(justify left)
+				)
+			)
+			(property "Value" "R_Small"
+				(at 0.762 -1.016 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(justify left)
+				)
+			)
+			(property "Footprint" ""
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Datasheet" "~"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Description" "Resistor, small symbol"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_keywords" "R resistor"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_fp_filters" "R_*"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(symbol "R_Small_0_1"
+				(rectangle
+					(start -0.762 1.778)
+					(end 0.762 -1.778)
+					(stroke
+						(width 0.2032)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "R_Small_1_1"
+				(pin passive line
+					(at 0 2.54 270)
+					(length 0.762)
+					(name "~"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 0 -2.54 90)
+					(length 0.762)
+					(name "~"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+		)
+		(symbol "Mechanical:MountingHole"
+			(pin_names
+				(offset 1.016)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(property "Reference" "H"
+				(at 0 5.08 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "MountingHole"
+				(at 0 3.175 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" ""
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Datasheet" "~"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Description" "Mounting Hole without connection"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_keywords" "mounting hole"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_fp_filters" "MountingHole*"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(symbol "MountingHole_0_1"
+				(circle
+					(center 0 0)
+					(radius 1.27)
+					(stroke
+						(width 1.27)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+		)
+		(symbol "Power_Protection:USBLC6-2SC6"
+			(pin_names hide)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(property "Reference" "U"
+				(at 0.635 5.715 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(justify left)
+				)
+			)
+			(property "Value" "USBLC6-2SC6"
+				(at 0.635 3.81 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(justify left)
+				)
+			)
+			(property "Footprint" "Package_TO_SOT_SMD:SOT-23-6"
+				(at 1.27 -6.35 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+						(italic yes)
+					)
+					(justify left)
+					(hide yes)
+				)
+			)
+			(property "Datasheet" "https://www.st.com/resource/en/datasheet/usblc6-2.pdf"
+				(at 1.27 -8.255 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(justify left)
+					(hide yes)
+				)
+			)
+			(property "Description" "Very low capacitance ESD protection diode, 2 data-line, SOT-23-6"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_keywords" "usb ethernet video"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_fp_filters" "SOT?23*"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(symbol "USBLC6-2SC6_0_0"
+				(circle
+					(center -1.524 0)
+					(radius 0.0001)
+					(stroke
+						(width 0.508)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(circle
+					(center -0.508 -4.572)
+					(radius 0.0001)
+					(stroke
+						(width 0.508)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(circle
+					(center -0.508 2.032)
+					(radius 0.0001)
+					(stroke
+						(width 0.508)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(circle
+					(center 0.508 -4.572)
+					(radius 0.0001)
+					(stroke
+						(width 0.508)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(circle
+					(center 0.508 2.032)
+					(radius 0.0001)
+					(stroke
+						(width 0.508)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(circle
+					(center 1.524 -2.54)
+					(radius 0.0001)
+					(stroke
+						(width 0.508)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "USBLC6-2SC6_0_1"
+				(polyline
+					(pts
+						(xy -2.54 -2.54) (xy 2.54 -2.54)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy -2.54 0) (xy 2.54 0)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy -2.032 -3.048) (xy -1.016 -3.048)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy -1.016 1.524) (xy -2.032 1.524)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 1.016 -3.048) (xy 2.032 -3.048)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 1.016 1.524) (xy 2.032 1.524)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy -0.508 -1.143) (xy -0.508 -0.762) (xy 0.508 -0.762)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy -2.032 0.508) (xy -1.016 0.508) (xy -1.524 1.524) (xy -2.032 0.508)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy -1.016 -4.064) (xy -2.032 -4.064) (xy -1.524 -3.048) (xy -1.016 -4.064)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 0.508 -1.778) (xy -0.508 -1.778) (xy 0 -0.762) (xy 0.508 -1.778)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 2.032 -4.064) (xy 1.016 -4.064) (xy 1.524 -3.048) (xy 2.032 -4.064)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 2.032 0.508) (xy 1.016 0.508) (xy 1.524 1.524) (xy 2.032 0.508)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 0 2.54) (xy -0.508 2.032) (xy 0.508 2.032) (xy 0 1.524) (xy 0 -4.064) (xy -0.508 -4.572) (xy 0.508 -4.572)
+						(xy 0 -5.08)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "USBLC6-2SC6_1_1"
+				(rectangle
+					(start -2.54 2.794)
+					(end 2.54 -5.334)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type background)
+					)
+				)
+				(polyline
+					(pts
+						(xy -0.508 2.032) (xy -1.524 2.032) (xy -1.524 -4.572) (xy -0.508 -4.572)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 0.508 -4.572) (xy 1.524 -4.572) (xy 1.524 2.032) (xy 0.508 2.032)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(pin passive line
+					(at -5.08 0 0)
+					(length 2.54)
+					(name "I/O1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 0 -7.62 90)
+					(length 2.54)
+					(name "GND"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at -5.08 -2.54 0)
+					(length 2.54)
+					(name "I/O2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 5.08 -2.54 180)
+					(length 2.54)
+					(name "I/O2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "4"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 0 5.08 270)
+					(length 2.54)
+					(name "VBUS"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "5"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 5.08 0 180)
+					(length 2.54)
+					(name "I/O1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "6"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+		)
+		(symbol "ProjectLocal:CH32X035C8T6"
+			(pin_names
+				(offset 1.016)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(property "Reference" "U"
+				(at -12.7 35.56 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "CH32X035C8T6"
+				(at 0 0 90)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" "Package_QFP:LQFP-48_7x7mm_P0.5mm"
+				(at 12.7 36.83 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Datasheet" ""
+				(at -46.99 -12.7 90)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Description" "CH32X035C8T6"
+				(at -0.762 22.606 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_keywords" "ch32x035  lqfp-48"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(symbol "CH32X035C8T6_0_1"
+				(rectangle
+					(start -15.24 31.75)
+					(end 15.24 -31.75)
+					(stroke
+						(width 0)
+						(type solid)
+					)
+					(fill
+						(type background)
+					)
+				)
+			)
+			(symbol "CH32X035C8T6_1_1"
+				(pin bidirectional line
+					(at -20.32 -8.89 0)
+					(length 5.08)
+					(name "PA15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at -20.32 29.21 0)
+					(length 5.08)
+					(name "PA0"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "10"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(alternate "A0" bidirectional line)
+					(alternate "C1P1" bidirectional line)
+					(alternate "CTS2" bidirectional line)
+					(alternate "T2C1" bidirectional line)
+				)
+				(pin bidirectional line
+					(at -20.32 26.67 0)
+					(length 5.08)
+					(name "PA1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "11"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(alternate " CTS2_" bidirectional line)
+					(alternate "A1" bidirectional line)
+					(alternate "C1O" bidirectional line)
+					(alternate "O1N2" bidirectional line)
+					(alternate "O2N2" bidirectional line)
+					(alternate "RTS2" bidirectional line)
+					(alternate "T2C2" bidirectional line)
+				)
+				(pin bidirectional line
+					(at -20.32 24.13 0)
+					(length 5.08)
+					(name "PA2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "12"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(alternate "A2" bidirectional line)
+					(alternate "C3N0" bidirectional line)
+					(alternate "O2O1" bidirectional line)
+					(alternate "RTS2_" bidirectional line)
+					(alternate "T2C3" bidirectional line)
+					(alternate "T2ET_" bidirectional line)
+					(alternate "TX2" bidirectional line)
+				)
+				(pin bidirectional line
+					(at -20.32 21.59 0)
+					(length 5.08)
+					(name "PA3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "13"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(alternate "A3" bidirectional line)
+					(alternate "CTS3_" bidirectional line)
+					(alternate "O1O0" bidirectional line)
+					(alternate "RX2" bidirectional line)
+					(alternate "T2C4" bidirectional line)
+					(alternate "T3C1_" bidirectional line)
+				)
+				(pin bidirectional line
+					(at -20.32 19.05 0)
+					(length 5.08)
+					(name "PA4"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(alternate "A4" power_out line)
+					(alternate "CS" power_out line)
+					(alternate "O2O0" power_out line)
+					(alternate "RTS3_" bidirectional line)
+					(alternate "T3C2_" power_out line)
+				)
+				(pin bidirectional line
+					(at -20.32 16.51 0)
+					(length 5.08)
+					(name "PA5"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(alternate "A5" power_out line)
+					(alternate "CTS4_" bidirectional line)
+					(alternate "O2N0" power_out line)
+					(alternate "SCK" power_out line)
+					(alternate "TX4_" power_out line)
+				)
+				(pin bidirectional line
+					(at -20.32 13.97 0)
+					(length 5.08)
+					(name "PA6"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "16"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(alternate "A6" bidirectional line)
+					(alternate "MISO" bidirectional line)
+					(alternate "O1N0" bidirectional line)
+					(alternate "RTS4_" bidirectional line)
+					(alternate "T1BK_" bidirectional line)
+					(alternate "T3C1" bidirectional line)
+				)
+				(pin input line
+					(at -20.32 11.43 0)
+					(length 5.08)
+					(name "PA7"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "17"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(alternate "A7" input line)
+					(alternate "CTS4_" input line)
+					(alternate "MOSI" bidirectional line)
+					(alternate "O2P0" bidirectional line)
+					(alternate "T1C1N_" bidirectional line)
+					(alternate "T3C2" bidirectional line)
+					(alternate "TX1_" input line)
+				)
+				(pin bidirectional line
+					(at 20.32 -11.43 180)
+					(length 5.08)
+					(name "PC6"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "18"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(alternate "T1C2N_" bidirectional line)
+				)
+				(pin bidirectional line
+					(at 20.32 -13.97 180)
+					(length 5.08)
+					(name "PC7"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "19"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(alternate "T1C3N_" bidirectional line)
+				)
+				(pin bidirectional line
+					(at -20.32 -11.43 0)
+					(length 5.08)
+					(name "PA16"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin input line
+					(at 20.32 29.21 180)
+					(length 5.08)
+					(name "PB0"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "20"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(alternate "A8" bidirectional line)
+					(alternate "O1P0" bidirectional line)
+					(alternate "T1C2N_" bidirectional line)
+					(alternate "TX4" bidirectional line)
+				)
+				(pin bidirectional line
+					(at 20.32 26.67 180)
+					(length 5.08)
+					(name "PB1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "21"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(alternate "A9" bidirectional line)
+					(alternate "O2N1" bidirectional line)
+					(alternate "RX4" bidirectional line)
+					(alternate "T1C3N_" bidirectional line)
+				)
+				(pin bidirectional line
+					(at 20.32 24.13 180)
+					(length 5.08)
+					(name "PB2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "22"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(alternate "C2O" input line)
+					(alternate "RX1_" input line)
+				)
+				(pin bidirectional line
+					(at 20.32 21.59 180)
+					(length 5.08)
+					(name "PB3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "23"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(alternate "C3O" input line)
+					(alternate "O2P1" input line)
+					(alternate "T2C3N_" input line)
+					(alternate "T2C3_" input line)
+					(alternate "TX3" input line)
+				)
+				(pin bidirectional line
+					(at 20.32 19.05 180)
+					(length 5.08)
+					(name "PB4"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "24"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(alternate "O1P2" input line)
+					(alternate "RX3" input line)
+					(alternate "T2BK_" input line)
+					(alternate "T2C4_" input line)
+					(alternate "T3C1_" input line)
+				)
+				(pin bidirectional line
+					(at 20.32 16.51 180)
+					(length 5.08)
+					(name "PB5"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "25"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(alternate "O1O1" input line)
+					(alternate "T1BK" input line)
+					(alternate "T3C2_" input line)
+				)
+				(pin bidirectional line
+					(at 20.32 13.97 180)
+					(length 5.08)
+					(name "PB6"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "26"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(alternate "CTS3" input line)
+					(alternate "O1N1" input line)
+					(alternate "T1C1N" input line)
+				)
+				(pin bidirectional line
+					(at 20.32 11.43 180)
+					(length 5.08)
+					(name "PB7"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "27"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(alternate "O2P2" bidirectional line)
+					(alternate "RTS3_" bidirectional line)
+					(alternate "T1C2N" bidirectional line)
+				)
+				(pin bidirectional line
+					(at 20.32 8.89 180)
+					(length 5.08)
+					(name "PB8"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "28"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(alternate "O1P1" bidirectional line)
+					(alternate "T1C3N" bidirectional line)
+				)
+				(pin bidirectional line
+					(at 20.32 6.35 180)
+					(length 5.08)
+					(name "PB9"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "29"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(alternate "MCO" bidirectional line)
+					(alternate "T1C1" bidirectional line)
+					(alternate "TX4_" bidirectional line)
+				)
+				(pin bidirectional line
+					(at -20.32 -13.97 0)
+					(length 5.08)
+					(name "PA17"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at 20.32 3.81 180)
+					(length 5.08)
+					(name "PB10"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "30"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(alternate "T1C2" bidirectional line)
+					(alternate "TX1" bidirectional line)
+				)
+				(pin bidirectional line
+					(at 20.32 1.27 180)
+					(length 5.08)
+					(name "PB11"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "31"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(alternate "RX1" bidirectional line)
+					(alternate "T1C3" bidirectional line)
+					(alternate "T2C1N_" bidirectional line)
+				)
+				(pin input line
+					(at 20.32 -21.59 180)
+					(length 5.08)
+					(name "PC16"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "32"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(alternate "CTS1" input line)
+					(alternate "I2C_" input line)
+					(alternate "PC11" input line)
+					(alternate "RX4_" input line)
+					(alternate "T1C4" input line)
+					(alternate "TX4_" input line)
+					(alternate "UDM" input line)
+				)
+				(pin input line
+					(at 20.32 -24.13 180)
+					(length 5.08)
+					(name "PC17"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "33"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(alternate "I2C_" input line)
+					(alternate "PC10" input line)
+					(alternate "RTS1" input line)
+					(alternate "RX4_" input line)
+					(alternate "T1ET" input line)
+					(alternate "TX4_" input line)
+					(alternate "UDP" input line)
+				)
+				(pin bidirectional line
+					(at 20.32 -26.67 180)
+					(length 5.08)
+					(name "PC18"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "34"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(alternate "DIO" bidirectional line)
+					(alternate "I2C_" bidirectional line)
+					(alternate "T1ET_" bidirectional line)
+					(alternate "T2C1N_" bidirectional line)
+					(alternate "T3C2_" bidirectional line)
+					(alternate "TX3_" bidirectional line)
+				)
+				(pin bidirectional line
+					(at 20.32 -1.27 180)
+					(length 5.08)
+					(name "PB12"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "35"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(alternate "T1C4_" bidirectional line)
+					(alternate "T2C2N_" bidirectional line)
+				)
+				(pin bidirectional line
+					(at 20.32 -3.81 180)
+					(length 5.08)
+					(name "PB13"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "36"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(alternate "TX4_" bidirectional line)
+				)
+				(pin bidirectional line
+					(at 20.32 -29.21 180)
+					(length 5.08)
+					(name "PC19"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "37"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(alternate "C1P0" power_out line)
+					(alternate "DCK" power_out line)
+					(alternate "I2C_" power_out line)
+					(alternate "RX3_" power_out line)
+					(alternate "RX4_" bidirectional line)
+					(alternate "T2C1_" power_out line)
+					(alternate "T3C1_" power_out line)
+				)
+				(pin bidirectional line
+					(at 20.32 -16.51 180)
+					(length 5.08)
+					(name "PC14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "38"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(alternate "CC1" bidirectional line)
+					(alternate "T1C3_" bidirectional line)
+					(alternate "T2C2_" bidirectional line)
+				)
+				(pin bidirectional line
+					(at 20.32 -19.05 180)
+					(length 5.08)
+					(name "PC15"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "39"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(alternate "CC2" bidirectional line)
+					(alternate "T1ET_" bidirectional line)
+					(alternate "T2C3_" bidirectional line)
+				)
+				(pin bidirectional line
+					(at -20.32 -16.51 0)
+					(length 5.08)
+					(name "PA18"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "4"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at -20.32 8.89 0)
+					(length 5.08)
+					(name "PA8"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "40"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(alternate "RTS1_" bidirectional line)
+					(alternate "RTS4" bidirectional line)
+				)
+				(pin bidirectional line
+					(at -20.32 6.35 0)
+					(length 5.08)
+					(name "PA9"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "41"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(alternate "CTS1_" bidirectional line)
+					(alternate "MISO_" bidirectional line)
+					(alternate "RX4_" bidirectional line)
+					(alternate "T2BK_" bidirectional line)
+				)
+				(pin bidirectional line
+					(at -20.32 3.81 0)
+					(length 5.08)
+					(name "PA10"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "42"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(alternate "MOSI_" bidirectional line)
+					(alternate "RX4_" bidirectional line)
+					(alternate "SCL" bidirectional line)
+					(alternate "TX1_" bidirectional line)
+				)
+				(pin bidirectional line
+					(at -20.32 1.27 0)
+					(length 5.08)
+					(name "PA11"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "43"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(alternate "C2P1" bidirectional line)
+					(alternate "RX1_" bidirectional line)
+					(alternate "SCK_" bidirectional line)
+					(alternate "SDA" bidirectional line)
+				)
+				(pin bidirectional line
+					(at -20.32 -1.27 0)
+					(length 5.08)
+					(name "PA12"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "44"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(alternate "C2P0" bidirectional line)
+					(alternate "CS_" bidirectional line)
+					(alternate "T2C1N_" bidirectional line)
+					(alternate "T2C2_" bidirectional line)
+				)
+				(pin bidirectional line
+					(at -20.32 -3.81 0)
+					(length 5.08)
+					(name "PA13"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "45"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(alternate "C3P0" bidirectional line)
+					(alternate "CTS1_" bidirectional line)
+					(alternate "RTS4_" bidirectional line)
+					(alternate "SCL_" bidirectional line)
+					(alternate "T2C2N_" bidirectional line)
+					(alternate "T2C3_" bidirectional line)
+				)
+				(pin bidirectional line
+					(at -20.32 -6.35 0)
+					(length 5.08)
+					(name "PA14"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "46"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(alternate "C3P1" bidirectional line)
+					(alternate "CTS4_" bidirectional line)
+					(alternate "RTS1_" bidirectional line)
+					(alternate "SDA_" bidirectional line)
+					(alternate "T2C3N_" bidirectional line)
+				)
+				(pin power_in line
+					(at 0 -36.83 90)
+					(length 5.08)
+					(name "GND"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "47"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin power_in line
+					(at 0 36.83 270)
+					(length 5.08)
+					(name "VDD"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "48"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at -20.32 -19.05 0)
+					(length 5.08)
+					(name "PA19"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "5"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at -20.32 -21.59 0)
+					(length 5.08)
+					(name "PA20"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "6"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at -20.32 -24.13 0)
+					(length 5.08)
+					(name "PA21"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "7"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(alternate "RST" bidirectional line)
+					(alternate "RTS2_" bidirectional line)
+					(alternate "T2C1N" bidirectional line)
+				)
+				(pin bidirectional line
+					(at -20.32 -26.67 0)
+					(length 5.08)
+					(name "PA22"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "8"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin bidirectional line
+					(at -20.32 -29.21 0)
+					(length 5.08)
+					(name "PA23"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "9"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+		)
+		(symbol "Switch:SW_Push"
+			(pin_numbers hide)
+			(pin_names
+				(offset 1.016) hide)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(property "Reference" "SW"
+				(at 1.27 2.54 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(justify left)
+				)
+			)
+			(property "Value" "SW_Push"
+				(at 0 -1.524 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" ""
+				(at 0 5.08 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Datasheet" "~"
+				(at 0 5.08 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Description" "Push button switch, generic, two pins"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_keywords" "switch normally-open pushbutton push-button"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(symbol "SW_Push_0_1"
+				(circle
+					(center -2.032 0)
+					(radius 0.508)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 0 1.27) (xy 0 3.048)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 2.54 1.27) (xy -2.54 1.27)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(circle
+					(center 2.032 0)
+					(radius 0.508)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(pin passive line
+					(at -5.08 0 0)
+					(length 2.54)
+					(name "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 5.08 0 180)
+					(length 2.54)
+					(name "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+		)
+		(symbol "Switch:SW_SPST"
+			(pin_names
+				(offset 0) hide)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(property "Reference" "SW"
+				(at 0 3.175 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "SW_SPST"
+				(at 0 -2.54 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" ""
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Datasheet" "~"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Description" "Single Pole Single Throw (SPST) switch"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_keywords" "switch lever"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(symbol "SW_SPST_0_0"
+				(circle
+					(center -2.032 0)
+					(radius 0.508)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy -1.524 0.254) (xy 1.524 1.778)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(circle
+					(center 2.032 0)
+					(radius 0.508)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "SW_SPST_1_1"
+				(pin passive line
+					(at -5.08 0 0)
+					(length 2.54)
+					(name "A"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 5.08 0 180)
+					(length 2.54)
+					(name "B"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+		)
+	)
+	(junction
+		(at 43.18 137.16)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "0218f4fa-dd2b-4e3b-a4a0-9355acc2eb1c")
+	)
+	(junction
+		(at 317.5 88.9)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "0420e50e-9fbf-40cf-9a89-87105dfbfd7f")
+	)
+	(junction
+		(at 332.74 88.9)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "05520b3e-0eae-4254-9dd6-fd3934553ff6")
+	)
+	(junction
+		(at 231.14 81.28)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "07f6dc7b-609a-491d-b2c3-2bb2ab91572f")
+	)
+	(junction
+		(at 226.06 201.93)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "0865f90a-8910-4f56-bbcb-1adeec7b0db3")
+	)
+	(junction
+		(at 347.98 105.41)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "0b7d43f7-b64d-458c-8bfe-ff7ab84a1aa7")
+	)
+	(junction
+		(at 297.18 187.96)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "0b9e92ac-ce97-483a-a821-6b34c31064f5")
+	)
+	(junction
+		(at 246.38 173.99)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "0bdbc29e-d8f5-447b-9b85-59561b715f63")
+	)
+	(junction
+		(at 215.9 31.75)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "0c1a9529-0353-40ba-8e78-69570fd7e656")
+	)
+	(junction
+		(at 215.9 201.93)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "0fa40fef-b657-4463-ac89-00bc54551ff4")
+	)
+	(junction
+		(at 276.86 160.02)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "0fe26751-7194-43e6-b94b-710f10390c1d")
+	)
+	(junction
+		(at 246.38 135.89)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "1076035a-a602-4b45-a04d-38e7bf72ae9c")
+	)
+	(junction
+		(at 353.06 64.77)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "113284cf-b645-422e-a768-e12c9e38d477")
+	)
+	(junction
+		(at 302.26 105.41)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "12672aba-2a7a-4d01-98aa-4824c3a6e968")
+	)
+	(junction
+		(at 276.86 187.96)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "12d684c8-bfdb-4e52-8969-a5038ce40972")
+	)
+	(junction
+		(at 215.9 146.05)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "13221a8b-9765-4028-91b1-353e7243df44")
+	)
+	(junction
+		(at 236.22 177.8)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "144f39a6-9765-4d2e-aa73-ec249be3c020")
+	)
+	(junction
+		(at 276.86 31.75)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "16bfab55-e79a-4764-b8a2-16013ee5f987")
+	)
+	(junction
+		(at 297.18 177.8)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "16f50446-6910-47a1-9164-374d12e5459e")
+	)
+	(junction
+		(at 226.06 149.86)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "174d58ab-6fee-46a7-85de-84f8aba9bbbf")
+	)
+	(junction
+		(at 261.62 81.28)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "185fc838-35e8-4b3e-837c-3d4d8a013a3c")
+	)
+	(junction
+		(at 175.26 187.96)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "18972f26-b5a3-470c-92ae-c2cffdb014b7")
+	)
+	(junction
+		(at 215.9 135.89)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "18a5d1c1-1cd0-4f35-9d5d-a2d430dec707")
+	)
+	(junction
+		(at 170.18 48.26)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "1a1cec66-1f36-4991-ad49-e497314cc5c0")
+	)
+	(junction
+		(at 195.58 55.88)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "1a610acb-7c24-4699-a71e-db4b11fc3719")
+	)
+	(junction
+		(at 307.34 31.75)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "1a925da1-6d67-404d-9971-dbfb057df82a")
+	)
+	(junction
+		(at 205.74 201.93)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "1b0a71e3-3d46-426a-9d6c-8d6d35604aaf")
+	)
+	(junction
+		(at 271.78 105.41)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "1bd9df04-129b-4bb1-b0a1-a7ee08732d69")
+	)
+	(junction
+		(at 215.9 48.26)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "1c947a09-05f6-4a27-a61a-b10d97a33dbe")
+	)
+	(junction
+		(at 180.34 72.39)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "1f7fe7e9-ee0b-4592-a220-0fce34d20947")
+	)
+	(junction
+		(at 287.02 187.96)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "210cddc1-72de-431b-b9d0-56ad748aa958")
+	)
+	(junction
+		(at 332.74 55.88)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "225d4d04-a595-4973-b0e3-b3fa29281514")
+	)
+	(junction
+		(at 271.78 55.88)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "2321f73c-00dd-4947-9313-31eeb89dd4f5")
+	)
+	(junction
+		(at 363.22 88.9)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "23a7db5b-b31f-4020-85eb-1ecce65d9b5a")
+	)
+	(junction
+		(at 195.58 105.41)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "23ab2984-27ad-4b9f-8dc9-8063ec2deef4")
+	)
+	(junction
+		(at 215.9 177.8)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "24c9db01-26ca-45be-94ec-fec9a9e92cd6")
+	)
+	(junction
+		(at 195.58 163.83)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "25c8d1aa-acf5-4c0f-8a6a-a1a6b0ddca69")
+	)
+	(junction
+		(at 322.58 64.77)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "2659d775-ff57-4c45-9e3e-5e6aa5d248ad")
+	)
+	(junction
+		(at 175.26 173.99)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "269e89fb-763b-4100-9079-5746ddc85307")
+	)
+	(junction
+		(at 307.34 48.26)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "27495181-7d35-4df1-acd5-7b827919bfd0")
+	)
+	(junction
+		(at 165.1 149.86)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "2a416734-94a1-4c6f-942b-c5c09374ba8e")
+	)
+	(junction
+		(at 332.74 39.37)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "2a950380-21cb-45e4-94f0-264ed9f00dce")
+	)
+	(junction
+		(at 185.42 48.26)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "2aa996b1-27da-431e-8ce2-5ec09ea3163d")
+	)
+	(junction
+		(at 297.18 201.93)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "2c0d58dc-941f-476b-9ad6-63563e4426ef")
+	)
+	(junction
+		(at 226.06 173.99)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "2c51c841-9611-4940-bf56-358eb1c24c7d")
+	)
+	(junction
+		(at 302.26 88.9)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "2ca013bd-ebd4-4afe-958d-67b904cd1a1d")
+	)
+	(junction
+		(at 378.46 55.88)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "2d37d227-be34-43b3-b597-1cbe1f7f8d08")
+	)
+	(junction
+		(at 302.26 72.39)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "2e169d2d-8717-4b85-baa8-619835960685")
+	)
+	(junction
+		(at 226.06 55.88)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "2f73d50d-2762-4c61-a650-237c8096f7a4")
+	)
+	(junction
+		(at 317.5 39.37)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "2fc80f24-83ff-4888-8a30-a05b581884f6")
+	)
+	(junction
+		(at 256.54 88.9)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "30e83076-09ca-4b18-83c3-4d4478a145ad")
+	)
+	(junction
+		(at 287.02 163.83)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "32550876-2db7-4620-bf5c-56e7b5222613")
+	)
+	(junction
+		(at 332.74 105.41)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "32e17ee8-88b9-4e1d-84ab-a847c4a84afe")
+	)
+	(junction
+		(at 347.98 39.37)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "32ef9623-b672-46f0-a4ec-78eb1c4e664f")
+	)
+	(junction
+		(at 205.74 177.8)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "3569c81b-015b-48b8-9cfc-dc607aeaa812")
+	)
+	(junction
+		(at 231.14 64.77)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "36a35048-4a34-4180-a9c2-b95ab18ef2d6")
+	)
+	(junction
+		(at 185.42 191.77)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "374f153e-0f1c-4d82-9c8d-df89d64d3e03")
+	)
+	(junction
+		(at 215.9 191.77)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "37ae1cf1-2451-4dbc-a521-b7a668dcc12e")
+	)
+	(junction
+		(at 297.18 163.83)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "37f34486-e89a-4298-9003-11b5050eda23")
+	)
+	(junction
+		(at 256.54 173.99)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "3896775b-6b47-4739-b29d-2ac6034accf6")
+	)
+	(junction
+		(at 236.22 163.83)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "3899d8fd-2c35-4e48-b8a0-f8c5ea0ddeb5")
+	)
+	(junction
+		(at 226.06 88.9)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "392e0ad9-6444-4a66-88ad-3b14e06cef7b")
+	)
+	(junction
+		(at 276.86 146.05)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "3a89d55d-a622-42e9-bb63-8f754b7d9e45")
+	)
+	(junction
+		(at 256.54 146.05)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "3ad8cbef-b076-41fe-b84e-1827fc6f372c")
+	)
+	(junction
+		(at 266.7 146.05)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "3ae3d45c-9278-410f-846e-d3503df1b66a")
+	)
+	(junction
+		(at 205.74 146.05)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "3c5bc869-1ae5-4993-bb87-63211e403480")
+	)
+	(junction
+		(at 231.14 48.26)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "3f27133b-00be-4838-9690-a8be4d9d866a")
+	)
+	(junction
+		(at 215.9 187.96)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "41e6b4b5-acf5-4eab-a180-aaa6ed9479c4")
+	)
+	(junction
+		(at 175.26 146.05)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "437abafa-3293-4300-8eb9-c91689e45b17")
+	)
+	(junction
+		(at 226.06 39.37)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "43cc37ac-430d-4ea7-855d-9207e4b71c8b")
+	)
+	(junction
+		(at 165.1 177.8)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "442ae8af-4e53-4df8-a2b1-8af30401a325")
+	)
+	(junction
+		(at 256.54 177.8)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "44a13d52-5ca4-43a9-88a8-c7e744d10289")
+	)
+	(junction
+		(at 195.58 88.9)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "45c8526f-21bc-482a-8b9b-e9c9a9219dff")
+	)
+	(junction
+		(at 195.58 201.93)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "45d0562f-917e-4288-8755-92f2a72e6a47")
+	)
+	(junction
+		(at 205.74 163.83)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "45f5f60c-99e5-4bef-9d17-ec8325c2a1eb")
+	)
+	(junction
+		(at 200.66 48.26)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "46236bbd-d485-4b9a-a7b0-e46f037dd54a")
+	)
+	(junction
+		(at 236.22 146.05)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "46d909a1-12c9-47b6-833c-e6648feb3803")
+	)
+	(junction
+		(at 241.3 72.39)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "4798c048-77ed-4a4a-9177-6b9d37437cd2")
+	)
+	(junction
+		(at 383.54 64.77)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "48bf266f-6f38-4a49-bb31-5e03f2f9b9ee")
+	)
+	(junction
+		(at 383.54 48.26)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "48ed45b2-d6b8-4861-85dc-7002571ac63e")
+	)
+	(junction
+		(at 246.38 163.83)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "48fc0b4a-730f-4881-ab14-c26bc77f8eb4")
+	)
+	(junction
+		(at 378.46 105.41)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "4ac7db03-dcdd-4813-a8f3-468a4930d206")
+	)
+	(junction
+		(at 215.9 160.02)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "4e271e1f-089d-4db3-be86-33df753f77e1")
+	)
+	(junction
+		(at 165.1 191.77)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "4e81d8bb-23d4-43f9-b408-b7af89c400a0")
+	)
+	(junction
+		(at 276.86 201.93)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "4f0ae4d7-d308-4f14-afe4-d255ecc05c8a")
+	)
+	(junction
+		(at 185.42 201.93)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "503d5b29-4ea1-418f-8523-f4e49a4d2e49")
+	)
+	(junction
+		(at 347.98 55.88)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "520ee5c7-d6e9-4f47-baad-b7f12f09cd3e")
+	)
+	(junction
+		(at 271.78 88.9)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "534f6d99-2d39-4b8a-99fe-5f5cf1e21c38")
+	)
+	(junction
+		(at 266.7 177.8)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "5361cc9c-7b7f-4a59-8043-b5a335775960")
+	)
+	(junction
+		(at 266.7 149.86)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "53869b70-a44d-4c53-8739-71febd599477")
+	)
+	(junction
+		(at 246.38 48.26)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "54b23ae9-f6a7-46c9-901c-82b2d93af6eb")
+	)
+	(junction
+		(at 353.06 81.28)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "55235723-0bbe-445e-9bf5-60e8ba5b616c")
+	)
+	(junction
+		(at 266.7 191.77)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "5568e769-c000-48a1-8bd5-2b82cc5a168c")
+	)
+	(junction
+		(at 287.02 105.41)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "559b1eed-0865-4efc-9f9f-97fc094eac79")
+	)
+	(junction
+		(at 353.06 31.75)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "58704899-499b-4a84-b9e9-3802363d0929")
+	)
+	(junction
+		(at 266.7 160.02)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "5a708bdc-8643-4b07-8153-4ed42b4dba32")
+	)
+	(junction
+		(at 256.54 160.02)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "5b0763ec-4a49-4fce-810f-ce0420100d71")
+	)
+	(junction
+		(at 292.1 48.26)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "5b26c0e9-6ec6-427e-8f1d-fe0addf944d6")
+	)
+	(junction
+		(at 246.38 149.86)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "5b34466b-b5c5-428a-b47d-9eeecd15b49a")
+	)
+	(junction
+		(at 226.06 163.83)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "5c5fbf6a-9a85-48f0-a8f6-056374f6dec5")
+	)
+	(junction
+		(at 165.1 187.96)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "60382a19-804d-4c28-a4fa-9bd8b8c7042b")
+	)
+	(junction
+		(at 297.18 173.99)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "61dbb9bb-261d-48e3-862b-a14814ecc200")
+	)
+	(junction
+		(at 200.66 31.75)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "6236c338-4444-4d2b-af2d-1a1cd936d2b8")
+	)
+	(junction
+		(at 170.18 31.75)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "63681fc8-6937-4931-a639-92769f3ee436")
+	)
+	(junction
+		(at 215.9 173.99)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "6376a822-1a64-4c5d-93b9-37aaeb0e089a")
+	)
+	(junction
+		(at 226.06 135.89)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "639ae0c3-fddf-4e14-b864-4bfbda7c4b81")
+	)
+	(junction
+		(at 195.58 187.96)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "63f1228b-1e89-4600-a035-1ccd17f95f34")
+	)
+	(junction
+		(at 297.18 135.89)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "63f6af3b-3c44-45f7-bc68-89466011db24")
+	)
+	(junction
+		(at 210.82 88.9)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "6536bf26-bda7-42fa-ad03-aae48a5b4dfb")
+	)
+	(junction
+		(at 175.26 163.83)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "673c58ea-e2e1-49a6-acd4-8e12fa683868")
+	)
+	(junction
+		(at 363.22 55.88)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "677a7310-0e61-4f10-800a-78da985488b3")
+	)
+	(junction
+		(at 175.26 135.89)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "6828ba33-c625-4cf1-8295-d465aaa4a258")
+	)
+	(junction
+		(at 266.7 201.93)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "68f9aca0-4cf7-4140-b591-3bcc37084d98")
+	)
+	(junction
+		(at 322.58 31.75)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "6a4a668f-537b-43d7-9c65-a9480103e511")
+	)
+	(junction
+		(at 266.7 163.83)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "6b3e176a-e23e-42f5-a242-ea20c21c6d33")
+	)
+	(junction
+		(at 175.26 177.8)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "6c70bd1a-73f5-4105-90b0-8fc1f1978971")
+	)
+	(junction
+		(at 297.18 146.05)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "6c7d872e-98d7-4da2-a79e-7d7cfce0f02d")
+	)
+	(junction
+		(at 205.74 160.02)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "6ce38248-f206-497c-b3fb-ed82642e62ec")
+	)
+	(junction
+		(at 215.9 64.77)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "6d9a237f-d9b2-487c-a180-9112fa0d8a45")
+	)
+	(junction
+		(at 307.34 64.77)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "6ec9b7e8-b9c3-4a80-83ab-1143281c328c")
+	)
+	(junction
+		(at 246.38 187.96)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "718f01c5-d596-48aa-909e-0c98b672c790")
+	)
+	(junction
+		(at 261.62 48.26)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "71fede06-d145-46ae-9d22-4caafa971859")
+	)
+	(junction
+		(at 215.9 149.86)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "73ce0f91-2c7a-4d88-9c30-1d81a6a163c1")
+	)
+	(junction
+		(at 287.02 201.93)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "743b7a6e-12b8-4420-bef7-edf462b5f121")
+	)
+	(junction
+		(at 256.54 55.88)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "7546c0b7-af6e-40b9-98e3-f11f665db0d3")
+	)
+	(junction
+		(at 195.58 173.99)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "756ff04c-6c4f-4337-afd3-7dc96d04558a")
+	)
+	(junction
+		(at 226.06 187.96)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "774f66d2-7031-4127-8264-4f3e428ea117")
+	)
+	(junction
+		(at 307.34 81.28)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "790fa24b-9ebc-430c-be6d-5b7bcb610ecf")
+	)
+	(junction
+		(at 287.02 88.9)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "7abe1449-db1b-4bd4-b1dc-fba4a321758a")
+	)
+	(junction
+		(at 347.98 72.39)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "7b125433-f343-4926-9a56-6b410039768f")
+	)
+	(junction
+		(at 195.58 135.89)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "7b529d18-47b0-4725-98a8-27d1943052de")
+	)
+	(junction
+		(at 195.58 160.02)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "7ba20ae8-e470-479d-b1be-f35f4804a44f")
+	)
+	(junction
+		(at 200.66 64.77)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "7be6d316-1da4-4ad8-ad50-e10ff10f73eb")
+	)
+	(junction
+		(at 302.26 39.37)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "7e56cfe6-7699-47b3-b1fe-7fc9ccaa1e03")
+	)
+	(junction
+		(at 185.42 81.28)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "7ebe2ad1-df88-4659-bd9a-e7d6787c6a5b")
+	)
+	(junction
+		(at 175.26 149.86)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "7f90c9b1-8163-40fa-b6f7-c2ec6b297589")
+	)
+	(junction
+		(at 256.54 163.83)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "806ea9d8-f201-410d-9da2-1c350b7034d5")
+	)
+	(junction
+		(at 276.86 191.77)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "8218449c-0efd-4028-9124-5565f4aa31e0")
+	)
+	(junction
+		(at 266.7 173.99)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "82c0fc68-e697-4edd-a78c-5abd0fced8ac")
+	)
+	(junction
+		(at 226.06 191.77)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "82c1e316-6ef7-48f7-aa2a-0e9fbdee93b7")
+	)
+	(junction
+		(at 302.26 55.88)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "83eeacc0-0968-4f62-9531-4d15cc3bb13f")
+	)
+	(junction
+		(at 378.46 72.39)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "8402083a-27ea-4203-b77c-868d8edc3d8c")
+	)
+	(junction
+		(at 256.54 149.86)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "8451d557-79fa-49b3-ae77-4167e58fd585")
+	)
+	(junction
+		(at 271.78 72.39)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "84fa19de-7efa-4af8-ad65-3c19ec570837")
+	)
+	(junction
+		(at 256.54 201.93)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "8538c091-13bd-48c7-a618-058208b706fb")
+	)
+	(junction
+		(at 205.74 187.96)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "85475524-7a4e-4717-8d95-ea149ad4c5f0")
+	)
+	(junction
+		(at 317.5 105.41)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "87258584-2d6a-43a0-9e08-624ee83a9c9a")
+	)
+	(junction
+		(at 347.98 88.9)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "8768b779-90a6-4da8-8726-0cf23315428e")
+	)
+	(junction
+		(at 276.86 135.89)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "87e5a0ec-dd20-4c17-bca6-78f7424cac75")
+	)
+	(junction
+		(at 226.06 177.8)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "88880b97-804f-413c-8f19-af2dc3817e12")
+	)
+	(junction
+		(at 185.42 187.96)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "89861215-2583-43b5-b062-c1a500100ac5")
+	)
+	(junction
+		(at 287.02 72.39)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "8aa1a3a8-a2c4-4269-b17d-4a2f0d0a13ec")
+	)
+	(junction
+		(at 241.3 88.9)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "8c50ff80-04c6-4e76-8e8b-9ab99db91f5a")
+	)
+	(junction
+		(at 165.1 135.89)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "8c8b2a66-2796-4b28-a29e-8af0a1d9f60d")
+	)
+	(junction
+		(at 236.22 149.86)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "8c8f7198-d76c-4992-8980-a0a05381edaf")
+	)
+	(junction
+		(at 165.1 163.83)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "8c9747e5-627a-402f-a986-b08d611c63de")
+	)
+	(junction
+		(at 256.54 39.37)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "8d052758-4dec-40fc-b18f-ca097ed92cc1")
+	)
+	(junction
+		(at 317.5 72.39)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "8d60ef46-7fd1-45b4-ad95-f7bdf4850c44")
+	)
+	(junction
+		(at 241.3 39.37)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "8d86b357-5da6-4f0f-b5a2-f887c1b7061a")
+	)
+	(junction
+		(at 185.42 163.83)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "8e7a628a-c49e-418b-93ca-a71dd703496f")
+	)
+	(junction
+		(at 256.54 187.96)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "900debc2-3031-45ea-a55a-4fd9d239a51d")
+	)
+	(junction
+		(at 368.3 64.77)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "905865bc-e5a1-407d-8896-fe7b4d07ec1f")
+	)
+	(junction
+		(at 236.22 135.89)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "92861ea9-712c-4c0f-b5a7-8bfc926cdbb7")
+	)
+	(junction
+		(at 256.54 191.77)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "935aff27-db59-4318-8d72-948a7e068dba")
+	)
+	(junction
+		(at 236.22 191.77)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "9365d068-b39e-4bcb-ba06-56b740df38c5")
+	)
+	(junction
+		(at 337.82 81.28)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "942aa589-009f-461e-a5d7-39820f2c19f5")
+	)
+	(junction
+		(at 185.42 177.8)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "9431e539-bf36-4a28-99a5-e14a3bf1134b")
+	)
+	(junction
+		(at 276.86 48.26)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "946620c7-7698-40a5-9f68-32d2195bc311")
+	)
+	(junction
+		(at 43.18 139.7)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "955fd1ac-0431-4c2b-b34c-3272b17cb5f7")
+	)
+	(junction
+		(at 170.18 64.77)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "978f80b0-0d79-48cf-a7f5-64c85480baf4")
+	)
+	(junction
+		(at 241.3 55.88)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "9790a79c-55ef-4b81-8a80-5682bca1ccfe")
+	)
+	(junction
+		(at 236.22 160.02)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "97c34fe6-a211-416e-ba13-e449aa3df3a8")
+	)
+	(junction
+		(at 246.38 64.77)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "9801cb6f-c175-4a54-a29a-2b934ecc466d")
+	)
+	(junction
+		(at 120.65 140.97)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "98fffa85-29bd-41fb-bffa-9c4a212d1502")
+	)
+	(junction
+		(at 210.82 55.88)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "9988a547-ccd5-4d3e-8d98-d75e30a7cd8c")
+	)
+	(junction
+		(at 195.58 149.86)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "9ae1785a-1bac-4762-9471-478c19bd166d")
+	)
+	(junction
+		(at 322.58 81.28)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "9b056624-aee4-40fc-853e-3fe0d6625247")
+	)
+	(junction
+		(at 292.1 64.77)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "9dbd1ef4-4369-4478-85f6-d9fa7465b65b")
+	)
+	(junction
+		(at 261.62 31.75)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "9dfc64b8-dae9-4350-9f94-8495417b712c")
+	)
+	(junction
+		(at 276.86 173.99)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "9ed7725b-e992-4c2c-97c0-34214aa0a117")
+	)
+	(junction
+		(at 205.74 149.86)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "9f252043-a485-4742-88d0-1ba8bf33dd77")
+	)
+	(junction
+		(at 180.34 55.88)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "a1bb2bc9-dc7d-499e-b568-8b8418b42d05")
+	)
+	(junction
+		(at 210.82 105.41)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "a33c0278-0b87-4df2-801a-ff3b9185d0d9")
+	)
+	(junction
+		(at 236.22 187.96)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "a35b4a6f-8f1e-4bf0-bee8-1a6a42c270ae")
+	)
+	(junction
+		(at 195.58 39.37)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "a3868b34-b663-47c2-aba7-47b15c9aad38")
+	)
+	(junction
+		(at 210.82 72.39)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "a575bcbe-e752-4e4c-bd8f-a9760466aa9b")
+	)
+	(junction
+		(at 332.74 72.39)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "a61af1a0-8dec-4037-90d5-51d0788bf171")
+	)
+	(junction
+		(at 363.22 39.37)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "ab2dcc6f-5e2e-47d1-a6f1-d76ae32cfec4")
+	)
+	(junction
+		(at 195.58 72.39)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "ad75da8d-2bd5-491b-9a17-8a4a5d1b4d56")
+	)
+	(junction
+		(at 195.58 191.77)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "aeda84b2-5e69-4db5-9462-6d3e16670adc")
+	)
+	(junction
+		(at 266.7 187.96)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "af8e07bd-f136-427f-8844-adb5c889ffc9")
+	)
+	(junction
+		(at 165.1 146.05)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "b0ce44f5-0a21-4bbf-842b-f38d892c75e5")
+	)
+	(junction
+		(at 287.02 160.02)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "b1251c4c-6880-4f69-bcfb-f62949d733e6")
+	)
+	(junction
+		(at 236.22 201.93)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "b1c68f4f-3444-47f0-88f6-b394f44819e7")
+	)
+	(junction
+		(at 297.18 160.02)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "b1f5add8-d0ac-46eb-8eba-8a910c1855d3")
+	)
+	(junction
+		(at 246.38 146.05)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "b497787e-e50e-4700-8cbf-cb6eb207d02d")
+	)
+	(junction
+		(at 256.54 72.39)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "b6254780-8966-45a8-b5df-174c6b5f3ef2")
+	)
+	(junction
+		(at 175.26 160.02)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "b724d04d-e41a-4331-b9a1-2833cad1a128")
+	)
+	(junction
+		(at 165.1 201.93)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "b99a2d0a-02ee-4bca-a533-fda015230bfe")
+	)
+	(junction
+		(at 287.02 135.89)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "b9d6dfe8-d643-4681-a0ff-f571eb4006d9")
+	)
+	(junction
+		(at 170.18 81.28)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "ba9aadaf-e79a-45c0-88c0-67e05302dfdb")
+	)
+	(junction
+		(at 246.38 191.77)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "bac303b5-a4e6-4947-ae6f-eebc597c489e")
+	)
+	(junction
+		(at 185.42 149.86)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "bb4987d5-e938-46f2-a23b-19ff99c3080f")
+	)
+	(junction
+		(at 287.02 146.05)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "bbeba694-4201-4454-b255-5030bb49c6f6")
+	)
+	(junction
+		(at 185.42 146.05)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "be28a920-3e68-4ca7-b9a7-38176646013f")
+	)
+	(junction
+		(at 175.26 201.93)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "bf39e6e1-68ea-4eb6-a030-5fd33b992bd9")
+	)
+	(junction
+		(at 368.3 48.26)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "bf7b3eb7-e18a-4069-ac33-cf0c0e72d7fb")
+	)
+	(junction
+		(at 165.1 160.02)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "c0945f67-9e98-45cc-bb7b-5ba92a869659")
+	)
+	(junction
+		(at 185.42 31.75)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "c1f1fc34-957f-4435-b7b8-dc87be3a1617")
+	)
+	(junction
+		(at 383.54 81.28)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "c625301d-0e64-44b1-bb46-f7ff384a4119")
+	)
+	(junction
+		(at 226.06 72.39)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "c73acb40-7d89-46ae-bd3f-d4e57fa34cd5")
+	)
+	(junction
+		(at 322.58 48.26)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "c790f404-c539-4700-83ab-cc09915c7d8e")
+	)
+	(junction
+		(at 200.66 81.28)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "cb70acb8-3f95-4a8c-831b-6c20a5b2a368")
+	)
+	(junction
+		(at 337.82 48.26)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "cbb3b890-46eb-449a-b564-c7e2698852db")
+	)
+	(junction
+		(at 231.14 31.75)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "ccf778d7-d7bc-40bc-9a8e-1d1ebc0c5225")
+	)
+	(junction
+		(at 246.38 177.8)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "d031636f-8516-468b-96f2-e7317f2ef09a")
+	)
+	(junction
+		(at 195.58 146.05)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "d14c2405-286b-4433-af9a-090e980bac2d")
+	)
+	(junction
+		(at 317.5 55.88)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "d1b04923-abfc-4f70-a119-328ccd3b0055")
+	)
+	(junction
+		(at 256.54 135.89)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "d581ae4b-68dd-49fb-92c2-e92357c225c9")
+	)
+	(junction
+		(at 353.06 48.26)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "d5b31f67-611c-4708-91ca-4ba13d7c5a28")
+	)
+	(junction
+		(at 246.38 31.75)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "d5ef4495-a687-41fe-a8fa-fc0aefb3e8d6")
+	)
+	(junction
+		(at 256.54 105.41)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "d6ca6ff4-4104-4032-b209-f2170f70593f")
+	)
+	(junction
+		(at 276.86 81.28)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "d709d586-81dd-4230-99fc-50c8653e09bf")
+	)
+	(junction
+		(at 185.42 173.99)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "d8ae992f-15fa-48b0-8763-a2dd068a4c37")
+	)
+	(junction
+		(at 205.74 191.77)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "d8dfde08-ee91-422a-a33f-91ce8186b391")
+	)
+	(junction
+		(at 368.3 81.28)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "dab37fd3-e122-40df-ad5b-3f6d88e59dfd")
+	)
+	(junction
+		(at 266.7 135.89)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "dbb2478f-cdd3-4c46-8fe2-01854ecfc29c")
+	)
+	(junction
+		(at 287.02 39.37)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "dcf109e9-9ae4-4186-b385-ecf1eafecf9d")
+	)
+	(junction
+		(at 287.02 149.86)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "dd9cd9b4-e225-497d-b359-cdc8c56b16eb")
+	)
+	(junction
+		(at 205.74 173.99)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "ddd89972-cc11-47e8-bbcc-82aab6c24ce2")
+	)
+	(junction
+		(at 102.87 133.35)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "de285bf3-eebb-48e7-9448-ccf82ba888b1")
+	)
+	(junction
+		(at 185.42 135.89)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "de424e9b-1080-458e-8f84-803dbc244b86")
+	)
+	(junction
+		(at 226.06 160.02)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "de558509-02ed-4e07-a2a8-90ae2e6b1fd3")
+	)
+	(junction
+		(at 337.82 64.77)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "dfec3b74-e175-4bf4-9832-ca2f8f547b6f")
+	)
+	(junction
+		(at 215.9 163.83)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "e134be67-b4a6-438f-88be-5e7632e9ce54")
+	)
+	(junction
+		(at 363.22 105.41)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "e15ec7ed-975b-4795-913e-91c841ba4a61")
+	)
+	(junction
+		(at 185.42 64.77)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "e24e4bc6-9d43-45c3-8d5b-3ed18090e344")
+	)
+	(junction
+		(at 287.02 177.8)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "e3bd0ab2-f75c-4d17-8ff9-32f5d0672ada")
+	)
+	(junction
+		(at 368.3 31.75)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "e41be7b9-7cee-4fbd-a4e3-ba4e8f2a43bd")
+	)
+	(junction
+		(at 246.38 81.28)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "e4914472-f094-4eaf-be2c-b02c4255477a")
+	)
+	(junction
+		(at 292.1 81.28)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "e4aa4723-9128-4d9b-a043-d34aa2523e36")
+	)
+	(junction
+		(at 287.02 55.88)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "e53ffe56-9763-44ef-b288-c0ab2f1e7a87")
+	)
+	(junction
+		(at 226.06 146.05)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "e6f26258-2862-44fb-9444-18fd5a7a89f5")
+	)
+	(junction
+		(at 185.42 160.02)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "e7421cb4-c1f0-447f-9bf6-010483e989d2")
+	)
+	(junction
+		(at 383.54 31.75)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "e7d49d9a-ac37-48c9-83ac-637dfd97b5f0")
+	)
+	(junction
+		(at 292.1 31.75)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "e8717437-6af3-4d9d-b27a-24f0abffb17a")
+	)
+	(junction
+		(at 205.74 135.89)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "e98cbd28-f1af-4e2d-93a8-4c69e7012658")
+	)
+	(junction
+		(at 226.06 105.41)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "e9aa873e-6a9c-401a-ab1f-2355e44ebebf")
+	)
+	(junction
+		(at 363.22 72.39)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "ea3b5845-7d71-48eb-a836-5b2012659168")
+	)
+	(junction
+		(at 165.1 173.99)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "ea53d5ed-de6c-49ab-b011-31f9d3b2b7d0")
+	)
+	(junction
+		(at 195.58 177.8)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "eaeb5bab-3292-434a-acac-393fb4a18f03")
+	)
+	(junction
+		(at 337.82 31.75)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "eb5ac7fa-e906-4ef7-a6a2-82e5b57660ae")
+	)
+	(junction
+		(at 180.34 105.41)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "ecb13aaa-80f1-4811-a0fd-aecedadea407")
+	)
+	(junction
+		(at 261.62 64.77)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "eeb09c51-7ab4-427b-be82-c631f0680829")
+	)
+	(junction
+		(at 276.86 163.83)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "ef1cca05-ed49-43f6-9e7e-6fa23f438185")
+	)
+	(junction
+		(at 287.02 173.99)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "efd4a251-9825-4d5d-858a-771a542a8556")
+	)
+	(junction
+		(at 378.46 39.37)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "effad78b-8c87-42eb-b7ae-32d3c460e38b")
+	)
+	(junction
+		(at 276.86 177.8)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "f0ce2e8e-4c55-4251-8a7e-63a984b8383b")
+	)
+	(junction
+		(at 246.38 160.02)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "f2e5eaff-2491-4ccb-9535-ad72b49b40a2")
+	)
+	(junction
+		(at 236.22 173.99)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "f324a6e0-5a7f-40d1-8d8e-76de42ff8b6c")
+	)
+	(junction
+		(at 215.9 81.28)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "f3df5ef8-5c5c-4706-ad3b-dd981583c985")
+	)
+	(junction
+		(at 180.34 88.9)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "f416785d-8013-46c4-9f36-42515366f7bb")
+	)
+	(junction
+		(at 276.86 64.77)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "f4384f7c-2f73-4a1b-b121-01a3fc807f7c")
+	)
+	(junction
+		(at 175.26 191.77)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "f449fbe6-566d-4bf6-ac30-4a2e62c44a2b")
+	)
+	(junction
+		(at 246.38 201.93)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "f533ffb0-4358-4786-ac63-a8d285b429cd")
+	)
+	(junction
+		(at 180.34 39.37)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "f6471bdd-b1dc-49a6-ab00-7681e62a8369")
+	)
+	(junction
+		(at 297.18 191.77)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "f6d8b1e5-b254-4a68-93bc-bb9d9abadbc9")
+	)
+	(junction
+		(at 276.86 149.86)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "f81cdd53-c648-4941-b84b-d0f7f525fac9")
+	)
+	(junction
+		(at 210.82 39.37)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "f84e61b1-afd1-406f-9f97-718f400318fb")
+	)
+	(junction
+		(at 297.18 149.86)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "fa70594c-2a73-45e9-85c1-a9f767a32737")
+	)
+	(junction
+		(at 271.78 39.37)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "faa927b4-984c-4ecb-ba82-855a1e9a807f")
+	)
+	(junction
+		(at 241.3 105.41)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "fac598af-9d75-4415-874e-880eec0c8a40")
+	)
+	(junction
+		(at 287.02 191.77)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "fb59e2cd-7f12-49cc-aa27-c32b45194dc6")
+	)
+	(junction
+		(at 378.46 88.9)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "fdee0d32-8afc-4650-8c2e-690b0863c4a9")
+	)
+	(no_connect
+		(at 69.85 78.74)
+		(uuid "079cb3f7-0f08-424e-9b09-200855ae0343")
+	)
+	(no_connect
+		(at 29.21 30.48)
+		(uuid "10b0e1be-3b69-4259-967a-43b429ce5aab")
+	)
+	(no_connect
+		(at 69.85 55.88)
+		(uuid "1250a014-206f-4950-a635-dacf952cbcea")
+	)
+	(no_connect
+		(at 69.85 60.96)
+		(uuid "1f526aea-56e4-46b5-8050-6fd6457ceb51")
+	)
+	(no_connect
+		(at 29.21 48.26)
+		(uuid "2a1ba492-c9a8-4077-a8a0-caf4ea21d02e")
+	)
+	(no_connect
+		(at 69.85 71.12)
+		(uuid "2b8a5063-424b-4118-a06d-f9feef43b446")
+	)
+	(no_connect
+		(at 69.85 30.48)
+		(uuid "5b5d51e3-3301-4c85-a455-0fb4f9c112fb")
+	)
+	(no_connect
+		(at 69.85 73.66)
+		(uuid "6cae788c-e0de-4932-a636-4fb6e914fdeb")
+	)
+	(no_connect
+		(at 29.21 86.36)
+		(uuid "7cd2a9b5-12ae-4fb4-beb0-e3f8bc7647cf")
+	)
+	(no_connect
+		(at 69.85 50.8)
+		(uuid "8276518e-6482-4344-9dda-d294dad48c2c")
+	)
+	(no_connect
+		(at 69.85 58.42)
+		(uuid "8960fce0-6e8a-4605-a506-7bed9f27a4a5")
+	)
+	(no_connect
+		(at 29.21 55.88)
+		(uuid "95469ab7-9ea3-4c18-84c9-7afac492e63a")
+	)
+	(no_connect
+		(at 69.85 45.72)
+		(uuid "9580f157-e592-4126-9731-8d812f6d663e")
+	)
+	(no_connect
+		(at 43.18 149.86)
+		(uuid "a697acd9-3075-431e-b0cc-28e2381e1285")
+	)
+	(no_connect
+		(at 43.18 152.4)
+		(uuid "b07b4592-322e-4680-bb00-0092c693cd68")
+	)
+	(no_connect
+		(at 69.85 48.26)
+		(uuid "b517b928-0cfc-422f-ae49-07fcdf5fbd69")
+	)
+	(no_connect
+		(at 29.21 66.04)
+		(uuid "d862d780-f15b-4d0d-9649-3a32dff5d060")
+	)
+	(no_connect
+		(at 29.21 88.9)
+		(uuid "e5a37d26-d1ad-413e-a008-5e00709a48a6")
+	)
+	(no_connect
+		(at 29.21 33.02)
+		(uuid "e5c71e10-535b-4d3a-8d88-2680266fd577")
+	)
+	(no_connect
+		(at 69.85 76.2)
+		(uuid "eb062b3e-cfd3-420b-9233-cfa63faad9e3")
+	)
+	(wire
+		(pts
+			(xy 261.62 48.26) (xy 261.62 64.77)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "006c5558-f9a5-46ad-bc0d-98a17edb1b30")
+	)
+	(wire
+		(pts
+			(xy 120.65 140.97) (xy 120.65 142.24)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "00a717c8-9dbe-48c8-8164-8d755270195c")
+	)
+	(wire
+		(pts
+			(xy 215.9 201.93) (xy 226.06 201.93)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "00a824f6-d778-4dd3-9838-900d0e1ed9d8")
+	)
+	(wire
+		(pts
+			(xy 297.18 149.86) (xy 307.34 149.86)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "03c75d68-ed7c-4d5a-bfbb-bde98868de3f")
+	)
+	(wire
+		(pts
+			(xy 297.18 177.8) (xy 307.34 177.8)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0415cd3a-11a1-4a3f-9b0f-09d3e1f09446")
+	)
+	(wire
+		(pts
+			(xy 43.18 139.7) (xy 46.99 139.7)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0416e3fd-4726-49e7-a188-5583fda3ee51")
+	)
+	(polyline
+		(pts
+			(xy 12.7 170.18) (xy 90.17 170.18)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "05536748-06a1-4c9c-ba5a-53cd726e39c4")
+	)
+	(wire
+		(pts
+			(xy 287.02 201.93) (xy 297.18 201.93)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "05dda4b8-ab8c-4cc7-a61d-76676c8ebd6f")
+	)
+	(wire
+		(pts
+			(xy 161.29 177.8) (xy 165.1 177.8)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "06e2ef08-dc5a-4bdf-a756-91cbc0f7de83")
+	)
+	(wire
+		(pts
+			(xy 383.54 31.75) (xy 383.54 48.26)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "09460e80-1773-42d6-8cc2-485c3eb64bb0")
+	)
+	(wire
+		(pts
+			(xy 195.58 149.86) (xy 205.74 149.86)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0aceb93e-22f1-45f7-8d95-52a779f5e374")
+	)
+	(wire
+		(pts
+			(xy 378.46 105.41) (xy 393.7 105.41)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0b46d3bd-c2b1-47a9-84a0-509de47d989d")
+	)
+	(wire
+		(pts
+			(xy 241.3 105.41) (xy 256.54 105.41)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0b589fb9-70a9-4d9b-a6eb-f8e414575bdc")
+	)
+	(wire
+		(pts
+			(xy 256.54 146.05) (xy 266.7 146.05)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0ce9cadf-ea55-458a-82ee-39dc4149a674")
+	)
+	(wire
+		(pts
+			(xy 241.3 88.9) (xy 256.54 88.9)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0d194e02-b876-4621-ad80-d4c25e9ce3d4")
+	)
+	(wire
+		(pts
+			(xy 236.22 173.99) (xy 246.38 173.99)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0da47c87-c02d-4509-b4d5-cacd218a0332")
+	)
+	(wire
+		(pts
+			(xy 302.26 39.37) (xy 317.5 39.37)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0e0a942a-4600-40cc-a50f-a57751413431")
+	)
+	(wire
+		(pts
+			(xy 276.86 173.99) (xy 287.02 173.99)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0ec0a991-a5c6-42ee-a9bb-39bdea0873a0")
+	)
+	(polyline
+		(pts
+			(xy 90.17 242.57) (xy 90.17 243.84)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "0f9cd9cb-5fec-4ff2-a412-983b104dfef5")
+	)
+	(wire
+		(pts
+			(xy 231.14 64.77) (xy 231.14 81.28)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "10278fb5-1bff-482a-ab9d-2f47e3868984")
+	)
+	(wire
+		(pts
+			(xy 276.86 163.83) (xy 287.02 163.83)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "11ade9fc-7d90-4335-ab7b-d002339f66cf")
+	)
+	(wire
+		(pts
+			(xy 161.29 149.86) (xy 165.1 149.86)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "126e2264-f7fc-4646-9888-d23f1bc9d04d")
+	)
+	(wire
+		(pts
+			(xy 241.3 72.39) (xy 256.54 72.39)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "15de4807-8be4-40b1-98d7-3d19e32eb0d4")
+	)
+	(wire
+		(pts
+			(xy 246.38 48.26) (xy 246.38 64.77)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "164bf7f3-a0e0-4de1-aaae-8b5f50a92ebf")
+	)
+	(wire
+		(pts
+			(xy 175.26 177.8) (xy 185.42 177.8)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "16d36b78-690c-416f-b79d-9e1921581a59")
+	)
+	(wire
+		(pts
+			(xy 226.06 146.05) (xy 236.22 146.05)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "1783193e-4a7a-4ada-8d5e-1a5329b70ad5")
+	)
+	(wire
+		(pts
+			(xy 226.06 177.8) (xy 236.22 177.8)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "19b91ae8-565f-47a3-ad81-359271600192")
+	)
+	(wire
+		(pts
+			(xy 180.34 72.39) (xy 195.58 72.39)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "1a7184b4-590e-4bd2-a17b-7b115f32acbe")
+	)
+	(wire
+		(pts
+			(xy 246.38 31.75) (xy 246.38 48.26)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "1ac043a2-973b-4f03-8401-030b427bb7aa")
+	)
+	(wire
+		(pts
+			(xy 347.98 88.9) (xy 363.22 88.9)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "1af89066-83fd-4983-9b32-aeb2a959f370")
+	)
+	(wire
+		(pts
+			(xy 231.14 81.28) (xy 231.14 97.79)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "1b46b409-6143-4f40-995c-2e2bc695623a")
+	)
+	(wire
+		(pts
+			(xy 161.29 201.93) (xy 165.1 201.93)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "1bab1e09-3c89-45c5-b0f1-9d51eb2e3777")
+	)
+	(wire
+		(pts
+			(xy 185.42 21.59) (xy 185.42 31.75)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "1bb09610-92db-48d4-becb-69c4e01e9f6e")
+	)
+	(wire
+		(pts
+			(xy 161.29 191.77) (xy 165.1 191.77)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "1c7bb331-e08e-4035-879e-f42fbf86763f")
+	)
+	(wire
+		(pts
+			(xy 185.42 149.86) (xy 195.58 149.86)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "21f7e5af-7996-4248-ba23-60fb19d416dd")
+	)
+	(polyline
+		(pts
+			(xy 90.17 219.71) (xy 407.67 219.71)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "21fc74a2-a771-48a6-9c1a-f8049aa4b2a5")
+	)
+	(wire
+		(pts
+			(xy 353.06 31.75) (xy 353.06 48.26)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "22438f00-36a9-4a3e-a8cb-f186719753c0")
+	)
+	(wire
+		(pts
+			(xy 337.82 21.59) (xy 337.82 31.75)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "242292ff-9945-49a5-8b0f-e17e93aae080")
+	)
+	(wire
+		(pts
+			(xy 205.74 191.77) (xy 215.9 191.77)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "24b60c70-25d3-4232-85e1-eb7065a179ad")
+	)
+	(wire
+		(pts
+			(xy 368.3 81.28) (xy 368.3 97.79)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "250f337c-258c-4908-89a8-a4a3d7b398c6")
+	)
+	(wire
+		(pts
+			(xy 246.38 160.02) (xy 256.54 160.02)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2581f4e5-ab1c-4b96-a9ae-8a8670274320")
+	)
+	(wire
+		(pts
+			(xy 246.38 21.59) (xy 246.38 31.75)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2652be47-26da-46d0-b527-988ad82d0481")
+	)
+	(polyline
+		(pts
+			(xy 90.17 110.49) (xy 407.67 110.49)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "26eac520-ee58-4650-ac6d-ad588ad2695f")
+	)
+	(wire
+		(pts
+			(xy 266.7 163.83) (xy 276.86 163.83)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "278bf6c8-d533-4d06-8533-b5d3e9cd328f")
+	)
+	(wire
+		(pts
+			(xy 236.22 201.93) (xy 246.38 201.93)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "293d16bb-9011-4212-a06d-e7c72dc8761f")
+	)
+	(wire
+		(pts
+			(xy 226.06 149.86) (xy 236.22 149.86)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2a1b793b-165b-45fe-a9fe-54389a40dbcf")
+	)
+	(polyline
+		(pts
+			(xy 90.17 172.72) (xy 90.17 171.45)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2a7bde14-d89a-499a-bd2c-7b5637011c4e")
+	)
+	(wire
+		(pts
+			(xy 236.22 146.05) (xy 246.38 146.05)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2a9508cc-ee3d-4d85-888b-5e281495d1dd")
+	)
+	(wire
+		(pts
+			(xy 322.58 81.28) (xy 322.58 97.79)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2bec4cca-6b9a-4bd9-a192-7fd6d620fb62")
+	)
+	(wire
+		(pts
+			(xy 271.78 88.9) (xy 287.02 88.9)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2c8a6f41-8f6a-4a04-9afb-c1a4ad052bba")
+	)
+	(wire
+		(pts
+			(xy 317.5 88.9) (xy 332.74 88.9)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2d570604-0fcb-4ed5-8b55-cf20b29bd1ec")
+	)
+	(wire
+		(pts
+			(xy 266.7 187.96) (xy 276.86 187.96)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2d812b65-d35c-488a-bfd2-dbc1ab69594f")
+	)
+	(wire
+		(pts
+			(xy 266.7 173.99) (xy 276.86 173.99)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2db8ab38-6c90-4e3a-acd7-e1b98db0067e")
+	)
+	(wire
+		(pts
+			(xy 287.02 163.83) (xy 297.18 163.83)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2e5fa02b-198b-4aa1-9003-91881e1b7382")
+	)
+	(wire
+		(pts
+			(xy 175.26 149.86) (xy 185.42 149.86)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2ecf165e-9df9-4479-827f-9f0d12e0688c")
+	)
+	(wire
+		(pts
+			(xy 332.74 105.41) (xy 347.98 105.41)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2ff3d97a-4d3d-4fe3-8686-4c71183998c8")
+	)
+	(wire
+		(pts
+			(xy 226.06 39.37) (xy 241.3 39.37)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "30c2678b-6950-4b20-aa65-6e6750cb33b6")
+	)
+	(wire
+		(pts
+			(xy 236.22 163.83) (xy 246.38 163.83)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "31c67bc7-1b9a-4046-81e8-d486670e96b4")
+	)
+	(wire
+		(pts
+			(xy 276.86 149.86) (xy 287.02 149.86)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "32cdf303-9e20-4905-8047-aa44b7e612d2")
+	)
+	(wire
+		(pts
+			(xy 161.29 135.89) (xy 165.1 135.89)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "35d471b1-f4b0-4e2c-abb4-b9cc293f817a")
+	)
+	(wire
+		(pts
+			(xy 287.02 88.9) (xy 302.26 88.9)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "3740fd57-2324-4eb1-aed8-6bfcf23a31d8")
+	)
+	(wire
+		(pts
+			(xy 297.18 173.99) (xy 307.34 173.99)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "37781a95-6437-4459-9bb4-a2caf397f527")
+	)
+	(wire
+		(pts
+			(xy 185.42 163.83) (xy 195.58 163.83)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "38867290-e94c-4e51-9197-7301a25947d7")
+	)
+	(wire
+		(pts
+			(xy 292.1 48.26) (xy 292.1 64.77)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "394bb03e-f217-475b-ba5f-91e29180b804")
+	)
+	(polyline
+		(pts
+			(xy 54.61 189.23) (xy 54.61 219.71)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "3b8dddd9-13c7-4d88-b202-76884fe70f30")
+	)
+	(wire
+		(pts
+			(xy 215.9 48.26) (xy 215.9 64.77)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "3baa3367-e4b0-471d-85b7-6dadad33b0a7")
+	)
+	(wire
+		(pts
+			(xy 363.22 72.39) (xy 378.46 72.39)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "3c82bdbe-d4dc-4527-b9f6-571c824b46ca")
+	)
+	(wire
+		(pts
+			(xy 241.3 39.37) (xy 256.54 39.37)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "3f584f47-d1f0-4e87-b4ed-10d418f6ffe7")
+	)
+	(wire
+		(pts
+			(xy 368.3 31.75) (xy 368.3 48.26)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "3f6c5db4-5de4-4dc5-b1d7-4b4f47c7e33a")
+	)
+	(wire
+		(pts
+			(xy 337.82 31.75) (xy 337.82 48.26)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "40507211-97f9-47c9-8b20-0b4e6d3d8d49")
+	)
+	(polyline
+		(pts
+			(xy 12.7 242.57) (xy 90.17 242.57)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "40a5a39b-188d-47f3-876d-e5174728a814")
+	)
+	(wire
+		(pts
+			(xy 292.1 64.77) (xy 292.1 81.28)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "43797a5e-36ff-4a05-af59-d0da4b65cb58")
+	)
+	(wire
+		(pts
+			(xy 378.46 39.37) (xy 393.7 39.37)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "440c549e-5e49-4f08-aa38-5de85cc4985b")
+	)
+	(wire
+		(pts
+			(xy 347.98 55.88) (xy 363.22 55.88)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "44f71e25-c176-4982-9593-7c17af185f4f")
+	)
+	(wire
+		(pts
+			(xy 266.7 149.86) (xy 276.86 149.86)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "456e7839-9b89-4130-b15c-4621f7f307a2")
+	)
+	(wire
+		(pts
+			(xy 246.38 149.86) (xy 256.54 149.86)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "4671d90f-a800-4d66-9316-e225081b95f7")
+	)
+	(wire
+		(pts
+			(xy 215.9 31.75) (xy 215.9 48.26)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "47796ff1-9b5e-4ed2-af1f-af50319fc2da")
+	)
+	(wire
+		(pts
+			(xy 215.9 64.77) (xy 215.9 81.28)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "4810d2e1-fdf7-4993-b416-8973b6aaa541")
+	)
+	(wire
+		(pts
+			(xy 226.06 201.93) (xy 236.22 201.93)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "48815fad-06ac-4eb0-b5bb-167d2634f22e")
+	)
+	(wire
+		(pts
+			(xy 200.66 64.77) (xy 200.66 81.28)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "492ae956-38a1-4066-8b16-659a75012c57")
+	)
+	(wire
+		(pts
+			(xy 215.9 177.8) (xy 226.06 177.8)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "493e02e9-6673-475d-bcdc-c194098e2d16")
+	)
+	(wire
+		(pts
+			(xy 347.98 105.41) (xy 363.22 105.41)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "4b7c990c-ed2b-4e24-ba53-450f83847c01")
+	)
+	(wire
+		(pts
+			(xy 215.9 81.28) (xy 215.9 97.79)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "4c69138e-a0fa-4b35-95d8-bf313f1f65cd")
+	)
+	(wire
+		(pts
+			(xy 205.74 163.83) (xy 215.9 163.83)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "4cffb6ed-1505-4707-b584-5e4206f6dbb7")
+	)
+	(wire
+		(pts
+			(xy 161.29 163.83) (xy 165.1 163.83)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "4d02a475-a7cd-4265-9fc7-97f1112a792e")
+	)
+	(wire
+		(pts
+			(xy 287.02 173.99) (xy 297.18 173.99)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "4d9c530e-d3a4-4f4f-b503-b5d70fae0e00")
+	)
+	(polyline
+		(pts
+			(xy 12.7 104.14) (xy 90.17 104.14)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "4e3de2f0-ea7c-484b-81de-91f4705826e1")
+	)
+	(wire
+		(pts
+			(xy 226.06 160.02) (xy 236.22 160.02)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "4e475c4b-ac49-4e49-9dc1-858a4f329394")
+	)
+	(wire
+		(pts
+			(xy 185.42 177.8) (xy 195.58 177.8)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "4e75dca0-ab96-4bd8-975e-c80196c4ad35")
+	)
+	(wire
+		(pts
+			(xy 276.86 21.59) (xy 276.86 31.75)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "4e81bf42-8991-4bbb-9298-9e2ba2d4ea45")
+	)
+	(wire
+		(pts
+			(xy 256.54 160.02) (xy 266.7 160.02)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "4e94fb01-bf07-4031-a0ca-e92da02f0009")
+	)
+	(wire
+		(pts
+			(xy 113.03 161.29) (xy 115.57 161.29)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "4f39f0fe-4eae-482b-8ed2-0817ba31dcc5")
+	)
+	(wire
+		(pts
+			(xy 287.02 55.88) (xy 302.26 55.88)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "4fbf8e13-1d5b-4931-aadd-5cc92d384c3c")
+	)
+	(wire
+		(pts
+			(xy 180.34 55.88) (xy 195.58 55.88)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "50f06dec-ae5a-4036-a7f6-cb6a1fe67eb1")
+	)
+	(wire
+		(pts
+			(xy 307.34 21.59) (xy 307.34 31.75)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "516dfe0e-ab9c-4bb0-983f-a7f0998eb52d")
+	)
+	(wire
+		(pts
+			(xy 185.42 64.77) (xy 185.42 81.28)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "52128d4f-f7cc-4bf1-8516-4e7081f46eb8")
+	)
+	(wire
+		(pts
+			(xy 256.54 177.8) (xy 266.7 177.8)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "52dfeb19-a6e3-4534-b5e4-1bc586973d3e")
+	)
+	(wire
+		(pts
+			(xy 195.58 88.9) (xy 210.82 88.9)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "53abf8f6-24e2-4c66-a0bb-8b32096b5364")
+	)
+	(wire
+		(pts
+			(xy 287.02 39.37) (xy 302.26 39.37)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "53f01a74-b89e-457f-a70f-515b6ae435ff")
+	)
+	(wire
+		(pts
+			(xy 276.86 191.77) (xy 287.02 191.77)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "540551d2-1c11-43cb-ac9c-490c901c6b73")
+	)
+	(wire
+		(pts
+			(xy 368.3 64.77) (xy 368.3 81.28)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "5562dfac-722d-4f59-a669-acd38acb3228")
+	)
+	(wire
+		(pts
+			(xy 226.06 135.89) (xy 236.22 135.89)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "55dd38ca-18e0-4f10-a26b-eecc2d255396")
+	)
+	(wire
+		(pts
+			(xy 43.18 139.7) (xy 43.18 142.24)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "55f233e1-40b5-4594-b298-5c3c7faeaeac")
+	)
+	(wire
+		(pts
+			(xy 205.74 135.89) (xy 215.9 135.89)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "56441a33-1f73-4d91-bfb0-197db451a52a")
+	)
+	(wire
+		(pts
+			(xy 163.83 55.88) (xy 180.34 55.88)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "565956ce-cd3b-4084-a0f2-48ef8714139d")
+	)
+	(wire
+		(pts
+			(xy 226.06 191.77) (xy 236.22 191.77)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "5668bc18-d53b-4e8c-b285-7133a8d40b56")
+	)
+	(polyline
+		(pts
+			(xy 13.97 219.71) (xy 90.17 219.71)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "5708d7f8-bbb9-4405-8a13-ad1091580059")
+	)
+	(wire
+		(pts
+			(xy 368.3 48.26) (xy 368.3 64.77)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "58767c51-174b-42a2-b971-fd56335e9f5a")
+	)
+	(wire
+		(pts
+			(xy 175.26 135.89) (xy 185.42 135.89)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "5977f19b-aa90-4109-b292-8d06347118ed")
+	)
+	(wire
+		(pts
+			(xy 297.18 135.89) (xy 307.34 135.89)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "59d93091-7c8e-4ac3-a3b0-5a4db179a629")
+	)
+	(wire
+		(pts
+			(xy 297.18 201.93) (xy 307.34 201.93)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "5ab3d494-6e40-41de-9bf2-1aedddecc813")
+	)
+	(wire
+		(pts
+			(xy 276.86 135.89) (xy 287.02 135.89)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "5c33d358-62cc-4508-b458-38190b3a7de8")
+	)
+	(wire
+		(pts
+			(xy 347.98 72.39) (xy 363.22 72.39)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "5c4bedcb-3c14-4d62-881c-23d3de04d8de")
+	)
+	(wire
+		(pts
+			(xy 215.9 21.59) (xy 215.9 31.75)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "5df8a96e-df8e-4fe7-8944-0d0c9f9772f7")
+	)
+	(wire
+		(pts
+			(xy 180.34 88.9) (xy 195.58 88.9)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "5ed6034a-7f93-4255-9d4c-d24be21ef156")
+	)
+	(wire
+		(pts
+			(xy 287.02 149.86) (xy 297.18 149.86)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "5ef6b0fb-c646-4fe6-b7ac-9b9fa300b42f")
+	)
+	(wire
+		(pts
+			(xy 256.54 187.96) (xy 266.7 187.96)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "5f19ec5f-e075-439d-a2ae-6e3efb77382c")
+	)
+	(wire
+		(pts
+			(xy 337.82 81.28) (xy 337.82 97.79)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "5f62ba26-4ffe-477d-8452-7f65ec8f2362")
+	)
+	(wire
+		(pts
+			(xy 246.38 177.8) (xy 256.54 177.8)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "6116b548-6e55-4c56-af3f-522e989502a8")
+	)
+	(wire
+		(pts
+			(xy 261.62 64.77) (xy 261.62 81.28)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "61b62fea-4852-44d1-99d1-b6f24f6acac0")
+	)
+	(wire
+		(pts
+			(xy 236.22 177.8) (xy 246.38 177.8)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "62c13901-0876-433e-84ce-b8d200881979")
+	)
+	(wire
+		(pts
+			(xy 368.3 21.59) (xy 368.3 31.75)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "62de3a02-9842-460e-afcd-d8e28ca6f13a")
+	)
+	(wire
+		(pts
+			(xy 276.86 201.93) (xy 287.02 201.93)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "6322c882-0134-4393-b8e6-d42824b0c547")
+	)
+	(wire
+		(pts
+			(xy 256.54 105.41) (xy 271.78 105.41)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "640c2061-3c0a-4ac4-94b4-02e86f34867a")
+	)
+	(wire
+		(pts
+			(xy 256.54 135.89) (xy 266.7 135.89)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "6420b748-cfa7-4bbc-8280-a6474beb8a80")
+	)
+	(wire
+		(pts
+			(xy 195.58 72.39) (xy 210.82 72.39)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "642dd021-4de9-4cde-bc29-8c604378553a")
+	)
+	(wire
+		(pts
+			(xy 215.9 173.99) (xy 226.06 173.99)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "6535e4bd-b01b-4f09-b7f9-18dfcdb5075d")
+	)
+	(wire
+		(pts
+			(xy 378.46 72.39) (xy 393.7 72.39)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "6656f2d8-960f-4720-a15e-da3d457c51ac")
+	)
+	(wire
+		(pts
+			(xy 120.65 138.43) (xy 120.65 140.97)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "6658c48d-f815-4566-a9ba-dc6b3f82e12d")
+	)
+	(wire
+		(pts
+			(xy 170.18 48.26) (xy 170.18 64.77)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "665a4b84-f55f-4a76-b04f-8ad0f5c71d1c")
+	)
+	(wire
+		(pts
+			(xy 302.26 55.88) (xy 317.5 55.88)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "668074e6-3516-4b47-8746-5e4458778d55")
+	)
+	(wire
+		(pts
+			(xy 163.83 72.39) (xy 180.34 72.39)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "675e4a49-a550-4031-aebe-b3a5fbfe61df")
+	)
+	(wire
+		(pts
+			(xy 266.7 201.93) (xy 276.86 201.93)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "676cdb6d-fafc-4e64-b7f1-d1fc6efb7404")
+	)
+	(wire
+		(pts
+			(xy 287.02 146.05) (xy 297.18 146.05)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "67eccc6d-b6cf-45f1-a73d-32710a3c91a9")
+	)
+	(wire
+		(pts
+			(xy 43.18 137.16) (xy 46.99 137.16)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "6a85c83b-29f6-488e-a6d0-badb865afd12")
+	)
+	(wire
+		(pts
+			(xy 266.7 160.02) (xy 276.86 160.02)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "6ac1e1ef-2f4f-4977-b904-78363104316e")
+	)
+	(wire
+		(pts
+			(xy 302.26 72.39) (xy 317.5 72.39)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "6d3ddbd9-8a7d-49f6-8ef2-296ee8626451")
+	)
+	(polyline
+		(pts
+			(xy 90.17 12.7) (xy 90.17 284.48)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "6da21d6e-86ed-4600-bf80-db2cff9485e5")
+	)
+	(wire
+		(pts
+			(xy 276.86 177.8) (xy 287.02 177.8)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "70e21679-8c5e-4e42-91f1-23f4ac5eeb75")
+	)
+	(wire
+		(pts
+			(xy 302.26 105.41) (xy 317.5 105.41)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "7122f7ba-d297-44a8-8b5e-9673430e9463")
+	)
+	(wire
+		(pts
+			(xy 307.34 48.26) (xy 307.34 64.77)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "7267c1ac-3bad-425c-a75e-bd1cf9e349e7")
+	)
+	(wire
+		(pts
+			(xy 43.18 129.54) (xy 66.04 129.54)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "72f44938-631a-40e8-bf13-10768e29bcee")
+	)
+	(wire
+		(pts
+			(xy 195.58 177.8) (xy 205.74 177.8)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "7362cc6c-9534-4f3d-98ab-5c74904050a3")
+	)
+	(wire
+		(pts
+			(xy 210.82 39.37) (xy 226.06 39.37)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "73684581-640b-406c-840d-6fd8b95e3a7c")
+	)
+	(wire
+		(pts
+			(xy 175.26 146.05) (xy 185.42 146.05)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "7408a714-fe5f-41ac-898a-53b82afd925f")
+	)
+	(wire
+		(pts
+			(xy 195.58 187.96) (xy 205.74 187.96)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "74402d9d-ab97-41c2-b3cb-7fb9d9b7c83a")
+	)
+	(wire
+		(pts
+			(xy 261.62 81.28) (xy 261.62 97.79)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "7648a2f0-4ac7-4ef8-b8f5-155025b2b3a4")
+	)
+	(wire
+		(pts
+			(xy 287.02 160.02) (xy 297.18 160.02)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "77b979b8-63f4-4f84-9dc6-a7b505debe9d")
+	)
+	(wire
+		(pts
+			(xy 332.74 39.37) (xy 347.98 39.37)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "77cbbbf6-8801-4ac1-9705-1a122044196f")
+	)
+	(wire
+		(pts
+			(xy 195.58 191.77) (xy 205.74 191.77)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "78db2b30-6186-458c-9e86-934721cbb6c3")
+	)
+	(wire
+		(pts
+			(xy 185.42 48.26) (xy 185.42 64.77)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "79d1ab1a-b342-40d7-9424-f484683a646c")
+	)
+	(wire
+		(pts
+			(xy 185.42 81.28) (xy 185.42 97.79)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "7a085270-c216-475e-960c-c9d22b722d87")
+	)
+	(wire
+		(pts
+			(xy 256.54 72.39) (xy 271.78 72.39)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "7ae85256-1e20-45dd-bd89-fb1ffc12ab3b")
+	)
+	(wire
+		(pts
+			(xy 256.54 149.86) (xy 266.7 149.86)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "7cafd25f-f7e5-4a2d-830b-740fa9927ec2")
+	)
+	(wire
+		(pts
+			(xy 383.54 48.26) (xy 383.54 64.77)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "7cbaca28-e491-4596-b8b3-73c3b097b17b")
+	)
+	(wire
+		(pts
+			(xy 205.74 173.99) (xy 215.9 173.99)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "7e911daa-4ab9-4e97-8cfa-bb17a063257a")
+	)
+	(wire
+		(pts
+			(xy 226.06 55.88) (xy 241.3 55.88)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "7f5a7341-78f1-42cc-8ceb-f3bbf467f846")
+	)
+	(wire
+		(pts
+			(xy 226.06 163.83) (xy 236.22 163.83)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "7fcb5ecc-fb6e-4add-b00c-39032279ae41")
+	)
+	(wire
+		(pts
+			(xy 205.74 201.93) (xy 215.9 201.93)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "7fcdc8f0-7ee8-46da-95f0-f565b1afe5e1")
+	)
+	(wire
+		(pts
+			(xy 43.18 127) (xy 76.2 127)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "807994c7-adb5-4c69-8a56-073dd23ba9d6")
+	)
+	(wire
+		(pts
+			(xy 378.46 88.9) (xy 393.7 88.9)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "822f5c50-25a9-4ef9-8a5d-3adbe9460a2a")
+	)
+	(wire
+		(pts
+			(xy 195.58 163.83) (xy 205.74 163.83)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "823fac2e-a211-4d8f-8841-b2dc51be19e7")
+	)
+	(wire
+		(pts
+			(xy 175.26 201.93) (xy 185.42 201.93)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "8394924c-9f88-46b1-b874-4d569a13bd65")
+	)
+	(wire
+		(pts
+			(xy 170.18 64.77) (xy 170.18 81.28)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "83e177f9-eb99-43ff-b36e-20faeebfb150")
+	)
+	(wire
+		(pts
+			(xy 165.1 201.93) (xy 175.26 201.93)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "83e82415-72b4-4ad0-afe4-5d0e2411cc22")
+	)
+	(wire
+		(pts
+			(xy 195.58 173.99) (xy 205.74 173.99)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "83ef4b6a-2bf5-4e47-b258-4b0abaacc14d")
+	)
+	(wire
+		(pts
+			(xy 175.26 163.83) (xy 185.42 163.83)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "8576062b-3f0f-4e79-9ca0-c25e583349d0")
+	)
+	(wire
+		(pts
+			(xy 322.58 64.77) (xy 322.58 81.28)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "869afa09-f970-4a2c-9c07-2426d4bdd014")
+	)
+	(wire
+		(pts
+			(xy 292.1 31.75) (xy 292.1 48.26)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "87652875-338a-431d-b928-a8f0b33cd57c")
+	)
+	(wire
+		(pts
+			(xy 226.06 173.99) (xy 236.22 173.99)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "879dc223-226b-4f3a-a8ca-90bc68407851")
+	)
+	(wire
+		(pts
+			(xy 347.98 39.37) (xy 363.22 39.37)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "87a3d0d6-0bd8-4e7e-b8bd-761c16134e26")
+	)
+	(wire
+		(pts
+			(xy 236.22 135.89) (xy 246.38 135.89)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "889bcba7-4c2b-4380-bd2c-aaa2e11f1fca")
+	)
+	(wire
+		(pts
+			(xy 317.5 39.37) (xy 332.74 39.37)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "89d09264-2ad7-4a4e-9e37-39c43c64f236")
+	)
+	(wire
+		(pts
+			(xy 256.54 201.93) (xy 266.7 201.93)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "8a012e0b-4c5e-42fa-be2b-aaff4615f4ad")
+	)
+	(wire
+		(pts
+			(xy 271.78 39.37) (xy 287.02 39.37)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "8ba3313e-d69e-4169-96e6-ae20692f41ca")
+	)
+	(wire
+		(pts
+			(xy 383.54 21.59) (xy 383.54 31.75)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "8c218ecf-0d03-411e-a29a-f68b6bd78558")
+	)
+	(wire
+		(pts
+			(xy 200.66 81.28) (xy 200.66 97.79)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "8c84f3cf-39ae-4599-aa4a-8c4f74e21919")
+	)
+	(wire
+		(pts
+			(xy 261.62 21.59) (xy 261.62 31.75)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "8dbe6214-3e37-4410-98e1-52ace71ac477")
+	)
+	(wire
+		(pts
+			(xy 102.87 133.35) (xy 105.41 133.35)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "8e781145-9ecc-4d97-bd09-19be74aef2ff")
+	)
+	(wire
+		(pts
+			(xy 256.54 173.99) (xy 266.7 173.99)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "8ea781b5-8180-47f0-ac65-cd88231598fb")
+	)
+	(wire
+		(pts
+			(xy 256.54 88.9) (xy 271.78 88.9)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "91198fd9-759c-4c96-b179-7fbb1b456537")
+	)
+	(wire
+		(pts
+			(xy 185.42 146.05) (xy 195.58 146.05)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "919829b5-a901-481a-bafb-99210c616e09")
+	)
+	(wire
+		(pts
+			(xy 383.54 64.77) (xy 383.54 81.28)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "92a579fc-eb33-4b3d-ad0e-dc5372c8ccef")
+	)
+	(wire
+		(pts
+			(xy 231.14 21.59) (xy 231.14 31.75)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "93044120-c04a-4331-885d-a2c8a3a4e20c")
+	)
+	(wire
+		(pts
+			(xy 195.58 39.37) (xy 210.82 39.37)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "935bc9fe-d31d-4114-a809-f7eac105fd12")
+	)
+	(wire
+		(pts
+			(xy 292.1 21.59) (xy 292.1 31.75)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "93850404-c34e-4a58-b79b-ccae642cd8c7")
+	)
+	(wire
+		(pts
+			(xy 185.42 187.96) (xy 195.58 187.96)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "93fe3d2b-623e-4e14-a1cc-437993a658a0")
+	)
+	(wire
+		(pts
+			(xy 276.86 81.28) (xy 276.86 97.79)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "9433687f-4d9b-4633-9f5f-5583f4117210")
+	)
+	(wire
+		(pts
+			(xy 297.18 160.02) (xy 307.34 160.02)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "9546ede2-202c-4f3f-80e8-cff3a43ee45a")
+	)
+	(wire
+		(pts
+			(xy 292.1 81.28) (xy 292.1 97.79)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "9628fd8e-0720-4761-a625-7e0c6eed7f9d")
+	)
+	(wire
+		(pts
+			(xy 200.66 21.59) (xy 200.66 31.75)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "96862234-efd6-4934-a958-ba5dabe75cac")
+	)
+	(wire
+		(pts
+			(xy 246.38 146.05) (xy 256.54 146.05)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "98d963ae-b9dc-4e51-bf27-46ccd20b4265")
+	)
+	(wire
+		(pts
+			(xy 276.86 146.05) (xy 287.02 146.05)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "9c0671e6-5913-4de3-8dd4-aff7bbcc1218")
+	)
+	(wire
+		(pts
+			(xy 297.18 191.77) (xy 307.34 191.77)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "9cc9e61f-f4a2-41f8-a024-c7b33ce8b1d9")
+	)
+	(wire
+		(pts
+			(xy 363.22 105.41) (xy 378.46 105.41)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "9e667f03-da52-4522-9710-91a4cf56bba9")
+	)
+	(wire
+		(pts
+			(xy 76.2 129.54) (xy 76.2 127)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "9f5a1f1f-9a83-4180-af7c-e9aeef5e9590")
+	)
+	(wire
+		(pts
+			(xy 322.58 21.59) (xy 322.58 31.75)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "9fc59c87-f0ac-486e-9ec9-e07f1f6ab90f")
+	)
+	(wire
+		(pts
+			(xy 210.82 88.9) (xy 226.06 88.9)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "a1884fe4-4cf0-4b1b-b8aa-2529400a2b52")
+	)
+	(wire
+		(pts
+			(xy 256.54 55.88) (xy 271.78 55.88)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "a2f3c36d-3104-416c-a3fd-20daf6e00fd0")
+	)
+	(wire
+		(pts
+			(xy 287.02 135.89) (xy 297.18 135.89)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "a3f10bba-de39-455c-8584-b95efca5df59")
+	)
+	(wire
+		(pts
+			(xy 142.24 161.29) (xy 144.78 161.29)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "a3f6be72-e0d3-42a1-844b-79e62a137d92")
+	)
+	(wire
+		(pts
+			(xy 256.54 191.77) (xy 266.7 191.77)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "a486ab69-c6f5-4330-bbfd-71f08bdd3ac1")
+	)
+	(wire
+		(pts
+			(xy 165.1 160.02) (xy 175.26 160.02)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "a56002a5-c8a3-4beb-9143-fad74190384f")
+	)
+	(wire
+		(pts
+			(xy 256.54 163.83) (xy 266.7 163.83)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "a6d13c3f-d813-4cdc-a763-5b6e7e4250cb")
+	)
+	(wire
+		(pts
+			(xy 215.9 163.83) (xy 226.06 163.83)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "a7870f35-14bb-4521-b225-53def4652754")
+	)
+	(wire
+		(pts
+			(xy 175.26 160.02) (xy 185.42 160.02)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "a7b1a7fc-0ceb-4be4-9ab4-6b00ffb9f795")
+	)
+	(wire
+		(pts
+			(xy 236.22 160.02) (xy 246.38 160.02)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "a7bd25e8-ff4a-4ca8-8d46-fbce89fc106f")
+	)
+	(wire
+		(pts
+			(xy 383.54 81.28) (xy 383.54 97.79)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "a8e971e2-0355-4922-b739-553332626e37")
+	)
+	(wire
+		(pts
+			(xy 161.29 187.96) (xy 165.1 187.96)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "aa07f95f-48f4-48c1-80f4-aec5dce2b057")
+	)
+	(wire
+		(pts
+			(xy 200.66 48.26) (xy 200.66 64.77)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "aa458051-4bd4-4070-8082-35f1bbee414a")
+	)
+	(wire
+		(pts
+			(xy 101.6 133.35) (xy 102.87 133.35)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "aa566c35-70fe-4f94-bb0d-eb0cef258d06")
+	)
+	(wire
+		(pts
+			(xy 246.38 64.77) (xy 246.38 81.28)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ab221107-cbdf-40d4-9809-f01b1e272ac9")
+	)
+	(wire
+		(pts
+			(xy 261.62 31.75) (xy 261.62 48.26)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ab4ad47f-089e-4f4f-89c9-ee3e0a73e9cd")
+	)
+	(wire
+		(pts
+			(xy 195.58 135.89) (xy 205.74 135.89)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "aca323d5-7da4-4ca0-bfe0-b8e74c1da50e")
+	)
+	(wire
+		(pts
+			(xy 226.06 72.39) (xy 241.3 72.39)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ad8e56d4-55cc-4c2d-8b78-f5fb214dea3d")
+	)
+	(wire
+		(pts
+			(xy 302.26 88.9) (xy 317.5 88.9)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ad928c7a-d916-43de-9c6a-41b36a31fbd7")
+	)
+	(wire
+		(pts
+			(xy 353.06 48.26) (xy 353.06 64.77)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "aead9b27-3d28-4a13-a8ba-07a21ca4016a")
+	)
+	(wire
+		(pts
+			(xy 185.42 201.93) (xy 195.58 201.93)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "b0aa8ce7-5d47-479f-9850-41f8b11e30c2")
+	)
+	(wire
+		(pts
+			(xy 266.7 177.8) (xy 276.86 177.8)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "b0c9f863-cb3f-4614-b4db-7408d4bc9db8")
+	)
+	(wire
+		(pts
+			(xy 205.74 177.8) (xy 215.9 177.8)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "b163eed7-6a49-4e17-b1e8-a2d8e235c06d")
+	)
+	(wire
+		(pts
+			(xy 287.02 187.96) (xy 297.18 187.96)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "b2ea6519-8157-41ca-bc01-c0fa1405e1b8")
+	)
+	(wire
+		(pts
+			(xy 165.1 135.89) (xy 175.26 135.89)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "b3641f37-2da3-46e5-994d-266c9721c9f4")
+	)
+	(polyline
+		(pts
+			(xy 12.7 189.23) (xy 90.17 189.23)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "b369de82-ff65-44bd-8973-6d3c617bb498")
+	)
+	(wire
+		(pts
+			(xy 307.34 31.75) (xy 307.34 48.26)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "b38c3b56-0d80-4715-b61d-b60e2c372226")
+	)
+	(wire
+		(pts
+			(xy 165.1 173.99) (xy 175.26 173.99)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "b662f9ac-6358-417a-aec6-124c52635960")
+	)
+	(wire
+		(pts
+			(xy 175.26 173.99) (xy 185.42 173.99)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "b6d3feab-3358-443b-9cc1-f9ec94b550cd")
+	)
+	(wire
+		(pts
+			(xy 226.06 187.96) (xy 236.22 187.96)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "b7d14708-d653-4651-a3df-bccc65fb584b")
+	)
+	(wire
+		(pts
+			(xy 226.06 88.9) (xy 241.3 88.9)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "b8685202-73bd-42a4-998e-ac8e56e688b5")
+	)
+	(wire
+		(pts
+			(xy 215.9 160.02) (xy 226.06 160.02)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "b92b5c9d-de5b-450d-b4c0-0b2ee4d8c3e6")
+	)
+	(wire
+		(pts
+			(xy 271.78 105.41) (xy 287.02 105.41)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ba11e487-ddea-4824-baaa-0d595e060fdf")
+	)
+	(wire
+		(pts
+			(xy 297.18 146.05) (xy 307.34 146.05)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ba41c924-5193-4a3e-9a11-c32e38e1c3b1")
+	)
+	(wire
+		(pts
+			(xy 317.5 72.39) (xy 332.74 72.39)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ba850917-b63e-4f0c-b406-911cb20fd01a")
+	)
+	(wire
+		(pts
+			(xy 246.38 191.77) (xy 256.54 191.77)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ba9d1a32-005a-4dd1-8355-b4bd72663c5e")
+	)
+	(wire
+		(pts
+			(xy 165.1 163.83) (xy 175.26 163.83)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "bafd72ce-547b-405e-9374-301cc4fedbd9")
+	)
+	(wire
+		(pts
+			(xy 210.82 55.88) (xy 226.06 55.88)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "bbc72f38-3ab4-479c-8c67-da15ea0e4295")
+	)
+	(wire
+		(pts
+			(xy 287.02 177.8) (xy 297.18 177.8)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "bcaea803-8959-4680-862e-34aa86d87f98")
+	)
+	(wire
+		(pts
+			(xy 276.86 48.26) (xy 276.86 64.77)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "bcc902b0-68dc-4a8b-9d73-f4b7414d1f00")
+	)
+	(wire
+		(pts
+			(xy 297.18 187.96) (xy 307.34 187.96)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "bd4ab997-394e-4ba4-b2bb-7294fbb51d81")
+	)
+	(wire
+		(pts
+			(xy 180.34 39.37) (xy 195.58 39.37)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "bda3fc14-994c-4820-9a3c-34412a4e3f74")
+	)
+	(wire
+		(pts
+			(xy 246.38 163.83) (xy 256.54 163.83)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "bdba9f28-b207-48ea-ba6d-a38dd2273e06")
+	)
+	(wire
+		(pts
+			(xy 353.06 81.28) (xy 353.06 97.79)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "bfa21ada-453c-4aa2-ae12-0bd56cd361ce")
+	)
+	(wire
+		(pts
+			(xy 271.78 72.39) (xy 287.02 72.39)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "bfb5312b-e0e7-40b1-9ccf-ba0b0e659937")
+	)
+	(wire
+		(pts
+			(xy 205.74 187.96) (xy 215.9 187.96)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c0163022-4826-4625-a38c-c30663162438")
+	)
+	(wire
+		(pts
+			(xy 287.02 72.39) (xy 302.26 72.39)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c11bffc7-0607-4b29-acf4-086ed08ff097")
+	)
+	(wire
+		(pts
+			(xy 215.9 146.05) (xy 226.06 146.05)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c11eb7a2-776f-4dbb-8d6d-f9f0a9eb79ec")
+	)
+	(wire
+		(pts
+			(xy 353.06 21.59) (xy 353.06 31.75)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c197277c-b018-4294-8f03-f184a9576e2b")
+	)
+	(wire
+		(pts
+			(xy 165.1 146.05) (xy 175.26 146.05)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c1d24b09-6494-4426-aef6-ff9445a92bc6")
+	)
+	(wire
+		(pts
+			(xy 205.74 149.86) (xy 215.9 149.86)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c2436098-88a0-4720-a176-9b799ae76902")
+	)
+	(wire
+		(pts
+			(xy 205.74 146.05) (xy 215.9 146.05)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c27dd86b-2ddc-46ce-a26a-b6d64d05f61c")
+	)
+	(wire
+		(pts
+			(xy 43.18 134.62) (xy 43.18 137.16)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c2db8881-4813-433e-be66-76bad37bb390")
+	)
+	(wire
+		(pts
+			(xy 163.83 88.9) (xy 180.34 88.9)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c349fff4-5f58-4a4a-91c4-7ad99f57e132")
+	)
+	(wire
+		(pts
+			(xy 165.1 191.77) (xy 175.26 191.77)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c38705b9-74e4-4f40-85ea-58c368f162b8")
+	)
+	(wire
+		(pts
+			(xy 102.87 140.97) (xy 120.65 140.97)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c4f7dbc8-0941-4b9f-8406-27302ad4697b")
+	)
+	(wire
+		(pts
+			(xy 165.1 177.8) (xy 175.26 177.8)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c50d6c31-33cf-42c9-89e4-6c0388e569b1")
+	)
+	(wire
+		(pts
+			(xy 185.42 160.02) (xy 195.58 160.02)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c64bd651-02ed-4d18-9614-743655abdff1")
+	)
+	(wire
+		(pts
+			(xy 271.78 55.88) (xy 287.02 55.88)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c6911c6d-7759-44a9-95f5-02fe91ca0e12")
+	)
+	(wire
+		(pts
+			(xy 185.42 191.77) (xy 195.58 191.77)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c80a4fea-2d98-4aaf-b902-620df314dbde")
+	)
+	(wire
+		(pts
+			(xy 236.22 187.96) (xy 246.38 187.96)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c898a3ec-1836-496b-a9d6-4191adc8081a")
+	)
+	(wire
+		(pts
+			(xy 322.58 48.26) (xy 322.58 64.77)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c8b00187-d072-4d26-b628-d95637fc2a88")
+	)
+	(wire
+		(pts
+			(xy 195.58 55.88) (xy 210.82 55.88)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c9153109-9367-4e21-beb2-dbbec5b90fe3")
+	)
+	(wire
+		(pts
+			(xy 69.85 83.82) (xy 74.93 83.82)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c920dab8-12b1-4b05-ad39-31323b4bd364")
+	)
+	(wire
+		(pts
+			(xy 266.7 191.77) (xy 276.86 191.77)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c92733c3-1425-4270-a161-5dd7f612083e")
+	)
+	(wire
+		(pts
+			(xy 307.34 64.77) (xy 307.34 81.28)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "c9c08b8c-0236-457d-9a6f-b8c18f213ee4")
+	)
+	(wire
+		(pts
+			(xy 215.9 187.96) (xy 226.06 187.96)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "cb22555a-ee6a-46a4-8b9b-deeb183bb8e9")
+	)
+	(wire
+		(pts
+			(xy 266.7 146.05) (xy 276.86 146.05)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "cb84d206-592b-4a57-a92b-672fb3f92af9")
+	)
+	(wire
+		(pts
+			(xy 246.38 201.93) (xy 256.54 201.93)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "cbbdbdd5-b5ad-410c-abd2-8b446d70086d")
+	)
+	(wire
+		(pts
+			(xy 241.3 55.88) (xy 256.54 55.88)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "cbfa0e7f-86cc-4abd-a7ee-9b2bf46c30bf")
+	)
+	(wire
+		(pts
+			(xy 363.22 39.37) (xy 378.46 39.37)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "cc40f95c-1719-45a5-9aa1-be52a3a601dc")
+	)
+	(wire
+		(pts
+			(xy 226.06 105.41) (xy 241.3 105.41)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "cccdf3dd-9d1f-400c-91f2-6e32aeeb9b0e")
+	)
+	(wire
+		(pts
+			(xy 297.18 163.83) (xy 307.34 163.83)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "cdac6432-28a6-4622-8d51-783287fd81d8")
+	)
+	(wire
+		(pts
+			(xy 337.82 64.77) (xy 337.82 81.28)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d05b5fca-de0d-42cb-9753-bea7239b817f")
+	)
+	(wire
+		(pts
+			(xy 307.34 81.28) (xy 307.34 97.79)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d08c322f-af2f-4a98-9ca2-e7d3864c4cd7")
+	)
+	(wire
+		(pts
+			(xy 378.46 55.88) (xy 393.7 55.88)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d1fcfa24-af60-4b3b-b7cf-e2207ede0401")
+	)
+	(polyline
+		(pts
+			(xy 12.7 219.71) (xy 15.24 219.71)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d3f23f59-7fb8-4a8e-9727-626d5df2b1e9")
+	)
+	(wire
+		(pts
+			(xy 180.34 105.41) (xy 195.58 105.41)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d5157129-db48-4189-a943-d2d59d088370")
+	)
+	(wire
+		(pts
+			(xy 256.54 39.37) (xy 271.78 39.37)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d554bbd6-23fc-4f7f-9cd9-e0f1ad0417e9")
+	)
+	(wire
+		(pts
+			(xy 287.02 191.77) (xy 297.18 191.77)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d5640b88-8168-4282-a32d-cc9be873b746")
+	)
+	(wire
+		(pts
+			(xy 163.83 39.37) (xy 180.34 39.37)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d5aafa63-5dd1-401a-94b5-f36c786b7e60")
+	)
+	(wire
+		(pts
+			(xy 332.74 55.88) (xy 347.98 55.88)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d6b967e3-d773-4a0c-822c-3309b29603f7")
+	)
+	(wire
+		(pts
+			(xy 185.42 173.99) (xy 195.58 173.99)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d7bae459-bd30-4c77-a3e0-fe0f8cfd2a5b")
+	)
+	(wire
+		(pts
+			(xy 246.38 81.28) (xy 246.38 97.79)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d7d2e033-7db7-4431-b06c-110667677a05")
+	)
+	(wire
+		(pts
+			(xy 161.29 173.99) (xy 165.1 173.99)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d9bbf963-f86f-4bf7-8b87-d6b35ed5c8cb")
+	)
+	(wire
+		(pts
+			(xy 363.22 88.9) (xy 378.46 88.9)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "d9f98fc0-11a6-4316-af87-54235236b1a7")
+	)
+	(wire
+		(pts
+			(xy 266.7 135.89) (xy 276.86 135.89)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "da8821ca-0b82-48f7-b942-07e15b88e50f")
+	)
+	(wire
+		(pts
+			(xy 276.86 31.75) (xy 276.86 48.26)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "daae9b90-61ef-45e9-b359-24104331c81a")
+	)
+	(wire
+		(pts
+			(xy 276.86 64.77) (xy 276.86 81.28)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "dbdf3d7d-1491-4519-9ebf-d8643a7523fd")
+	)
+	(wire
+		(pts
+			(xy 210.82 72.39) (xy 226.06 72.39)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "dbea69c7-ad80-4091-b1ff-a9fed54e4fc2")
+	)
+	(wire
+		(pts
+			(xy 195.58 105.41) (xy 210.82 105.41)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "dc39b5de-c60e-4716-9f7d-4fc8988b760f")
+	)
+	(wire
+		(pts
+			(xy 246.38 187.96) (xy 256.54 187.96)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "dd5a4d59-62de-45ce-898b-7d0a245ecc3a")
+	)
+	(wire
+		(pts
+			(xy 246.38 135.89) (xy 256.54 135.89)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "dd6ba940-c7cd-4ec0-814c-fa141f5020b3")
+	)
+	(wire
+		(pts
+			(xy 175.26 187.96) (xy 185.42 187.96)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "df4ae402-2038-4155-b376-9a4ec26e74db")
+	)
+	(wire
+		(pts
+			(xy 332.74 72.39) (xy 347.98 72.39)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "df689136-1e95-4330-af09-a3e33d7b6ca1")
+	)
+	(wire
+		(pts
+			(xy 246.38 173.99) (xy 256.54 173.99)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "e1b6830d-8db0-4d7a-a049-a0cf6dc18544")
+	)
+	(wire
+		(pts
+			(xy 317.5 105.41) (xy 332.74 105.41)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "e363a156-5323-4ae9-94d7-e03d6b132ca7")
+	)
+	(wire
+		(pts
+			(xy 185.42 135.89) (xy 195.58 135.89)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "e364fda3-ff3e-4d2c-8d25-4e4957d56707")
+	)
+	(wire
+		(pts
+			(xy 161.29 146.05) (xy 165.1 146.05)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "e423398c-4c4d-441c-9d6b-297b3e33cf44")
+	)
+	(wire
+		(pts
+			(xy 165.1 149.86) (xy 175.26 149.86)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "e4938fad-d575-444d-80f9-6c10e78a591a")
+	)
+	(wire
+		(pts
+			(xy 185.42 31.75) (xy 185.42 48.26)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "e5298c66-8a0f-4009-a265-6533d9a4819c")
+	)
+	(wire
+		(pts
+			(xy 195.58 146.05) (xy 205.74 146.05)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "e85d1bb7-d730-4caf-8aa9-0031bc54d446")
+	)
+	(wire
+		(pts
+			(xy 170.18 81.28) (xy 170.18 97.79)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "e8c04fcf-1517-4c3d-a2c7-a80f6fde440d")
+	)
+	(wire
+		(pts
+			(xy 317.5 55.88) (xy 332.74 55.88)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "e8d7a21f-8363-423b-8b23-6455f8ed6341")
+	)
+	(wire
+		(pts
+			(xy 276.86 160.02) (xy 287.02 160.02)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "e977a2f2-beca-474b-ac43-2933e9f6fb1b")
+	)
+	(wire
+		(pts
+			(xy 205.74 160.02) (xy 215.9 160.02)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "e99be181-5c6c-4748-8012-67f5be37ec63")
+	)
+	(polyline
+		(pts
+			(xy 90.17 219.71) (xy 90.17 218.44)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "eae13bdd-48a4-4949-b558-b11d43586bdf")
+	)
+	(wire
+		(pts
+			(xy 236.22 149.86) (xy 246.38 149.86)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ec9c8c98-233b-424f-8d9a-0a296100ec17")
+	)
+	(wire
+		(pts
+			(xy 363.22 55.88) (xy 378.46 55.88)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ed11753a-e340-4e2d-90f2-a723e93cac58")
+	)
+	(wire
+		(pts
+			(xy 236.22 191.77) (xy 246.38 191.77)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ed148b1e-a596-408f-85ab-5deb8f5d06fa")
+	)
+	(wire
+		(pts
+			(xy 337.82 48.26) (xy 337.82 64.77)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "eda39938-7855-4f4c-a734-bce6cb26770b")
+	)
+	(wire
+		(pts
+			(xy 161.29 160.02) (xy 165.1 160.02)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "eeccb291-4a14-47b0-bc29-5915745112ac")
+	)
+	(wire
+		(pts
+			(xy 165.1 187.96) (xy 175.26 187.96)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "eefb2a11-3ba6-434b-a8d6-2c34545e5a17")
+	)
+	(wire
+		(pts
+			(xy 276.86 187.96) (xy 287.02 187.96)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ef1e008a-27ec-4268-b048-ca140a15da9e")
+	)
+	(wire
+		(pts
+			(xy 170.18 31.75) (xy 170.18 48.26)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "ef5ae606-024b-4368-b254-58fb13c1744a")
+	)
+	(wire
+		(pts
+			(xy 353.06 64.77) (xy 353.06 81.28)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f091b3d4-280e-4a51-bb77-b1453968ae62")
+	)
+	(wire
+		(pts
+			(xy 215.9 191.77) (xy 226.06 191.77)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f11d6406-257d-4652-aaf6-42b2c02ea0ef")
+	)
+	(wire
+		(pts
+			(xy 163.83 105.41) (xy 180.34 105.41)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f13c90b2-8b30-4ca1-9068-92d8a86973b4")
+	)
+	(wire
+		(pts
+			(xy 332.74 88.9) (xy 347.98 88.9)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f2425464-3fe7-4325-822d-1545c856b1aa")
+	)
+	(wire
+		(pts
+			(xy 170.18 21.59) (xy 170.18 31.75)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f441d873-bdcc-4344-b6d3-857d2e8657d8")
+	)
+	(wire
+		(pts
+			(xy 215.9 149.86) (xy 226.06 149.86)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f54f58d5-eb16-4529-9d94-c83c83a26733")
+	)
+	(wire
+		(pts
+			(xy 231.14 31.75) (xy 231.14 48.26)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f58b8c1e-b8f8-439e-80bc-797c058c1402")
+	)
+	(wire
+		(pts
+			(xy 231.14 48.26) (xy 231.14 64.77)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f6cdab97-fb41-49dd-aef6-1d7c0193412e")
+	)
+	(wire
+		(pts
+			(xy 215.9 135.89) (xy 226.06 135.89)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f724369f-2ba5-4da4-b502-849733a7ba9e")
+	)
+	(wire
+		(pts
+			(xy 210.82 105.41) (xy 226.06 105.41)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f79ac282-4dc9-4085-aeb8-8a29add4fd8c")
+	)
+	(wire
+		(pts
+			(xy 287.02 105.41) (xy 302.26 105.41)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f87c59c4-3cc2-495f-a4f1-f739ebf312ff")
+	)
+	(wire
+		(pts
+			(xy 200.66 31.75) (xy 200.66 48.26)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f9da871a-704b-4bbc-9e3a-8f6aefe16959")
+	)
+	(wire
+		(pts
+			(xy 195.58 201.93) (xy 205.74 201.93)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "fb8c6898-96ae-429e-a758-dda0908a202f")
+	)
+	(wire
+		(pts
+			(xy 175.26 191.77) (xy 185.42 191.77)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "fc03feb3-2ca9-4472-97ee-33f7981b36b2")
+	)
+	(wire
+		(pts
+			(xy 195.58 160.02) (xy 205.74 160.02)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "fc1b8941-958c-4b50-aef7-3a149b2577a6")
+	)
+	(wire
+		(pts
+			(xy 322.58 31.75) (xy 322.58 48.26)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "fe30e83f-32d2-42d0-84b9-744272d38386")
+	)
+	(text_box "\n\n\n\nFor CH32X035:\n- Only PA0-PA15 and PC16-PC17 support pull down input.\n  (ref. CH32X035 datasheet, section 1.4.19).\n- PA7, PB0 cannot be used as outputs.\n  (ref. notes to Table 2-1).\n\nFor \"cathode(-) faces row\",\ncurrent flows from column to row,\nmatrix scanning is done by either:\n- write col high (+), and read from pull-down rows (-),\n- write row low (-), and read from pull-up cols (+).\n\nFor \"cathode(-) faces col\",\ncurrent flows from row to column,\nmatrix scanning is done by either:\n- write row high (+), and read from pull-down cols (-),\n- write col low (-), and read from pull-up rows (+)."
+		(exclude_from_sim no)
+		(at 91.44 22.606 0)
+		(size 59.69 55.88)
+		(stroke
+			(width 0.0254)
+			(type default)
+			(color 255 153 0 1)
+		)
+		(fill
+			(type color)
+			(color 255 255 0 0.51)
+		)
+		(effects
+			(font
+				(size 1.27 1.27)
+				(italic yes)
+				(color 0 0 0 1)
+			)
+			(justify left top)
+		)
+		(uuid "d24818f0-d37b-461b-b4c1-cc65c1f20322")
+	)
+	(text "Microcontroller"
+		(exclude_from_sim no)
+		(at 13.716 15.494 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "1a3f595b-29ec-4585-8bef-a7f36cc202f7")
+	)
+	(text "USB Connector, ESD Protection"
+		(exclude_from_sim no)
+		(at 13.97 108.204 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "20cbef4f-ea13-426a-bbcd-ef6be5da0d1c")
+	)
+	(text "LEDs (Indicators, Backlighting)"
+		(exclude_from_sim no)
+		(at 91.694 113.538 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left top)
+		)
+		(uuid "3a0c52ae-7c74-4964-8956-07e50be7d964")
+	)
+	(text "Reset Switch\nref. Figure 3-3 Typical circuit\nof CH32X datasheet."
+		(exclude_from_sim no)
+		(at 56.642 196.596 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "59c44a69-548c-4499-b969-18be4103306e")
+	)
+	(text "WCH Link interface\n(CH32X033 only compatible with WCH-LinkE or WCH-LinkW)\nUsing DIO/DCK prevents use of ROW2/ROW6."
+		(exclude_from_sim no)
+		(at 14.986 250.698 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "5a15dbc3-9e18-4482-a7cb-dffc665b7408")
+	)
+	(text "Download switch.\nShort while plugging in USB to enter\nISP flashing mode. e.g. with wchisp."
+		(exclude_from_sim no)
+		(at 14.732 197.104 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "6d4b0f5b-1ee7-4297-b0fe-23f503e788d1")
+	)
+	(text "Decoupling capacitors"
+		(exclude_from_sim no)
+		(at 15.494 173.736 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "716d03a9-9251-4784-8c4d-6d86723e1ecc")
+	)
+	(text "LED Backlighting\n\n- Supply voltage: 5V\n- LED forward voltage, e.g.: 1.8V\n- Current Limiting Resistor: 560R\n- Voltage across LED = 5V - 1.8V = 3.2V\n- Individual LED current = 3.2V / 560R = 5.7mA\n- Total LED current (of backlighting) = 75 * 5.7mA = 427.5 mA"
+		(exclude_from_sim no)
+		(at 158.242 114.554 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left top)
+		)
+		(uuid "73b27a60-54f0-4b02-b9a3-aff796cc6788")
+	)
+	(text "- Constraints on pin output:\n   None of PA7, PB0 used by matrix.\n   (No constraint).\n- Constraints on pull-down input:\n   All matrix rows are PA0-PA15.\n   Can be used with pull-down input.\n\nHence, the diodes in the matrix can be \"col to row\". "
+		(exclude_from_sim no)
+		(at 94.234 81.28 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left top)
+		)
+		(uuid "8b002cc5-0423-42d5-af6d-baed88706203")
+	)
+	(text "IMPORTANT:\nTake care with diode direction!"
+		(exclude_from_sim no)
+		(at 120.65 26.924 0)
+		(effects
+			(font
+				(size 1.651 1.651)
+				(thickness 0.254)
+				(bold yes)
+				(color 0 0 0 1)
+			)
+		)
+		(uuid "8ee71737-3414-413b-9734-5a88add6046f")
+	)
+	(text "Switch Matrix\n\nThe keyboard has 75 keys laid out\nin a 5-row-15-column grid."
+		(exclude_from_sim no)
+		(at 91.948 13.97 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left top)
+		)
+		(uuid "90dc8a85-5197-4b81-b333-ce01362591ce")
+	)
+	(text "UART\nFor simple printf debugging with UART2.\n(\"ROW4\"/SW_4_x switches can't be used\n while using UART2)."
+		(exclude_from_sim no)
+		(at 14.732 230.124 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "c578f8ae-a382-4504-8dc3-15503748c72d")
+	)
+	(text "Indicator LEDs"
+		(exclude_from_sim no)
+		(at 92.202 148.336 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left top)
+		)
+		(uuid "d5af6a95-06e9-4881-a0a7-fe0d3e323fda")
+	)
+	(text "Hardware, Mounting Holes\nFor M2 screws.\nMay be useful for 3DP case, or switch plate."
+		(exclude_from_sim no)
+		(at 254.254 263.398 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "d93d8cd6-5f83-4b0b-b58b-afcfdda762ca")
+	)
+	(text "N-channel FET used as a switch for the LEDs"
+		(exclude_from_sim no)
+		(at 91.44 121.666 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left top)
+		)
+		(uuid "df231841-0729-4b4e-9db2-418bf9d78ea7")
+	)
+	(text "Take care the diode direction agrees with matrix scanning\nrequirements for writing to the pin / pulling down."
+		(exclude_from_sim no)
+		(at 92.71 73.66 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+				(thickness 0.254)
+				(bold yes)
+				(color 0 0 0 1)
+			)
+			(justify left)
+		)
+		(uuid "e5dcc4f3-a909-4a10-80b9-45a9ae4e9f4b")
+	)
+	(label "DCK"
+		(at 69.85 88.9 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "00be30ae-0992-4aa4-b456-53908d07c65c")
+	)
+	(label "VDD"
+		(at 52.07 132.08 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "01d1d09b-fe00-4d50-9c15-46828b312734")
+	)
+	(label "COL4"
+		(at 215.9 21.59 90)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "050abf82-37a2-4e41-bb42-c66bc416f5b9")
+	)
+	(label "ROW2"
+		(at 163.83 55.88 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "07e2532e-a3cf-4ac1-85e7-ad8af53b753d")
+	)
+	(label "GND"
+		(at 120.65 142.24 270)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "08c24ad7-d189-4a3b-8a37-ee5f4252058f")
+	)
+	(label "DCK"
+		(at 44.45 260.35 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "0b891cf8-7c87-4868-849d-417c84e5939b")
+	)
+	(label "RESET"
+		(at 68.58 205.74 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "0cc8598b-0597-4b1d-ab9f-f78fecaea026")
+	)
+	(label "TX"
+		(at 29.21 35.56 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "0e73ee2c-b724-4aba-9788-04568ad0f63e")
+	)
+	(label "GND"
+		(at 45.72 181.61 270)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "109d03e7-964e-4dc2-9393-34f6d3c39eaa")
+	)
+	(label "COL15"
+		(at 29.21 81.28 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "122a26d4-7b04-44fb-9629-a1586ef5c9a4")
+	)
+	(label "COL1"
+		(at 170.18 21.59 90)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "14d0b728-1923-406a-9eb0-b73bb5b09eb7")
+	)
+	(label "COL9"
+		(at 292.1 21.59 90)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "17f003f8-1349-475d-97c5-1af2400a129e")
+	)
+	(label "RX"
+		(at 29.21 38.1 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "18b82c37-aad4-43df-8fe4-01d2cf1176a2")
+	)
+	(label "VDD"
+		(at 45.72 173.99 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "1ab180b0-7c30-4cbc-a505-a3decbfe25c2")
+	)
+	(label "GND"
+		(at 52.07 144.78 270)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "1fbca358-9afb-4fb3-b66a-37c9f6d2efff")
+	)
+	(label "COL2"
+		(at 185.42 21.59 90)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "20447fef-bd87-4796-ab3b-a435936dd8f8")
+	)
+	(label "COL5"
+		(at 231.14 21.59 90)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "20fc221a-5404-4f9e-91e2-8c7d97f8c45d")
+	)
+	(label "RESET"
+		(at 29.21 83.82 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "21893ef6-f6a2-4ef8-bcb2-5445eb088102")
+	)
+	(label "COL6"
+		(at 69.85 63.5 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "251769f5-6666-4adf-bf65-f86197cd2a03")
+	)
+	(label "COL4"
+		(at 69.85 40.64 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "31dc951e-9a22-4525-9b67-92bd1ea449ed")
+	)
+	(label "GND"
+		(at 20.32 160.02 270)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "3212aa56-c107-483d-b883-2706db6bd2e2")
+	)
+	(label "LED"
+		(at 161.29 160.02 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "35ccf000-9c25-4f6e-8a79-546eafe560a5")
+	)
+	(label "GND"
+		(at 115.57 161.29 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "36a96549-0c5f-4763-b695-26c526d935dd")
+	)
+	(label "ROW4"
+		(at 163.83 88.9 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "37204a02-45c3-4182-b6bd-efaecbb972e3")
+	)
+	(label "VDD"
+		(at 43.18 121.92 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "3746cc94-5dd9-4f8f-9174-cc4c0ae5dca6")
+	)
+	(label "GND"
+		(at 44.45 257.81 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "3885f191-e722-4ec6-864a-62c081a999b2")
+	)
+	(label "VDD"
+		(at 161.29 177.8 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "3e37f5da-4d6e-4237-b0ab-2b251ea20c07")
+	)
+	(label "COL14"
+		(at 368.3 21.59 90)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "3ef2a608-248e-4766-b934-702c394b0e70")
+	)
+	(label "VDD"
+		(at 161.29 191.77 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "40e40994-359d-4ed9-9be2-e5be19f68b7a")
+	)
+	(label "LED_CTRL"
+		(at 101.6 133.35 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "47ae2a6a-7534-4628-8570-5473c8021fd0")
+	)
+	(label "DIO"
+		(at 69.85 86.36 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "4880d68c-0847-4558-9239-5de1f8c49ca7")
+	)
+	(label "GND"
+		(at 78.74 205.74 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "4b8892ed-4ef1-4db6-8e30-9259e24c9a03")
+	)
+	(label "COL10"
+		(at 307.34 21.59 90)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "4c8ec636-8bef-4d3b-a4ea-4cb4db490ec8")
+	)
+	(label "DM"
+		(at 57.15 137.16 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "58575551-68cd-4f39-bf36-a5bf0a9c1924")
+	)
+	(label "COL8"
+		(at 276.86 21.59 90)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "5b3c7e34-7a77-4231-bc36-a286a643e51d")
+	)
+	(label "LED"
+		(at 120.65 128.27 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "5bb912eb-2310-4043-a20d-8f1fac2e490e")
+	)
+	(label "ROW1"
+		(at 163.83 39.37 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "5bcba8c2-52ae-4552-9fe2-dc6c808e208a")
+	)
+	(label "COL1"
+		(at 69.85 33.02 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "5f68c5e9-ca2b-4e01-9daf-b1cf07dfd4ef")
+	)
+	(label "LED"
+		(at 161.29 201.93 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "608d7bfc-8dbd-4def-9a97-414311d5bc12")
+	)
+	(label "GND"
+		(at 68.58 213.36 270)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "63e597bb-2814-43ac-bf8c-744f43972141")
+	)
+	(label "COL10"
+		(at 29.21 68.58 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "645de1b2-7b47-4873-80b3-fd42cf750956")
+	)
+	(label "COL15"
+		(at 383.54 21.59 90)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "67465828-40a7-477c-9422-4b6c71530f85")
+	)
+	(label "COL11"
+		(at 29.21 71.12 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "6b9f805c-80fc-4994-a0fb-f4333f644a9b")
+	)
+	(label "GND"
+		(at 76.2 137.16 270)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "6ccd2d38-a28c-4f73-9ae0-4ec87d5a4c25")
+	)
+	(label "GND"
+		(at 59.69 181.61 270)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "70231272-edc0-40d2-83b6-b55529aa5d10")
+	)
+	(label "TX"
+		(at 44.45 236.22 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "7281444b-9729-4f1d-99e0-ee3bff14d131")
+	)
+	(label "COL3"
+		(at 200.66 21.59 90)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "78c32e96-8d88-461f-9ae9-bb79874df682")
+	)
+	(label "ROW5"
+		(at 163.83 105.41 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "7dc6af0c-d850-4334-acc1-692f2e072cb2")
+	)
+	(label "DIO"
+		(at 44.45 262.89 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "7e4d5efa-3eeb-4369-9a1c-8f13a8cc5be6")
+	)
+	(label "DP"
+		(at 69.85 83.82 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "804d1b49-6aa4-41d1-b85e-08a189751e16")
+	)
+	(label "ROW3"
+		(at 29.21 40.64 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "81ec95f7-874a-43b3-af14-cb94352f67bc")
+	)
+	(label "COL2"
+		(at 69.85 35.56 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "8f3e1743-63ba-4134-a74b-71b5cd4f8b1a")
+	)
+	(label "LED"
+		(at 97.79 161.29 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "901b374c-0b65-425a-b1b8-2b3f2e21c209")
+	)
+	(label "DP"
+		(at 57.15 139.7 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "9329ba21-0edb-4f5b-a4eb-bb68bd7c7187")
+	)
+	(label "GND"
+		(at 66.04 137.16 270)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "975e51ef-c815-44b0-9dc1-2b78bd9171f4")
+	)
+	(label "ROW4"
+		(at 29.21 43.18 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "991c1a1a-a73e-489f-b845-c2b42baef07d")
+	)
+	(label "VDD"
+		(at 161.29 163.83 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "9f5941b4-1a86-4da8-9b7f-b92af4b06404")
+	)
+	(label "GND"
+		(at 27.94 160.02 270)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "a3aa3127-88e0-4fc4-abb2-e28ff047f420")
+	)
+	(label "DM"
+		(at 69.85 81.28 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "a501fe4b-ccd5-4857-8064-39caa5f2a32b")
+	)
+	(label "COL6"
+		(at 246.38 21.59 90)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "a6118391-454c-425a-8c44-b8f3e41558e4")
+	)
+	(label "COL3"
+		(at 69.85 38.1 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "a7b46870-2a06-44f3-b857-66d118386552")
+	)
+	(label "LED"
+		(at 161.29 173.99 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "a826474f-6e86-42af-a44d-345991c8a6ec")
+	)
+	(label "LED_CTRL"
+		(at 69.85 53.34 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "aaa2c50e-a6ac-49ab-b41e-5896899316d1")
+	)
+	(label "LED"
+		(at 161.29 187.96 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "b2ed6600-3459-424b-8eee-75f48ebfc415")
+	)
+	(label "ROW3"
+		(at 163.83 72.39 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "b651679f-637a-43bf-88f9-b15cf71c2fb6")
+	)
+	(label "GND"
+		(at 49.53 96.52 270)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "bbc8b485-25a0-4015-8159-95aabcbb2ec3")
+	)
+	(label "VDD"
+		(at 59.69 173.99 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "bd60c7cd-471a-4823-a414-f3db15a553d1")
+	)
+	(label "VDD"
+		(at 161.29 149.86 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "bdee9fbd-c6b2-4d41-96c5-803ce39305ab")
+		(property "Netclass" "Power"
+			(at 161.29 151.13 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+					(italic yes)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(label "RX"
+		(at 44.45 238.76 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "c021b389-de08-43c5-9f49-2e1a581d7d5a")
+	)
+	(label "ROW5"
+		(at 29.21 45.72 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "c35568c6-2e20-4d4a-8e44-d176b96b355f")
+	)
+	(label "VDD"
+		(at 127 161.29 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "c429a08e-c761-498b-bd1a-e919c0e97918")
+	)
+	(label "COL5"
+		(at 69.85 43.18 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "ccadf59c-123a-448f-846d-4de2e3bfa864")
+	)
+	(label "COL7"
+		(at 29.21 63.5 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "cd8bc611-bc35-453f-9000-aeb0530920c7")
+	)
+	(label "VDD"
+		(at 161.29 135.89 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "cf491c33-9068-4019-9032-6fe6d4ed7743")
+	)
+	(label "DOWNLOAD"
+		(at 74.93 83.82 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "d0505f87-b350-4ec3-ab2d-c4faf8a4352f")
+	)
+	(label "COL7"
+		(at 261.62 21.59 90)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "d389cfb1-96bc-4a43-9774-c246c86eb0b8")
+	)
+	(label "COL13"
+		(at 353.06 21.59 90)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "d495c0c3-adfc-4305-b5a1-5342f48838d8")
+	)
+	(label "ROW2"
+		(at 29.21 53.34 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "d5081e98-7afd-4873-be28-30db24163ec2")
+	)
+	(label "COL12"
+		(at 337.82 21.59 90)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "d584e991-7b8f-47cd-a3ea-f44fdbbb042a")
+	)
+	(label "COL14"
+		(at 29.21 78.74 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "d740a9d5-2bb5-497c-8834-06434d75ba4f")
+	)
+	(label "COL13"
+		(at 29.21 76.2 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "dbe42c8e-87ee-457b-9e31-1ba23cd2face")
+	)
+	(label "LED"
+		(at 161.29 146.05 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "e130d052-a69a-4fc9-b475-6f05a337d209")
+		(property "Netclass" "Power"
+			(at 161.29 147.32 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+					(italic yes)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+	)
+	(label "COL8"
+		(at 29.21 60.96 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "e20949d8-cba1-441d-a552-0216c1b3339a")
+	)
+	(label "COL9"
+		(at 29.21 58.42 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "e79ab8e1-4a2f-4b40-a472-b867e85a9761")
+	)
+	(label "VDD"
+		(at 49.53 22.86 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "eef4452c-2d67-467e-ad3e-e143c229ea15")
+	)
+	(label "VDD"
+		(at 46.99 208.28 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "ef3460e6-7403-405f-a22c-08d265e16ea3")
+	)
+	(label "ROW1"
+		(at 29.21 50.8 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "f1f54f2d-afed-45e0-8042-2b5d7ffaa4cd")
+	)
+	(label "VDD"
+		(at 44.45 255.27 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "f3170dc4-0fb6-4683-886e-e3108baeb2cd")
+	)
+	(label "DOWNLOAD"
+		(at 29.21 208.28 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "f49134bb-c063-4df1-b19e-e3bc11ed9a15")
+	)
+	(label "COL11"
+		(at 322.58 21.59 90)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "f87be198-3542-4f54-a567-fbaebf79030d")
+	)
+	(label "COL12"
+		(at 29.21 73.66 180)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right bottom)
+		)
+		(uuid "fe97b2e0-750b-4b4b-969c-6397ae480157")
+	)
+	(label "GND"
+		(at 144.78 161.29 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left bottom)
+		)
+		(uuid "ff251ac5-46fa-4c29-8932-31a7a69049ff")
+	)
+	(symbol
+		(lib_id "Device:D")
+		(at 210.82 35.56 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "0053a213-556a-4e66-8a06-82f567e38da1")
+		(property "Reference" "D_1_3"
+			(at 203.2 35.56 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 212.852 36.703 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_SMD:D_1206_3216Metric"
+			(at 210.82 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 210.82 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Diode (Through-hole or 0805)"
+			(at 210.82 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" "C9808"
+			(at 210.82 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "ba6fcbda-6958-4956-b96c-7e984ef76cb1")
+		)
+		(pin "2"
+			(uuid "f5df924b-9eff-48fc-99b3-9d436d7f7ac3")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "D_1_3")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_SPST")
+		(at 73.66 205.74 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "00ae1504-1a81-49ed-8d9d-d638ce87b96e")
+		(property "Reference" "SW1"
+			(at 73.66 199.39 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_SPST"
+			(at 73.66 201.93 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Connector_Wire:SolderWire-0.5sqmm_1x02_P4.6mm_D0.9mm_OD2.1mm"
+			(at 73.66 205.74 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 73.66 205.74 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 73.66 205.74 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "0a4dc498-8db6-4344-b08d-96f848956eeb")
+		)
+		(pin "2"
+			(uuid "9233ef21-a8e7-4066-abb2-d6b0ea683dba")
+		)
+		(instances
+			(project "keyboard-ch552-48"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "SW1")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:LED_Small")
+		(at 297.18 157.48 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "014728a6-4820-4175-9289-48489d04f53b")
+		(property "Reference" "L_2_14"
+			(at 299.72 156.1464 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "LED_Small"
+			(at 299.72 158.6864 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "LED_SMD:LED_0805_2012Metric_Pad1.15x1.40mm_HandSolder"
+			(at 297.18 157.48 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 297.18 157.48 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Light emitting diode, small symbol"
+			(at 297.18 157.48 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "c7683c2b-2e53-42a7-be9e-24df23689e7e")
+		)
+		(pin "2"
+			(uuid "d980d953-91e9-4abd-8408-96511a8ee1f1")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "L_2_14")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:D")
+		(at 180.34 85.09 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "016d9601-02ec-4a7f-93bf-2dd016bef811")
+		(property "Reference" "D_4_1"
+			(at 172.72 85.09 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 182.372 86.233 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_SMD:D_1206_3216Metric"
+			(at 180.34 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 180.34 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Diode (Through-hole or 0805)"
+			(at 180.34 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" "C9808"
+			(at 180.34 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "aec58bc9-5e1e-4330-ab41-2f6b0ef6bf3e")
+		)
+		(pin "2"
+			(uuid "ed00ed75-9e4e-4340-87d9-f40dba318b2e")
+		)
+		(instances
+			(project "keyboard-ch552-48"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "D_4_1")
+					(unit 1)
+				)
+			)
+			(project "PyKey40-HS"
+				(path "/6e68f0cd-800e-4167-9553-71fc59da1eeb"
+					(reference "D_4_1")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 220.98 48.26 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "01f769d6-e5fa-472e-8973-9af66346a5d9")
+		(property "Reference" "SW_2_4"
+			(at 220.98 43.18 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "Redragon Low Profile switches"
+			(at 220.98 43.3324 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "ProjectLocal:SW_Redragon_LowProfile_PCB_1.00u"
+			(at 220.98 43.18 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 220.98 43.18 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Mechanical Keyboard Switch"
+			(at 220.98 48.26 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" ""
+			(at 220.98 48.26 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "28a6dd7a-a418-4704-bf1f-99a02af61e67")
+		)
+		(pin "2"
+			(uuid "7c6c77e1-1178-4dd8-89f0-851a6d9affbf")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "SW_2_4")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 101.6 161.29 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "026ed65e-0904-47c2-a952-b64ac85246df")
+		(property "Reference" "R4"
+			(at 101.6 154.94 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "10K"
+			(at 101.6 157.48 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0805_2012Metric"
+			(at 101.6 163.068 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 101.6 161.29 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 101.6 161.29 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" "C17414"
+			(at 101.6 161.29 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "36fbbd42-c511-4705-b6a6-58b29ba10bb3")
+		)
+		(pin "2"
+			(uuid "c6d2daad-f898-4d45-bea7-9e175a978300")
+		)
+		(instances
+			(project "keyboard-ch32x-48"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "R4")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:D")
+		(at 287.02 52.07 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "02778962-93c1-4bed-a2e6-4cc05e3f43ff")
+		(property "Reference" "D_2_8"
+			(at 279.4 52.07 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 289.052 53.213 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_SMD:D_1206_3216Metric"
+			(at 287.02 52.07 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 287.02 52.07 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Diode (Through-hole or 0805)"
+			(at 287.02 52.07 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" "C9808"
+			(at 287.02 52.07 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "7c64ffd9-751b-4155-bf3f-2919548cd323")
+		)
+		(pin "2"
+			(uuid "477ef5aa-788b-452a-8022-69f985f183fd")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "D_2_8")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 266.7 48.26 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "036270eb-c217-4d54-91ee-ee2a1b8e0515")
+		(property "Reference" "SW_2_7"
+			(at 266.7 43.18 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "Redragon Low Profile switches"
+			(at 266.7 43.3324 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "ProjectLocal:SW_Redragon_LowProfile_PCB_1.00u"
+			(at 266.7 43.18 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 266.7 43.18 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Mechanical Keyboard Switch"
+			(at 266.7 48.26 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" ""
+			(at 266.7 48.26 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "9a926ade-0613-408f-85a3-8279a2c998b2")
+		)
+		(pin "2"
+			(uuid "a54269bf-fbe9-4c6e-a661-2da044f8c557")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "SW_2_7")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:LED_Small")
+		(at 307.34 185.42 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "0411f68c-2622-4490-89f3-769bc362cb82")
+		(property "Reference" "L_4_15"
+			(at 309.88 184.0864 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "LED_Small"
+			(at 309.88 186.6264 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "LED_SMD:LED_0805_2012Metric_Pad1.15x1.40mm_HandSolder"
+			(at 307.34 185.42 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 307.34 185.42 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Light emitting diode, small symbol"
+			(at 307.34 185.42 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "1fff2dd2-8ab3-4108-ba43-09419e5e0bcf")
+		)
+		(pin "2"
+			(uuid "b50271ce-70e2-4f83-93a1-b49eadfe92e3")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "L_4_15")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 102.87 137.16 180)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "04be3bcb-c954-4093-9445-344b044a2f92")
+		(property "Reference" "R7"
+			(at 105.41 135.8899 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "10K"
+			(at 105.41 138.4299 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0805_2012Metric"
+			(at 104.648 137.16 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 102.87 137.16 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 102.87 137.16 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" "C17414"
+			(at 102.87 137.16 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "2e28b66b-4047-48ad-b0d1-5b93bd35fc4b")
+		)
+		(pin "2"
+			(uuid "76cae9c0-5e1a-44c1-9483-c2c28f71bfcb")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "R7")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:LED_Small")
+		(at 195.58 199.39 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "050c4b8c-6458-4889-8bb9-0df91f5a4e0a")
+		(property "Reference" "L_5_4"
+			(at 198.12 198.0564 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "LED_Small"
+			(at 198.12 200.5964 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "LED_SMD:LED_0805_2012Metric_Pad1.15x1.40mm_HandSolder"
+			(at 195.58 199.39 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 195.58 199.39 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Light emitting diode, small symbol"
+			(at 195.58 199.39 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "604011cc-1bb1-42d5-a44b-ea9889edaf80")
+		)
+		(pin "2"
+			(uuid "08105966-0638-414b-8ad1-3a99d8b586c4")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "L_5_4")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R_Small")
+		(at 175.26 194.31 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "05763886-4269-4637-96fa-bd165f3b053f")
+		(property "Reference" "R_5_2"
+			(at 177.8 193.0399 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "560R"
+			(at 177.8 195.5799 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0805_2012Metric"
+			(at 175.26 194.31 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 175.26 194.31 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Resistor, small symbol"
+			(at 175.26 194.31 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "2"
+			(uuid "e363d1e4-25a9-43c8-8046-f99ef065029c")
+		)
+		(pin "1"
+			(uuid "a505bbd0-becd-4ae6-8215-d7a5a31ae11c")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "R_5_2")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 388.62 48.26 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "065a033b-5d67-4cc7-81e8-7a2ddcfc4384")
+		(property "Reference" "SW_2_15"
+			(at 388.62 43.18 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "Redragon Low Profile switches"
+			(at 388.62 43.3324 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "ProjectLocal:SW_Redragon_LowProfile_PCB_1.00u"
+			(at 388.62 43.18 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 388.62 43.18 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Mechanical Keyboard Switch"
+			(at 388.62 48.26 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" ""
+			(at 388.62 48.26 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "d5b8e799-ff20-4301-96d8-9859a710f150")
+		)
+		(pin "2"
+			(uuid "a17081d3-948d-4eb1-b951-8914f7d5ccee")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "SW_2_15")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 205.74 64.77 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "065e8d56-1ae6-447d-bbbf-e2beae1eaf6d")
+		(property "Reference" "SW_3_3"
+			(at 205.74 59.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "Redragon Low Profile switches"
+			(at 205.74 59.8424 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "ProjectLocal:SW_Redragon_LowProfile_PCB_1.00u"
+			(at 205.74 59.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 205.74 59.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Mechanical Keyboard Switch"
+			(at 205.74 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" ""
+			(at 205.74 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "34b49daa-ed57-459a-bc9a-ec833636831d")
+		)
+		(pin "2"
+			(uuid "a1839b3f-f22c-4e81-89c0-20d3dc506737")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "SW_3_3")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Connector_Generic:Conn_01x04")
+		(at 49.53 257.81 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom no)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "074f91cc-585a-436d-b7ae-bbb0ef848887")
+		(property "Reference" "J3"
+			(at 52.07 257.8099 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "Conn_01x04"
+			(at 52.07 260.3499 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Connector_PinHeader_2.54mm:PinHeader_1x04_P2.54mm_Vertical"
+			(at 49.53 257.81 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 49.53 257.81 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Generic connector, single row, 01x04, script generated (kicad-library-utils/schlib/autogen/connector/)"
+			(at 49.53 257.81 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "2"
+			(uuid "22d66788-b2c3-4f62-aa81-dca4bfff9e5a")
+		)
+		(pin "3"
+			(uuid "7b6c063b-5428-4d18-b8ff-70d76820f2ca")
+		)
+		(pin "4"
+			(uuid "150d7acb-d775-4da8-a1e1-603a0dbb8850")
+		)
+		(pin "1"
+			(uuid "90e9a7e9-a818-4d29-a16b-4c215f3f7424")
+		)
+		(instances
+			(project ""
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "J3")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R_Small")
+		(at 185.42 166.37 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "07de37ca-63a9-4c78-adae-200ce0cc5e47")
+		(property "Reference" "R_3_3"
+			(at 187.96 165.0999 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "560R"
+			(at 187.96 167.6399 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0805_2012Metric"
+			(at 185.42 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 185.42 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Resistor, small symbol"
+			(at 185.42 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "2"
+			(uuid "177997cb-ffc0-4b32-b5d7-d39f84c0348a")
+		)
+		(pin "1"
+			(uuid "734da8f7-8ba1-4b2b-833e-9d94d3dce297")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "R_3_3")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R_Small")
+		(at 246.38 180.34 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "07e9f707-9d7d-4b9c-a39c-742e96ea5fba")
+		(property "Reference" "R_4_9"
+			(at 248.92 179.0699 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "560R"
+			(at 248.92 181.6099 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0805_2012Metric"
+			(at 246.38 180.34 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 246.38 180.34 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Resistor, small symbol"
+			(at 246.38 180.34 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "2"
+			(uuid "268f71eb-b05f-4241-a016-4183b2c56c16")
+		)
+		(pin "1"
+			(uuid "28833639-3bee-4079-b7df-79ab6f0fed4a")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "R_4_9")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:D")
+		(at 226.06 68.58 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "0bc9dcd9-16d7-468d-9194-a7a92d9b11ba")
+		(property "Reference" "D_3_4"
+			(at 218.44 68.58 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 228.092 69.723 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_SMD:D_1206_3216Metric"
+			(at 226.06 68.58 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 226.06 68.58 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Diode (Through-hole or 0805)"
+			(at 226.06 68.58 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" "C9808"
+			(at 226.06 68.58 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "a0f00f4c-2f49-439a-9a99-77d894cbcf1a")
+		)
+		(pin "2"
+			(uuid "a23cc285-ef0b-4884-a172-6e4d5930d573")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "D_3_4")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:D")
+		(at 302.26 52.07 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "0d77c1d7-07b6-4655-85af-209a9271627b")
+		(property "Reference" "D_2_9"
+			(at 294.64 52.07 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 304.292 53.213 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_SMD:D_1206_3216Metric"
+			(at 302.26 52.07 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 302.26 52.07 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Diode (Through-hole or 0805)"
+			(at 302.26 52.07 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" "C9808"
+			(at 302.26 52.07 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "bfd55321-2d62-4faa-8da8-2345dc371ca9")
+		)
+		(pin "2"
+			(uuid "4d0add9a-4df6-44bd-a236-247bfaf94fb9")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "D_2_9")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:D")
+		(at 378.46 85.09 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "0d9aa0ea-f9cc-4ccd-bea4-7ead0a710fae")
+		(property "Reference" "D_4_14"
+			(at 370.84 85.09 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 380.492 86.233 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_SMD:D_1206_3216Metric"
+			(at 378.46 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 378.46 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Diode (Through-hole or 0805)"
+			(at 378.46 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" "C9808"
+			(at 378.46 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "662ebd88-8caf-4283-8801-36c987304df0")
+		)
+		(pin "2"
+			(uuid "5a1c2f15-3faa-4776-a8b6-81a2959bdcf9")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "D_4_14")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R_Small")
+		(at 236.22 180.34 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "0e101e4a-e59b-4d1b-ab9a-22ae2dfc6282")
+		(property "Reference" "R_4_8"
+			(at 238.76 179.0699 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "560R"
+			(at 238.76 181.6099 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0805_2012Metric"
+			(at 236.22 180.34 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 236.22 180.34 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Resistor, small symbol"
+			(at 236.22 180.34 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "2"
+			(uuid "8480e4cc-b997-4b71-aca9-00af466b8610")
+		)
+		(pin "1"
+			(uuid "de90d657-b75d-4b89-8964-915c83699552")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "R_4_8")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:D")
+		(at 302.26 68.58 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "1100760e-7148-4d3f-91af-b9fc1aa178f8")
+		(property "Reference" "D_3_9"
+			(at 294.64 68.58 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 304.292 69.723 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_SMD:D_1206_3216Metric"
+			(at 302.26 68.58 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 302.26 68.58 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Diode (Through-hole or 0805)"
+			(at 302.26 68.58 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" "C9808"
+			(at 302.26 68.58 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "48ab8e79-eeee-415c-a671-1f21c361a56c")
+		)
+		(pin "2"
+			(uuid "4e4c9b77-35e7-4d44-83dd-069002dbb2f6")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "D_3_9")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:D")
+		(at 317.5 52.07 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "116c5a9c-b4b3-4b67-b933-fa853e51a72b")
+		(property "Reference" "D_2_10"
+			(at 309.88 52.07 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 319.532 53.213 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_SMD:D_1206_3216Metric"
+			(at 317.5 52.07 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 317.5 52.07 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Diode (Through-hole or 0805)"
+			(at 317.5 52.07 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" "C9808"
+			(at 317.5 52.07 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "55632837-c14e-4e7c-9eb3-ee04a0dd00f3")
+		)
+		(pin "2"
+			(uuid "7fc11be6-4a75-49c1-b968-6fdbc2da5bd4")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "D_2_10")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:D")
+		(at 287.02 35.56 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "121f3e3f-79b4-416b-85ed-3a742b3febf8")
+		(property "Reference" "D_1_8"
+			(at 279.4 35.56 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 289.052 36.703 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_SMD:D_1206_3216Metric"
+			(at 287.02 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 287.02 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Diode (Through-hole or 0805)"
+			(at 287.02 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" "C9808"
+			(at 287.02 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "44607e2d-0699-410e-a24d-389626bed0bd")
+		)
+		(pin "2"
+			(uuid "3b71589c-58cc-4546-b84f-83d98d4c1353")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "D_1_8")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R_Small")
+		(at 297.18 152.4 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "12218a62-b736-479d-ad6f-7002e5fd56e4")
+		(property "Reference" "R_2_14"
+			(at 299.72 151.1299 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "560R"
+			(at 299.72 153.6699 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0805_2012Metric"
+			(at 297.18 152.4 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 297.18 152.4 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Resistor, small symbol"
+			(at 297.18 152.4 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "2"
+			(uuid "96699a66-edd4-4373-af06-dffd80d7cb9c")
+		)
+		(pin "1"
+			(uuid "b3eeac0a-66c7-4dfa-8a69-838d4d074eae")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "R_2_14")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 251.46 81.28 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "12b77cd4-20c0-44e5-b2fd-5223de02815e")
+		(property "Reference" "SW_4_6"
+			(at 251.46 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "Redragon Low Profile switches"
+			(at 251.46 76.3524 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "ProjectLocal:SW_Redragon_LowProfile_PCB_1.00u"
+			(at 251.46 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 251.46 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Mechanical Keyboard Switch"
+			(at 251.46 81.28 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" ""
+			(at 251.46 81.28 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "80fc9990-bb84-4eca-9e4c-f6436e88afa4")
+		)
+		(pin "2"
+			(uuid "1a753ee2-68ee-465b-adfe-e14fc716038d")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "SW_4_6")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:LED_Small")
+		(at 307.34 143.51 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "1497297f-c5aa-456b-99b7-3737cb724833")
+		(property "Reference" "L_1_15"
+			(at 309.88 142.1764 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "LED_Small"
+			(at 309.88 144.7164 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "LED_SMD:LED_0805_2012Metric_Pad1.15x1.40mm_HandSolder"
+			(at 307.34 143.51 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 307.34 143.51 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Light emitting diode, small symbol"
+			(at 307.34 143.51 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "89bd675f-25d1-432e-9b47-f967ce21d482")
+		)
+		(pin "2"
+			(uuid "e9ccf461-ff60-4bbe-b66a-2b0e7a0daad4")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "L_1_15")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R_Small")
+		(at 226.06 166.37 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "1498a7a3-1f36-43f6-b9fd-4f7b97e3bb9b")
+		(property "Reference" "R_3_7"
+			(at 228.6 165.0999 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "560R"
+			(at 228.6 167.6399 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0805_2012Metric"
+			(at 226.06 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 226.06 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Resistor, small symbol"
+			(at 226.06 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "2"
+			(uuid "749fe24a-320f-4f9a-9830-b9937b126b37")
+		)
+		(pin "1"
+			(uuid "ff9eb98d-52fb-4ea9-9ca8-fdd569814d05")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "R_3_7")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 327.66 81.28 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "153875bc-0bf1-42ab-9ee2-7408cd213c7a")
+		(property "Reference" "SW_4_11"
+			(at 327.66 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "Redragon Low Profile switches"
+			(at 327.66 76.3524 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "ProjectLocal:SW_Redragon_LowProfile_PCB_1.00u"
+			(at 327.66 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 327.66 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Mechanical Keyboard Switch"
+			(at 327.66 81.28 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" ""
+			(at 327.66 81.28 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "7ba4f7da-d31e-4586-a8e5-5a57ee4a245a")
+		)
+		(pin "2"
+			(uuid "f0e2c5c3-756a-4969-acf3-907797cd6bad")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "SW_4_11")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R_Small")
+		(at 165.1 194.31 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "158cb656-17f2-4a61-9ba1-fd0be20bb97d")
+		(property "Reference" "R_5_1"
+			(at 167.64 193.0399 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "560R"
+			(at 167.64 195.5799 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0805_2012Metric"
+			(at 165.1 194.31 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 165.1 194.31 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Resistor, small symbol"
+			(at 165.1 194.31 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "2"
+			(uuid "071f9f41-37f7-4c0c-a790-983dde95e825")
+		)
+		(pin "1"
+			(uuid "9b7d43d4-9ddb-460f-ba10-bae5bfb2787a")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "R_5_1")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:D")
+		(at 210.82 101.6 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "15ccbaae-417b-4e88-8970-b79e1b4a690f")
+		(property "Reference" "D_5_3"
+			(at 203.2 101.6 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 212.852 102.743 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_SMD:D_1206_3216Metric"
+			(at 210.82 101.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 210.82 101.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Diode (Through-hole or 0805)"
+			(at 210.82 101.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" "C9808"
+			(at 210.82 101.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "b0c89ded-e6d1-4c24-bece-956268ae9a6e")
+		)
+		(pin "2"
+			(uuid "567e4b1f-eb38-43dc-9a7a-a538bbe3dccd")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "D_5_3")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 358.14 64.77 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "162fd3cc-a7e5-4d04-8421-64f48cba6903")
+		(property "Reference" "SW_3_13"
+			(at 358.14 59.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "Redragon Low Profile switches"
+			(at 358.14 59.8424 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "ProjectLocal:SW_Redragon_LowProfile_PCB_1.00u"
+			(at 358.14 59.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 358.14 59.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Mechanical Keyboard Switch"
+			(at 358.14 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" ""
+			(at 358.14 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "71c2b85c-ff7e-4cec-89f0-6b02a9ccf4d6")
+		)
+		(pin "2"
+			(uuid "cf3ca50d-87a5-4976-93c4-4113458cef19")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "SW_3_13")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:D")
+		(at 363.22 101.6 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "16a66826-ad4a-4bfb-b36f-60184b67b902")
+		(property "Reference" "D_5_13"
+			(at 355.6 101.6 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 365.252 102.743 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_SMD:D_1206_3216Metric"
+			(at 363.22 101.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 363.22 101.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Diode (Through-hole or 0805)"
+			(at 363.22 101.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" "C9808"
+			(at 363.22 101.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "ae71be43-84c5-4f9e-b44f-d50c8f1dcdaa")
+		)
+		(pin "2"
+			(uuid "1cd7ef54-1d0a-4363-8e88-d621875876bd")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "D_5_13")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R_Small")
+		(at 266.7 152.4 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "172094c7-c3b9-4f94-b7ad-f64611545a32")
+		(property "Reference" "R_2_11"
+			(at 269.24 151.1299 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "560R"
+			(at 269.24 153.6699 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0805_2012Metric"
+			(at 266.7 152.4 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 266.7 152.4 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Resistor, small symbol"
+			(at 266.7 152.4 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "2"
+			(uuid "3fe1933a-0334-495f-9845-eb179a723f9a")
+		)
+		(pin "1"
+			(uuid "e32ef60a-345b-40a0-a08a-2363799a3e91")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "R_2_11")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R_Small")
+		(at 256.54 152.4 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "17395987-1578-40ed-8513-15a4c9870dc0")
+		(property "Reference" "R_2_10"
+			(at 259.08 151.1299 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "560R"
+			(at 259.08 153.6699 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0805_2012Metric"
+			(at 256.54 152.4 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 256.54 152.4 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Resistor, small symbol"
+			(at 256.54 152.4 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "2"
+			(uuid "3846a366-d4c2-48cf-aa20-0fe9a8e5e077")
+		)
+		(pin "1"
+			(uuid "58d68349-2e34-49aa-929f-763bc429226d")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "R_2_10")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:LED_Small")
+		(at 256.54 143.51 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "18a6958e-1c8e-4912-a826-b6baac6abc7b")
+		(property "Reference" "L_1_10"
+			(at 259.08 142.1764 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "LED_Small"
+			(at 259.08 144.7164 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "LED_SMD:LED_0805_2012Metric_Pad1.15x1.40mm_HandSolder"
+			(at 256.54 143.51 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 256.54 143.51 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Light emitting diode, small symbol"
+			(at 256.54 143.51 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "e16b39e2-1c3e-4aae-9f11-0cf3bce05f25")
+		)
+		(pin "2"
+			(uuid "a43e2679-a46e-45a0-9780-a023a7baf80c")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "L_1_10")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:D")
+		(at 271.78 52.07 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "18e98dc2-aa1d-4ef4-a725-2c2c45c088a3")
+		(property "Reference" "D_2_7"
+			(at 264.16 52.07 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 273.812 53.213 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_SMD:D_1206_3216Metric"
+			(at 271.78 52.07 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 271.78 52.07 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Diode (Through-hole or 0805)"
+			(at 271.78 52.07 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" "C9808"
+			(at 271.78 52.07 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "4b79ff2d-8e3a-4763-bdf4-769878771850")
+		)
+		(pin "2"
+			(uuid "6cf50494-b2da-417a-994c-03a4d04404e2")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "D_2_7")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 312.42 48.26 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "1a10244d-aee7-456d-bbd9-784e92975ace")
+		(property "Reference" "SW_2_10"
+			(at 312.42 43.18 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "Redragon Low Profile switches"
+			(at 312.42 43.3324 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "ProjectLocal:SW_Redragon_LowProfile_PCB_1.00u"
+			(at 312.42 43.18 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 312.42 43.18 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Mechanical Keyboard Switch"
+			(at 312.42 48.26 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" ""
+			(at 312.42 48.26 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "70754903-2cec-4a63-b479-bb62db22e9d8")
+		)
+		(pin "2"
+			(uuid "4bcf4ea0-4270-4076-8cb7-6cba4e72af8d")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "SW_2_10")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 281.94 48.26 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "1ae7e635-ac00-44d3-9134-1ea7805a8a11")
+		(property "Reference" "SW_2_8"
+			(at 281.94 43.18 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "Redragon Low Profile switches"
+			(at 281.94 43.3324 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "ProjectLocal:SW_Redragon_LowProfile_PCB_1.00u"
+			(at 281.94 43.18 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 281.94 43.18 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Mechanical Keyboard Switch"
+			(at 281.94 48.26 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" ""
+			(at 281.94 48.26 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "3625a6ee-9f37-4ded-a098-baf12a94bca5")
+		)
+		(pin "2"
+			(uuid "5819d818-f70c-4408-a320-e8fb0095cc5b")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "SW_2_8")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:D")
+		(at 393.7 101.6 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "1b8b40de-6792-4f7f-892b-b31f26445751")
+		(property "Reference" "D_5_15"
+			(at 386.08 101.6 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 395.732 102.743 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_SMD:D_1206_3216Metric"
+			(at 393.7 101.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 393.7 101.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Diode (Through-hole or 0805)"
+			(at 393.7 101.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" "C9808"
+			(at 393.7 101.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "66d94da5-8cd3-4675-b83b-b190cf2eb9ad")
+		)
+		(pin "2"
+			(uuid "800370b0-4ca9-4245-a2d0-af72177e05a1")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "D_5_15")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R_Small")
+		(at 236.22 138.43 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "1c3f027b-6f3b-4539-b23e-2d84fe0568ab")
+		(property "Reference" "R_1_8"
+			(at 238.76 137.1599 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "560R"
+			(at 238.76 139.6999 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0805_2012Metric"
+			(at 236.22 138.43 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 236.22 138.43 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Resistor, small symbol"
+			(at 236.22 138.43 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "2"
+			(uuid "e1dac38f-2191-4ca0-89d3-8cc2a7311cc4")
+		)
+		(pin "1"
+			(uuid "01aa0458-ec0d-48ac-946d-1172ea34c9c7")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "R_1_8")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:LED_Small")
+		(at 226.06 199.39 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "1c64ff17-b209-4def-9dad-68bcceda0c73")
+		(property "Reference" "L_5_7"
+			(at 228.6 198.0564 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "LED_Small"
+			(at 228.6 200.5964 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "LED_SMD:LED_0805_2012Metric_Pad1.15x1.40mm_HandSolder"
+			(at 226.06 199.39 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 226.06 199.39 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Light emitting diode, small symbol"
+			(at 226.06 199.39 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "72b29f6a-9888-400e-902d-a247c8190c93")
+		)
+		(pin "2"
+			(uuid "5cba04a4-5691-4d23-8694-2267148d3d11")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "L_5_7")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Mechanical:MountingHole")
+		(at 256.54 276.86 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "1c81f76a-f1c4-41fa-b3dd-bda378aef69f")
+		(property "Reference" "H3"
+			(at 259.08 275.6916 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "MountingHole"
+			(at 259.08 278.003 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "MountingHole:MountingHole_2.2mm_M2_DIN965"
+			(at 256.54 276.86 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 256.54 276.86 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 256.54 276.86 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(instances
+			(project "keyboard-ch552-48"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "H3")
+					(unit 1)
+				)
+			)
+			(project "PyKey40-HS"
+				(path "/6e68f0cd-800e-4167-9553-71fc59da1eeb"
+					(reference "H4")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:D")
+		(at 393.7 52.07 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "1d094f60-b14f-4115-8b81-1d22a581302a")
+		(property "Reference" "D_2_15"
+			(at 386.08 52.07 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 395.732 53.213 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_SMD:D_1206_3216Metric"
+			(at 393.7 52.07 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 393.7 52.07 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Diode (Through-hole or 0805)"
+			(at 393.7 52.07 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" "C9808"
+			(at 393.7 52.07 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "5e5b04b7-a0d8-497a-8805-2c28a75811f6")
+		)
+		(pin "2"
+			(uuid "bcb79e1c-62a3-48d4-8658-2bd893972881")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "D_2_15")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 66.04 133.35 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "1d545dec-ef09-4976-8a2a-98f7e9565b3a")
+		(property "Reference" "R2"
+			(at 68.58 132.0799 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "5.1k"
+			(at 68.58 134.6199 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0805_2012Metric"
+			(at 64.262 133.35 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 66.04 133.35 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 66.04 133.35 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" "C27834"
+			(at 66.04 133.35 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "44ff529c-597f-4e1c-9894-4e0f570d7769")
+		)
+		(pin "2"
+			(uuid "7b53be38-08bd-4d62-aaba-cc5027e538cd")
+		)
+		(instances
+			(project "keyboard-ch552-48"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "R2")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 190.5 64.77 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "1ed6581d-bd68-4a96-be09-58268a6a8e29")
+		(property "Reference" "SW_3_2"
+			(at 190.5 59.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "Redragon Low Profile switches"
+			(at 190.5 59.8424 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "ProjectLocal:SW_Redragon_LowProfile_PCB_1.00u"
+			(at 190.5 59.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 190.5 59.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Mechanical Keyboard Switch"
+			(at 190.5 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" ""
+			(at 190.5 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "b3b34834-5b0f-41c4-a6b2-92a852f8022c")
+		)
+		(pin "2"
+			(uuid "7090fcf4-b077-4a75-88ca-67201176964e")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "SW_3_2")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:LED_Small")
+		(at 297.18 143.51 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "1ee65d8c-9118-434c-ba82-a0dae241f6b8")
+		(property "Reference" "L_1_14"
+			(at 299.72 142.1764 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "LED_Small"
+			(at 299.72 144.7164 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "LED_SMD:LED_0805_2012Metric_Pad1.15x1.40mm_HandSolder"
+			(at 297.18 143.51 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 297.18 143.51 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Light emitting diode, small symbol"
+			(at 297.18 143.51 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "a9d32416-bd7d-4667-8db6-aa391910942c")
+		)
+		(pin "2"
+			(uuid "0da404ff-d598-4ea4-a56a-782e6d7856ca")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "L_1_14")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Mechanical:MountingHole")
+		(at 256.54 271.78 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "1f2aa985-9927-41c1-aecb-10d2f484145b")
+		(property "Reference" "H2"
+			(at 259.08 270.6116 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "MountingHole"
+			(at 259.08 272.923 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "MountingHole:MountingHole_2.2mm_M2_DIN965"
+			(at 256.54 271.78 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 256.54 271.78 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 256.54 271.78 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(instances
+			(project "keyboard-ch552-48"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "H2")
+					(unit 1)
+				)
+			)
+			(project "PyKey40-HS"
+				(path "/6e68f0cd-800e-4167-9553-71fc59da1eeb"
+					(reference "H1")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R_Small")
+		(at 266.7 194.31 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "2159b063-a99b-44a4-8de7-2817c36f9c78")
+		(property "Reference" "R_5_11"
+			(at 269.24 193.0399 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "560R"
+			(at 269.24 195.5799 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0805_2012Metric"
+			(at 266.7 194.31 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 266.7 194.31 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Resistor, small symbol"
+			(at 266.7 194.31 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "2"
+			(uuid "7c309ab8-779e-46cd-8f51-f6de06da48bc")
+		)
+		(pin "1"
+			(uuid "d9e6a71e-4da5-487a-86e4-abe870f4c5e6")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "R_5_11")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 327.66 48.26 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "21715a05-7513-4218-af6e-aafbb3966416")
+		(property "Reference" "SW_2_11"
+			(at 327.66 43.18 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "Redragon Low Profile switches"
+			(at 327.66 43.3324 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "ProjectLocal:SW_Redragon_LowProfile_PCB_1.00u"
+			(at 327.66 43.18 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 327.66 43.18 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Mechanical Keyboard Switch"
+			(at 327.66 48.26 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" ""
+			(at 327.66 48.26 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "8c56dbc7-1b6f-4c58-ab8d-80a3921943d0")
+		)
+		(pin "2"
+			(uuid "3e934521-a776-48e4-ba4b-f47be371aa93")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "SW_2_11")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:LED_Small")
+		(at 205.74 185.42 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "24988355-d3bd-41e8-9af3-95f79d807d17")
+		(property "Reference" "L_4_5"
+			(at 208.28 184.0864 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "LED_Small"
+			(at 208.28 186.6264 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "LED_SMD:LED_0805_2012Metric_Pad1.15x1.40mm_HandSolder"
+			(at 205.74 185.42 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 205.74 185.42 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Light emitting diode, small symbol"
+			(at 205.74 185.42 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "dc55476e-9d46-4a09-b666-5fa3ad5847fa")
+		)
+		(pin "2"
+			(uuid "cab9834a-173a-4080-92bb-e803fe51f169")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "L_4_5")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 342.9 64.77 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "273a8165-e983-4014-ae9c-76963b8dc4db")
+		(property "Reference" "SW_3_12"
+			(at 342.9 59.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "Redragon Low Profile switches"
+			(at 342.9 59.8424 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "ProjectLocal:SW_Redragon_LowProfile_PCB_1.00u"
+			(at 342.9 59.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 342.9 59.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Mechanical Keyboard Switch"
+			(at 342.9 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" ""
+			(at 342.9 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "ad24bd49-0ae5-48fb-ba37-1b3f26d7f41d")
+		)
+		(pin "2"
+			(uuid "ef1acdf4-bc16-468f-a7fd-924fcdefda87")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "SW_3_12")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:D")
+		(at 287.02 101.6 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "27fd3d34-4275-4dc5-9f00-869f92c0ba0a")
+		(property "Reference" "D_5_8"
+			(at 279.4 101.6 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 289.052 102.743 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_SMD:D_1206_3216Metric"
+			(at 287.02 101.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 287.02 101.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Diode (Through-hole or 0805)"
+			(at 287.02 101.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" "C9808"
+			(at 287.02 101.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "6677bccc-7189-4803-8b1b-966d43c6291e")
+		)
+		(pin "2"
+			(uuid "576a95b3-67fd-4eb6-820a-8b245a9ce657")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "D_5_8")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 190.5 48.26 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "2878beb0-f583-4e47-b681-1440a0558b2d")
+		(property "Reference" "SW_2_2"
+			(at 190.5 43.18 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "Redragon Low Profile switches"
+			(at 190.5 43.3324 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "ProjectLocal:SW_Redragon_LowProfile_PCB_1.00u"
+			(at 190.5 43.18 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 190.5 43.18 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Mechanical Keyboard Switch"
+			(at 190.5 48.26 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" ""
+			(at 190.5 48.26 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "7e1177af-93d1-4630-ad3b-85bd3d0a2565")
+		)
+		(pin "2"
+			(uuid "c49608a2-21dc-4d3f-be15-c3afa14a231b")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "SW_2_2")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 251.46 64.77 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "2b853d77-1a13-422a-aec0-40525d7c75ce")
+		(property "Reference" "SW_3_6"
+			(at 251.46 59.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "Redragon Low Profile switches"
+			(at 251.46 59.8424 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "ProjectLocal:SW_Redragon_LowProfile_PCB_1.00u"
+			(at 251.46 59.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 251.46 59.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Mechanical Keyboard Switch"
+			(at 251.46 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" ""
+			(at 251.46 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "6b44e883-aa27-45c3-b807-1b2d5127e835")
+		)
+		(pin "2"
+			(uuid "6670cec8-29e4-4d8c-86aa-5f1e09a05777")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "SW_3_6")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:D")
+		(at 195.58 85.09 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "2be223a2-56dc-490f-bd79-f83c6e456783")
+		(property "Reference" "D_4_2"
+			(at 187.96 85.09 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 197.612 86.233 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_SMD:D_1206_3216Metric"
+			(at 195.58 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 195.58 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Diode (Through-hole or 0805)"
+			(at 195.58 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" "C9808"
+			(at 195.58 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "8f8c2ab2-5b39-4df5-aa5b-6360fce84f5f")
+		)
+		(pin "2"
+			(uuid "f0aec9c1-1d4d-4462-aeda-5b5317b899bb")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "D_4_2")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:LED_Small")
+		(at 195.58 171.45 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "2bf1db7e-388b-48f4-8d0e-2d67445120d6")
+		(property "Reference" "L_3_4"
+			(at 198.12 170.1164 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "LED_Small"
+			(at 198.12 172.6564 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "LED_SMD:LED_0805_2012Metric_Pad1.15x1.40mm_HandSolder"
+			(at 195.58 171.45 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 195.58 171.45 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Light emitting diode, small symbol"
+			(at 195.58 171.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "c10c5186-f3a9-46ac-b63e-986b979af6ff")
+		)
+		(pin "2"
+			(uuid "31607086-0b5f-457e-a29b-d788438588dc")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "L_3_4")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 190.5 31.75 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "2d87c009-d34a-4b32-b70e-f10900ec0f38")
+		(property "Reference" "SW_1_2"
+			(at 190.5 26.67 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "Redragon Low Profile switches"
+			(at 190.5 26.8224 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "ProjectLocal:SW_Redragon_LowProfile_PCB_1.00u"
+			(at 190.5 26.67 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 190.5 26.67 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Mechanical Keyboard Switch"
+			(at 190.5 31.75 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" ""
+			(at 190.5 31.75 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "6abb602e-b013-44b5-bb27-7681aae5c513")
+		)
+		(pin "2"
+			(uuid "525619b7-ee04-4d77-944c-1984a785d2ef")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "SW_1_2")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:LED_Small")
+		(at 287.02 157.48 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "2edc0d53-2a1b-4725-b970-da5caf41668e")
+		(property "Reference" "L_2_13"
+			(at 289.56 156.1464 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "LED_Small"
+			(at 289.56 158.6864 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "LED_SMD:LED_0805_2012Metric_Pad1.15x1.40mm_HandSolder"
+			(at 287.02 157.48 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 287.02 157.48 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Light emitting diode, small symbol"
+			(at 287.02 157.48 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "8ea0317d-e567-4066-84a1-4ad4213a8313")
+		)
+		(pin "2"
+			(uuid "e92347de-eca9-4208-8132-70dd9f2280e1")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "L_2_13")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R_Small")
+		(at 307.34 166.37 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "2f6d79be-4306-49ba-bdb0-a570fddb0dea")
+		(property "Reference" "R_3_15"
+			(at 309.88 165.0999 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "560R"
+			(at 309.88 167.6399 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0805_2012Metric"
+			(at 307.34 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 307.34 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Resistor, small symbol"
+			(at 307.34 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "2"
+			(uuid "a65661fe-63cb-4326-8fb4-9f207c64085f")
+		)
+		(pin "1"
+			(uuid "6aed1c8e-8c5d-4181-8d2b-f1eee5626868")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "R_3_15")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:D")
+		(at 302.26 35.56 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "301b08b8-e8d1-40eb-bfb8-d3773b06550a")
+		(property "Reference" "D_1_9"
+			(at 294.64 35.56 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 304.292 36.703 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_SMD:D_1206_3216Metric"
+			(at 302.26 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 302.26 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Diode (Through-hole or 0805)"
+			(at 302.26 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" "C9808"
+			(at 302.26 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "afe89c47-aa53-47b2-9d19-623f1765657f")
+		)
+		(pin "2"
+			(uuid "d6fbf883-888e-453f-91d0-159bd7409835")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "D_1_9")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:D")
+		(at 210.82 52.07 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "301f866a-c8b9-4a7e-a68d-582646bf54e2")
+		(property "Reference" "D_2_3"
+			(at 203.2 52.07 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 212.852 53.213 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_SMD:D_1206_3216Metric"
+			(at 210.82 52.07 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 210.82 52.07 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Diode (Through-hole or 0805)"
+			(at 210.82 52.07 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" "C9808"
+			(at 210.82 52.07 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "f0007cee-1cab-4b8f-89e7-9b3b09ec458a")
+		)
+		(pin "2"
+			(uuid "e7da4912-867c-4243-8afc-afb22bd8b583")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "D_2_3")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:LED_Small")
+		(at 266.7 199.39 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "304d017c-801f-4676-9ee8-f2f3a1dba2bb")
+		(property "Reference" "L_5_11"
+			(at 269.24 198.0564 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "LED_Small"
+			(at 269.24 200.5964 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "LED_SMD:LED_0805_2012Metric_Pad1.15x1.40mm_HandSolder"
+			(at 266.7 199.39 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 266.7 199.39 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Light emitting diode, small symbol"
+			(at 266.7 199.39 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "ef55f548-f2a3-4d7f-8f51-34bd852ed1dc")
+		)
+		(pin "2"
+			(uuid "a3edd78b-9eb5-47a5-9f25-fc31e58cd7ea")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "L_5_11")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R_Small")
+		(at 287.02 180.34 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "3089b0d3-3651-4707-9e1c-c041717f36fd")
+		(property "Reference" "R_4_13"
+			(at 289.56 179.0699 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "560R"
+			(at 289.56 181.6099 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0805_2012Metric"
+			(at 287.02 180.34 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 287.02 180.34 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Resistor, small symbol"
+			(at 287.02 180.34 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "2"
+			(uuid "bec7bcf6-8e3f-4f5f-857b-587413462caa")
+		)
+		(pin "1"
+			(uuid "d5edb7b1-2c9e-4f18-a348-06242486c166")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "R_4_13")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R_Small")
+		(at 246.38 194.31 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "346adc10-8c5f-47fb-9aa9-d5509f4bae22")
+		(property "Reference" "R_5_9"
+			(at 248.92 193.0399 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "560R"
+			(at 248.92 195.5799 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0805_2012Metric"
+			(at 246.38 194.31 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 246.38 194.31 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Resistor, small symbol"
+			(at 246.38 194.31 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "2"
+			(uuid "5a58c14f-6fca-4426-899e-97b2aea14bb6")
+		)
+		(pin "1"
+			(uuid "4e579669-7800-4f1d-84a4-5508697a26a1")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "R_5_9")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Power_Protection:USBLC6-2SC6")
+		(at 52.07 137.16 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "34e65d6c-caf6-47ac-b18f-85e5e4ed4a72")
+		(property "Reference" "U2"
+			(at 53.594 144.018 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "USBLC6-2SC6"
+			(at 53.594 146.05 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Package_TO_SOT_SMD:SOT-23-6"
+			(at 53.34 143.51 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+					(italic yes)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://www.st.com/resource/en/datasheet/usblc6-2.pdf"
+			(at 53.34 145.415 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+		(property "Description" "Very low capacitance ESD protection diode, 2 data-line, SOT-23-6"
+			(at 52.07 137.16 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "5"
+			(uuid "85a29252-141e-4712-9528-170a7735b1a6")
+		)
+		(pin "1"
+			(uuid "9c36a07d-a51b-4160-a1fd-088bbf6b0b52")
+		)
+		(pin "4"
+			(uuid "a13fa62d-fd47-407c-9945-5c1feb1e67ba")
+		)
+		(pin "3"
+			(uuid "dce90f69-267e-4f92-9e43-f7fe38026d97")
+		)
+		(pin "6"
+			(uuid "99ec15d0-7a31-4166-b526-e8ca9b46308b")
+		)
+		(pin "2"
+			(uuid "8635e8af-9e45-47d0-8ecd-8a31a4000072")
+		)
+		(instances
+			(project ""
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "U2")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:LED_Small")
+		(at 195.58 143.51 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "35243816-5367-4ba4-9c3b-060756b42513")
+		(property "Reference" "L_1_4"
+			(at 198.12 142.1764 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "LED_Small"
+			(at 198.12 144.7164 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "LED_SMD:LED_0805_2012Metric_Pad1.15x1.40mm_HandSolder"
+			(at 195.58 143.51 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 195.58 143.51 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Light emitting diode, small symbol"
+			(at 195.58 143.51 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "3b1d1891-1880-4534-b6fc-ab11f30df9f1")
+		)
+		(pin "2"
+			(uuid "6f540132-6622-4eae-87ce-d4f9f8514bc6")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "L_1_4")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 281.94 81.28 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "3538c321-a5a0-4b90-a2c9-7345a41eb389")
+		(property "Reference" "SW_4_8"
+			(at 281.94 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "Redragon Low Profile switches"
+			(at 281.94 76.3524 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "ProjectLocal:SW_Redragon_LowProfile_PCB_1.00u"
+			(at 281.94 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 281.94 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Mechanical Keyboard Switch"
+			(at 281.94 81.28 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" ""
+			(at 281.94 81.28 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "8a563429-a891-43d2-ad5a-fec9839a7ec4")
+		)
+		(pin "2"
+			(uuid "ffb11d1a-0c42-426e-92b9-379f2bffc03d")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "SW_4_8")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R_Small")
+		(at 226.06 138.43 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "35868ba4-0594-4fb0-8a1f-09699409624e")
+		(property "Reference" "R_1_7"
+			(at 228.6 137.1599 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "560R"
+			(at 228.6 139.6999 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0805_2012Metric"
+			(at 226.06 138.43 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 226.06 138.43 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Resistor, small symbol"
+			(at 226.06 138.43 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "2"
+			(uuid "6a5545ef-e2ec-4c93-aed6-40124b051233")
+		)
+		(pin "1"
+			(uuid "123806a6-64c4-40d9-b2d4-7fcae4270b37")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "R_1_7")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:LED_Small")
+		(at 185.42 157.48 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "361205d1-009b-40f9-a375-59bec92ab8df")
+		(property "Reference" "L_2_3"
+			(at 187.96 156.1464 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "LED_Small"
+			(at 187.96 158.6864 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "LED_SMD:LED_0805_2012Metric_Pad1.15x1.40mm_HandSolder"
+			(at 185.42 157.48 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 185.42 157.48 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Light emitting diode, small symbol"
+			(at 185.42 157.48 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "919f9df8-62b3-4bc1-9817-4a2a3a21cbc1")
+		)
+		(pin "2"
+			(uuid "c474e9a5-7c14-4124-86fa-c5911360b0e6")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "L_2_3")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:LED_Small")
+		(at 165.1 185.42 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "36125e81-2886-410e-9fef-6d3a9d9bdfb4")
+		(property "Reference" "L_4_1"
+			(at 167.64 184.0864 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "LED_Small"
+			(at 167.64 186.6264 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "LED_SMD:LED_0805_2012Metric_Pad1.15x1.40mm_HandSolder"
+			(at 165.1 185.42 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 165.1 185.42 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Light emitting diode, small symbol"
+			(at 165.1 185.42 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "643011fd-101e-49fe-a124-7e7a027b7801")
+		)
+		(pin "2"
+			(uuid "d74b5446-7fe9-457b-b98a-3b4ed045198e")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "L_4_1")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:LED_Small")
+		(at 276.86 185.42 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "362613b5-6bf8-4822-9892-b03e25cd4c04")
+		(property "Reference" "L_4_12"
+			(at 279.4 184.0864 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "LED_Small"
+			(at 279.4 186.6264 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "LED_SMD:LED_0805_2012Metric_Pad1.15x1.40mm_HandSolder"
+			(at 276.86 185.42 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 276.86 185.42 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Light emitting diode, small symbol"
+			(at 276.86 185.42 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "4facd302-1505-48d8-a9cc-b384b0092946")
+		)
+		(pin "2"
+			(uuid "47ffe45d-701f-4ed5-83be-7126014c8037")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "L_4_12")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:LED_Small")
+		(at 185.42 185.42 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "38228d05-cff8-4c70-b5e2-f1a2993281df")
+		(property "Reference" "L_4_3"
+			(at 187.96 184.0864 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "LED_Small"
+			(at 187.96 186.6264 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "LED_SMD:LED_0805_2012Metric_Pad1.15x1.40mm_HandSolder"
+			(at 185.42 185.42 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 185.42 185.42 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Light emitting diode, small symbol"
+			(at 185.42 185.42 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "39be1f7b-929e-4e06-9e69-f179f291d2e8")
+		)
+		(pin "2"
+			(uuid "bb8262b9-c4bb-442c-9b83-bfb1190e534a")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "L_4_3")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:LED_Small")
+		(at 215.9 157.48 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "3968e0ef-c504-461f-b327-f7b531a96330")
+		(property "Reference" "L_2_6"
+			(at 218.44 156.1464 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "LED_Small"
+			(at 218.44 158.6864 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "LED_SMD:LED_0805_2012Metric_Pad1.15x1.40mm_HandSolder"
+			(at 215.9 157.48 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 215.9 157.48 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Light emitting diode, small symbol"
+			(at 215.9 157.48 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "dc3f2170-d776-48e3-858a-9707fa2fa106")
+		)
+		(pin "2"
+			(uuid "c35623d2-c861-492f-b664-6ae3021ad9d9")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "L_2_6")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:D")
+		(at 256.54 101.6 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "3c16c858-0e43-4182-a673-89a4d0ab29c3")
+		(property "Reference" "D_5_6"
+			(at 248.92 101.6 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 258.572 102.743 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_SMD:D_1206_3216Metric"
+			(at 256.54 101.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 256.54 101.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Diode (Through-hole or 0805)"
+			(at 256.54 101.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" "C9808"
+			(at 256.54 101.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "65c65cb9-29b9-47b7-ab26-88774547a0de")
+		)
+		(pin "2"
+			(uuid "2dfd1613-083e-49d4-b202-aea124c8c165")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "D_5_6")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:D")
+		(at 378.46 35.56 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "3c2bfed5-2073-4588-8bc3-fa6ca253e4b1")
+		(property "Reference" "D_1_14"
+			(at 370.84 35.56 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 380.492 36.703 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_SMD:D_1206_3216Metric"
+			(at 378.46 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 378.46 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Diode (Through-hole or 0805)"
+			(at 378.46 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" "C9808"
+			(at 378.46 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "63bd378b-80dd-4e0b-b8c0-108343f16665")
+		)
+		(pin "2"
+			(uuid "267688bf-5b33-4f48-9166-024a1e234a5a")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "D_1_14")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R_Small")
+		(at 195.58 138.43 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "3ceeb772-319c-47ed-8ced-49838aaba11b")
+		(property "Reference" "R_1_4"
+			(at 198.12 137.1599 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "560R"
+			(at 198.12 139.6999 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0805_2012Metric"
+			(at 195.58 138.43 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 195.58 138.43 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Resistor, small symbol"
+			(at 195.58 138.43 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "2"
+			(uuid "90684c5a-5fd7-4b68-ba5a-5a2ab3b94cc4")
+		)
+		(pin "1"
+			(uuid "e07e4d17-7257-419c-81fb-a2f7ab2b9bb7")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "R_1_4")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:D")
+		(at 302.26 101.6 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "3d3b24dc-8752-4786-aa90-7f00b5bf0020")
+		(property "Reference" "D_5_9"
+			(at 294.64 101.6 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 304.292 102.743 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_SMD:D_1206_3216Metric"
+			(at 302.26 101.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 302.26 101.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Diode (Through-hole or 0805)"
+			(at 302.26 101.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" "C9808"
+			(at 302.26 101.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "829235e7-6170-4c64-b225-9b3d1c910216")
+		)
+		(pin "2"
+			(uuid "10949815-e36d-47c0-b4d2-7a942dd5fa22")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "D_5_9")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:C")
+		(at 68.58 209.55 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "3e1e889a-d802-44c5-90dc-cf6ee1624952")
+		(property "Reference" "C1"
+			(at 72.39 208.28 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "100n"
+			(at 72.39 210.82 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Capacitor_SMD:C_0805_2012Metric"
+			(at 69.5452 213.36 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 68.58 209.55 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 68.58 209.55 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" "C28233"
+			(at 68.58 209.55 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "73003baa-a885-4c37-96d8-423ae452cd8a")
+		)
+		(pin "2"
+			(uuid "2a17b0ac-030c-4db1-a0a5-6954f8b6b18a")
+		)
+		(instances
+			(project "keyboard-ch552-48"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "C1")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 266.7 97.79 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "3eabb492-c494-4819-ac80-1fda67c81045")
+		(property "Reference" "SW_5_7"
+			(at 266.7 92.71 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "Redragon Low Profile switches"
+			(at 266.7 92.8624 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "ProjectLocal:SW_Redragon_LowProfile_PCB_1.00u"
+			(at 266.7 92.71 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 266.7 92.71 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Mechanical Keyboard Switch"
+			(at 266.7 97.79 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" ""
+			(at 266.7 97.79 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "8e540fcc-aa75-4989-8a83-ad1996b7e309")
+		)
+		(pin "2"
+			(uuid "d654d5d9-bb17-4b42-87e7-83307ad709c2")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "SW_5_7")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 175.26 97.79 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "3fa0114f-a427-47a5-b1c0-b063f128581d")
+		(property "Reference" "SW_5_1"
+			(at 175.26 92.71 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "Redragon Low Profile switches"
+			(at 175.26 92.8624 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "ProjectLocal:SW_Redragon_LowProfile_PCB_1.00u"
+			(at 175.26 92.71 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 175.26 92.71 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Mechanical Keyboard Switch"
+			(at 175.26 97.79 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" ""
+			(at 175.26 97.79 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "fea03907-2bce-446c-a27c-e2c5da6fe09b")
+		)
+		(pin "2"
+			(uuid "bb1bd960-8790-45dc-9ac1-3f7604c65126")
+		)
+		(instances
+			(project "keyboard-ch552-48"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "SW_5_1")
+					(unit 1)
+				)
+			)
+			(project "PyKey40-HS"
+				(path "/6e68f0cd-800e-4167-9553-71fc59da1eeb"
+					(reference "SW_4_1")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 205.74 97.79 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "3fed495d-f4a8-4e4d-a2c7-b0ed4c50e848")
+		(property "Reference" "SW_5_3"
+			(at 205.74 92.71 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "Redragon Low Profile switches"
+			(at 205.74 92.8624 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "ProjectLocal:SW_Redragon_LowProfile_PCB_1.00u"
+			(at 205.74 92.71 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 205.74 92.71 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Mechanical Keyboard Switch"
+			(at 205.74 97.79 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" ""
+			(at 205.74 97.79 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "5d781bf8-9a30-40eb-935d-ce51198459ee")
+		)
+		(pin "2"
+			(uuid "55cda8af-b82b-4769-a31b-db8e5a0488d8")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "SW_5_3")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:D")
+		(at 347.98 85.09 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "403f315f-9ea8-473d-b74b-9be094091075")
+		(property "Reference" "D_4_12"
+			(at 340.36 85.09 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 350.012 86.233 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_SMD:D_1206_3216Metric"
+			(at 347.98 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 347.98 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Diode (Through-hole or 0805)"
+			(at 347.98 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" "C9808"
+			(at 347.98 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "32203df8-d6e7-4ed1-bd0f-a7a7926b7a5d")
+		)
+		(pin "2"
+			(uuid "eff9fdde-91e2-484a-9fbd-edeb4cab217d")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "D_4_12")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R_Small")
+		(at 246.38 166.37 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "40846c14-b202-41af-ba75-89f359f6ffef")
+		(property "Reference" "R_3_9"
+			(at 248.92 165.0999 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "560R"
+			(at 248.92 167.6399 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0805_2012Metric"
+			(at 246.38 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 246.38 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Resistor, small symbol"
+			(at 246.38 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "2"
+			(uuid "1f86b376-7358-4082-8515-194deba0851a")
+		)
+		(pin "1"
+			(uuid "88d9ee34-53e4-4f0e-be92-fc8daf2950f6")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "R_3_9")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:D")
+		(at 287.02 68.58 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "40887cc4-1367-4d07-b3a4-10962e0312ab")
+		(property "Reference" "D_3_8"
+			(at 279.4 68.58 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 289.052 69.723 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_SMD:D_1206_3216Metric"
+			(at 287.02 68.58 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 287.02 68.58 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Diode (Through-hole or 0805)"
+			(at 287.02 68.58 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" "C9808"
+			(at 287.02 68.58 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "d3bba820-1377-48ab-aec4-6cf60597abbf")
+		)
+		(pin "2"
+			(uuid "b655d82f-b830-49e0-afc0-ca0bd1b308c8")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "D_3_8")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R_Small")
+		(at 236.22 166.37 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "41d1231e-f12a-4202-b72b-f0bad6a644cb")
+		(property "Reference" "R_3_8"
+			(at 238.76 165.0999 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "560R"
+			(at 238.76 167.6399 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0805_2012Metric"
+			(at 236.22 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 236.22 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Resistor, small symbol"
+			(at 236.22 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "2"
+			(uuid "1b3517aa-1127-4930-a674-e4c0ce1c77ae")
+		)
+		(pin "1"
+			(uuid "9b6f7cff-9647-49e7-a2c2-fae3ad5cb60a")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "R_3_8")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 190.5 97.79 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "438d3ad9-1d56-49f5-b4bc-1f09ce0bb107")
+		(property "Reference" "SW_5_2"
+			(at 190.5 92.71 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "Redragon Low Profile switches"
+			(at 190.5 92.8624 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "ProjectLocal:SW_Redragon_LowProfile_PCB_1.00u"
+			(at 190.5 92.71 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 190.5 92.71 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Mechanical Keyboard Switch"
+			(at 190.5 97.79 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" ""
+			(at 190.5 97.79 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "b6768370-29e5-4f89-8b99-d66a1089524b")
+		)
+		(pin "2"
+			(uuid "1af516e7-d201-42c5-9d5c-f0e8a87fd6bc")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "SW_5_2")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Connector:USB_C_Receptacle_USB2.0")
+		(at 27.94 137.16 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "43bddfb4-e0d4-4dcd-b7e2-422045c4c526")
+		(property "Reference" "J1"
+			(at 27.94 114.3 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "USB_C_Receptacle_USB2.0"
+			(at 27.94 116.84 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Connector_USB:USB_C_Receptacle_HRO_TYPE-C-31-M-12"
+			(at 31.75 137.16 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "https://www.usb.org/sites/default/files/documents/usb_type-c.zip"
+			(at 31.75 137.16 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 27.94 137.16 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" "C165948"
+			(at 27.94 137.16 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "A1"
+			(uuid "5bc16b1d-00d3-4a09-a235-1ee05eae3ecb")
+		)
+		(pin "A12"
+			(uuid "414f32ed-f77b-4398-8693-8b59c0161284")
+		)
+		(pin "A4"
+			(uuid "47538ba2-6409-43fe-b1b2-2597d5d9f20e")
+		)
+		(pin "A5"
+			(uuid "29cfe930-0c31-418b-a977-3eee750b0696")
+		)
+		(pin "A6"
+			(uuid "74e7fa8a-f1cc-48e7-ae80-776356d96e69")
+		)
+		(pin "A7"
+			(uuid "d09147aa-6729-4769-8fe2-4be16080dfa5")
+		)
+		(pin "A8"
+			(uuid "1926eb8b-2cfb-409c-9ef5-1148a81c9d0a")
+		)
+		(pin "A9"
+			(uuid "5f5393b0-cf84-4f3d-a368-0b0f58bc2b55")
+		)
+		(pin "B1"
+			(uuid "35657127-ec4c-4ce8-9ece-7460938edb2d")
+		)
+		(pin "B12"
+			(uuid "30c2a815-7893-4f25-bf7d-e73123fd6f67")
+		)
+		(pin "B4"
+			(uuid "61143c29-0573-4f47-957f-ea3cadd56cf7")
+		)
+		(pin "B5"
+			(uuid "73429646-a62a-425f-8b7b-ed6ad7c9a0a3")
+		)
+		(pin "B6"
+			(uuid "5f4928fe-93e9-44b2-9b58-1508ba31f460")
+		)
+		(pin "B7"
+			(uuid "fc2055ec-9d5f-4714-9bdb-73cbe9c4a48c")
+		)
+		(pin "B8"
+			(uuid "67c55eab-5a82-409d-aa2a-537e2b35da3f")
+		)
+		(pin "B9"
+			(uuid "1aa61101-c198-4d87-b04c-53e894df62d3")
+		)
+		(pin "S1"
+			(uuid "42c1b036-fb2a-411a-ad86-1064ecff241a")
+		)
+		(instances
+			(project "keyboard-ch552-48"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "J1")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:LED_Small")
+		(at 226.06 157.48 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "449bd284-4fa0-489e-8acd-61c35141663d")
+		(property "Reference" "L_2_7"
+			(at 228.6 156.1464 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "LED_Small"
+			(at 228.6 158.6864 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "LED_SMD:LED_0805_2012Metric_Pad1.15x1.40mm_HandSolder"
+			(at 226.06 157.48 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 226.06 157.48 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Light emitting diode, small symbol"
+			(at 226.06 157.48 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "22df8cf4-9eb8-4875-bbad-477802f3520e")
+		)
+		(pin "2"
+			(uuid "2e9ba6a9-b882-4c8b-be68-3389f2e9c875")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "L_2_7")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:LED_Small")
+		(at 246.38 199.39 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "44f472dd-cf99-4e3b-91c1-27240f11edd3")
+		(property "Reference" "L_5_9"
+			(at 248.92 198.0564 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "LED_Small"
+			(at 248.92 200.5964 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "LED_SMD:LED_0805_2012Metric_Pad1.15x1.40mm_HandSolder"
+			(at 246.38 199.39 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 246.38 199.39 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Light emitting diode, small symbol"
+			(at 246.38 199.39 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "54f0f225-07a3-4310-a4ed-7898ddb29c84")
+		)
+		(pin "2"
+			(uuid "10cde23b-73ec-4cfd-a0c8-d87bea1961ae")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "L_5_9")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:D")
+		(at 287.02 85.09 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "45f67ad6-eadc-4b7e-99ee-43dc7ebeb3d3")
+		(property "Reference" "D_4_8"
+			(at 279.4 85.09 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 289.052 86.233 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_SMD:D_1206_3216Metric"
+			(at 287.02 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 287.02 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Diode (Through-hole or 0805)"
+			(at 287.02 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" "C9808"
+			(at 287.02 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "1de95763-0d58-49b2-8f69-0a928c6de7cd")
+		)
+		(pin "2"
+			(uuid "d1a8313d-abd6-471f-b045-f6fd6b4677de")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "D_4_8")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 342.9 48.26 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "463f24fb-d30f-44ed-accf-df4dc64a9466")
+		(property "Reference" "SW_2_12"
+			(at 342.9 43.18 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "Redragon Low Profile switches"
+			(at 342.9 43.3324 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "ProjectLocal:SW_Redragon_LowProfile_PCB_1.00u"
+			(at 342.9 43.18 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 342.9 43.18 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Mechanical Keyboard Switch"
+			(at 342.9 48.26 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" ""
+			(at 342.9 48.26 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "5f7b780d-0c10-41dd-ab98-2904a4d3951c")
+		)
+		(pin "2"
+			(uuid "64205e82-058b-4c73-add0-176989a8a8d8")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "SW_2_12")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:LED_Small")
+		(at 256.54 157.48 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "46883c73-88ed-4e06-9631-7ad739ca9b3c")
+		(property "Reference" "L_2_10"
+			(at 259.08 156.1464 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "LED_Small"
+			(at 259.08 158.6864 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "LED_SMD:LED_0805_2012Metric_Pad1.15x1.40mm_HandSolder"
+			(at 256.54 157.48 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 256.54 157.48 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Light emitting diode, small symbol"
+			(at 256.54 157.48 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "c82b8096-d4cc-40ea-92f8-df70294b4b87")
+		)
+		(pin "2"
+			(uuid "6eb66901-f523-428f-a58c-e7fbfbe266e3")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "L_2_10")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_SPST")
+		(at 34.29 208.28 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "472f82c5-fe49-4683-b873-c14973f22ecb")
+		(property "Reference" "SW2"
+			(at 34.29 201.93 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "SW_SPST"
+			(at 34.29 204.47 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Connector_Wire:SolderWire-0.5sqmm_1x02_P4.6mm_D0.9mm_OD2.1mm"
+			(at 34.29 208.28 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 34.29 208.28 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 34.29 208.28 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "b3eb4dfe-d792-40cc-85f7-674274066fa5")
+		)
+		(pin "2"
+			(uuid "4fcde02f-c2d2-4c5e-b0a3-2c66f6531ee6")
+		)
+		(instances
+			(project "keyboard-ch552-48"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "SW2")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:LED_Small")
+		(at 175.26 185.42 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "4747826e-af89-44c5-b386-af5ca966f5b9")
+		(property "Reference" "L_4_2"
+			(at 177.8 184.0864 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "LED_Small"
+			(at 177.8 186.6264 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "LED_SMD:LED_0805_2012Metric_Pad1.15x1.40mm_HandSolder"
+			(at 175.26 185.42 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 175.26 185.42 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Light emitting diode, small symbol"
+			(at 175.26 185.42 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "1503f721-effd-41bf-a74c-e3b9bafb761b")
+		)
+		(pin "2"
+			(uuid "3a473d62-cf0f-4913-8cef-5a59f2bf31b9")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "L_4_2")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:LED_Small")
+		(at 256.54 185.42 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "47a79bb2-bb48-4c79-90de-e6e028e29653")
+		(property "Reference" "L_4_10"
+			(at 259.08 184.0864 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "LED_Small"
+			(at 259.08 186.6264 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "LED_SMD:LED_0805_2012Metric_Pad1.15x1.40mm_HandSolder"
+			(at 256.54 185.42 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 256.54 185.42 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Light emitting diode, small symbol"
+			(at 256.54 185.42 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "172f6711-b57b-4207-bf98-4231f3c5312b")
+		)
+		(pin "2"
+			(uuid "fed2d985-5a98-4011-9960-6095d41af0e0")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "L_4_10")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:LED_Small")
+		(at 236.22 143.51 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "4805a994-9433-47e3-b03a-d4915d2bd38c")
+		(property "Reference" "L_1_8"
+			(at 238.76 142.1764 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "LED_Small"
+			(at 238.76 144.7164 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "LED_SMD:LED_0805_2012Metric_Pad1.15x1.40mm_HandSolder"
+			(at 236.22 143.51 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 236.22 143.51 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Light emitting diode, small symbol"
+			(at 236.22 143.51 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "21bd22bf-d086-4a99-9509-b396ed5764cd")
+		)
+		(pin "2"
+			(uuid "eb2400ac-9cc7-4f88-88e5-43262e8afd6c")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "L_1_8")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R_Small")
+		(at 165.1 152.4 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "48e00785-efdb-4a8e-956b-5ae3dbd19e42")
+		(property "Reference" "R_2_1"
+			(at 167.64 151.1299 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "560R"
+			(at 167.64 153.6699 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0805_2012Metric"
+			(at 165.1 152.4 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 165.1 152.4 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Resistor, small symbol"
+			(at 165.1 152.4 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "2"
+			(uuid "91c49b07-f217-4264-b1e2-f0cab6495afd")
+		)
+		(pin "1"
+			(uuid "c281f5a9-2eec-4f90-99e5-3095403a80d8")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "R_2_1")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "ProjectLocal:CH32X035C8T6")
+		(at 49.53 59.69 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "48e4503b-d9f9-475d-9bec-577319b3a8c6")
+		(property "Reference" "U1"
+			(at 51.7241 24.13 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "CH32X035C8T6"
+			(at 51.7241 26.67 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Package_QFP:LQFP-48_7x7mm_P0.5mm"
+			(at 62.23 22.86 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 2.54 72.39 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "CH32X035C8T6"
+			(at 48.768 37.084 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "22"
+			(uuid "13c1d000-0260-4861-ab32-420d2162766f")
+		)
+		(pin "43"
+			(uuid "69e4e98b-d914-4978-957c-3a0bc3bd3ecc")
+		)
+		(pin "38"
+			(uuid "a34fbd10-e055-4991-8e09-666a43c08daf")
+		)
+		(pin "44"
+			(uuid "458cbcc4-76b0-4755-aeea-cdabb02dafce")
+		)
+		(pin "26"
+			(uuid "52668ff9-e1ea-4341-9863-451a7273568a")
+		)
+		(pin "13"
+			(uuid "64b4f264-f71d-4328-9950-84006a7ff06b")
+			(alternate "RX2")
+		)
+		(pin "34"
+			(uuid "27bff200-33ac-4b35-8725-31592b685b7c")
+			(alternate "DIO")
+		)
+		(pin "33"
+			(uuid "b47192cf-98b9-40b7-a070-59f7fcda30d7")
+			(alternate "UDP")
+		)
+		(pin "45"
+			(uuid "377d4305-5029-4556-878e-a8ce1b74e4ef")
+		)
+		(pin "32"
+			(uuid "d0da7038-a4f8-48b3-8fd2-6361f2e0df5e")
+			(alternate "UDM")
+		)
+		(pin "14"
+			(uuid "01af670c-2d17-4cd7-83ae-4f85aa07d37a")
+		)
+		(pin "48"
+			(uuid "8a55305f-cd1b-4921-9cac-302184ad3e0e")
+		)
+		(pin "5"
+			(uuid "c79cdc34-6ffa-4e64-aaa5-b6fcc466523e")
+		)
+		(pin "15"
+			(uuid "1eafea9d-4176-4955-befc-579108199dab")
+		)
+		(pin "40"
+			(uuid "a7fa0a5f-6b4d-4936-90a3-6b6b3fb15b82")
+		)
+		(pin "39"
+			(uuid "a826036b-160c-4973-b9fa-bd17e35bd4fb")
+		)
+		(pin "4"
+			(uuid "b8d42e24-16be-4ac5-a00d-9a192b6eb5ff")
+		)
+		(pin "37"
+			(uuid "de0018ba-92c0-456d-a58f-2f497d0b0dc0")
+			(alternate "DCK")
+		)
+		(pin "11"
+			(uuid "c407249a-d87d-4dee-84e6-51d7dc503de6")
+		)
+		(pin "10"
+			(uuid "f1891eea-6937-43a4-b5a4-a7718d0a023f")
+		)
+		(pin "46"
+			(uuid "b0ccafb9-a0d6-4e38-9573-c826c5abe346")
+		)
+		(pin "47"
+			(uuid "c145db4e-e9c0-4ea7-9655-4240520c328c")
+		)
+		(pin "36"
+			(uuid "6ae652b0-897e-46e0-870c-cf049b841bc3")
+		)
+		(pin "42"
+			(uuid "351826ea-dd0d-44a7-870e-46e1b364c7a4")
+		)
+		(pin "12"
+			(uuid "85eda571-ba29-42b9-b7ed-3ebc0cf93988")
+			(alternate "TX2")
+		)
+		(pin "6"
+			(uuid "9b081d0c-d74e-4453-8d9c-69e64c5d3c7a")
+		)
+		(pin "7"
+			(uuid "faad7142-3101-4ccb-9f4f-851735b666c6")
+			(alternate "RST")
+		)
+		(pin "16"
+			(uuid "cc926847-cfea-4ec4-9961-2e17218c3a5c")
+		)
+		(pin "25"
+			(uuid "69ee9597-d7a8-41a4-b2e7-d602bbb2bf6f")
+		)
+		(pin "31"
+			(uuid "87011aea-ab98-49b1-aed5-a36accf438c5")
+		)
+		(pin "3"
+			(uuid "4f3491a3-157a-44c4-821d-8d2a5d596a11")
+		)
+		(pin "19"
+			(uuid "a67d0e88-d585-4fea-b2fc-549894b5a350")
+		)
+		(pin "29"
+			(uuid "bb6bb162-258e-4c21-9c81-b41592bdb375")
+		)
+		(pin "1"
+			(uuid "ca89eab4-7a9c-4094-9d2c-b0ac68cafd35")
+		)
+		(pin "24"
+			(uuid "0cf4d069-b59e-4e71-84ca-e4919020910e")
+		)
+		(pin "28"
+			(uuid "e11ea3a6-f661-4a5e-becd-d13c96724774")
+		)
+		(pin "30"
+			(uuid "1c0754b6-6344-4aca-b99d-55d5e677d94b")
+		)
+		(pin "17"
+			(uuid "b99efb05-5ad8-42d2-9f40-700cc202ccc0")
+		)
+		(pin "23"
+			(uuid "9e7be0d5-353c-4db8-a9ea-998afb9aa96b")
+		)
+		(pin "41"
+			(uuid "a4214275-98a5-4a5a-bd5d-85a55f449bf2")
+		)
+		(pin "18"
+			(uuid "edcc48fa-beed-4b77-beb6-6034f0a42262")
+		)
+		(pin "8"
+			(uuid "772f265a-8174-4f56-ae60-2504ba6cc264")
+		)
+		(pin "9"
+			(uuid "c1b5a5ed-7dc3-4ee2-912e-6b668a5392b0")
+		)
+		(pin "2"
+			(uuid "1f8bf83e-8dd0-426c-b6f2-01e1af2e959b")
+		)
+		(pin "27"
+			(uuid "464a9a8d-b919-47c5-85dd-17fe5431d647")
+		)
+		(pin "21"
+			(uuid "65428c66-140a-444f-82a5-68faf7b6780d")
+		)
+		(pin "20"
+			(uuid "e29c1b60-583f-4c7f-8a05-825d0cf0c44a")
+		)
+		(pin "35"
+			(uuid "37d7ea20-1591-43bc-9b0c-810c5f8287f2")
+		)
+		(instances
+			(project ""
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "U1")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:D")
+		(at 271.78 35.56 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "48e7667e-3aa9-49e0-85e9-693c4b06178c")
+		(property "Reference" "D_1_7"
+			(at 264.16 35.56 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 273.812 36.703 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_SMD:D_1206_3216Metric"
+			(at 271.78 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 271.78 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Diode (Through-hole or 0805)"
+			(at 271.78 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" "C9808"
+			(at 271.78 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "04abeb06-afef-4df5-a3a5-02d368a4fc6a")
+		)
+		(pin "2"
+			(uuid "6963d469-083b-4aba-bbf1-d07dd5845989")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "D_1_7")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:LED_Small")
+		(at 226.06 171.45 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "48f5ba5c-cd4c-4693-bd62-8bcb1e6800f9")
+		(property "Reference" "L_3_7"
+			(at 228.6 170.1164 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "LED_Small"
+			(at 228.6 172.6564 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "LED_SMD:LED_0805_2012Metric_Pad1.15x1.40mm_HandSolder"
+			(at 226.06 171.45 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 226.06 171.45 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Light emitting diode, small symbol"
+			(at 226.06 171.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "ab2412da-a7b5-4cdb-a9ec-5c20977639aa")
+		)
+		(pin "2"
+			(uuid "c8e2c8ba-ecc2-4adf-b11c-a0849b489ca8")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "L_3_7")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R_Small")
+		(at 215.9 152.4 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "49627abe-c2e6-43a0-baf8-af576284c1db")
+		(property "Reference" "R_2_6"
+			(at 218.44 151.1299 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "560R"
+			(at 218.44 153.6699 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0805_2012Metric"
+			(at 215.9 152.4 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 215.9 152.4 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Resistor, small symbol"
+			(at 215.9 152.4 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "2"
+			(uuid "38ee09b0-a6f1-4005-b217-49446d372654")
+		)
+		(pin "1"
+			(uuid "2877afff-d2c3-4bd5-a1fe-e69a03bd8bea")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "R_2_6")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R_Small")
+		(at 266.7 138.43 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "4a8db99e-f71c-490c-901b-454bf7335afb")
+		(property "Reference" "R_1_11"
+			(at 269.24 137.1599 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "560R"
+			(at 269.24 139.6999 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0805_2012Metric"
+			(at 266.7 138.43 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 266.7 138.43 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Resistor, small symbol"
+			(at 266.7 138.43 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "2"
+			(uuid "ce1a33b4-5854-48a4-afcb-d315f9488776")
+		)
+		(pin "1"
+			(uuid "02c990fb-203c-4332-9662-11fbcc071f77")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "R_1_11")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R_Small")
+		(at 276.86 194.31 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "4b21f601-133c-446f-b86e-ab9e9d14fceb")
+		(property "Reference" "R_5_12"
+			(at 279.4 193.0399 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "560R"
+			(at 279.4 195.5799 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0805_2012Metric"
+			(at 276.86 194.31 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 276.86 194.31 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Resistor, small symbol"
+			(at 276.86 194.31 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "2"
+			(uuid "812cc098-4087-4d67-9873-7f4f7231e860")
+		)
+		(pin "1"
+			(uuid "828753ce-c2da-43ed-9b89-431e7f9dbc0b")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "R_5_12")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:C")
+		(at 45.72 177.8 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "4c68f5bf-7a1f-42f7-ab50-136262e609ed")
+		(property "Reference" "C2"
+			(at 49.53 176.53 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "100n"
+			(at 49.53 179.07 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Capacitor_SMD:C_0805_2012Metric"
+			(at 46.6852 181.61 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 45.72 177.8 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 45.72 177.8 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" "C28233"
+			(at 45.72 177.8 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "874ae894-1356-4095-844d-7056dbf87a85")
+		)
+		(pin "2"
+			(uuid "e7bfc115-c038-46e7-bcca-cc1ba02f80a9")
+		)
+		(instances
+			(project "keyboard-ch552-48"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "C2")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:LED_Small")
+		(at 266.7 157.48 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "4decc12d-52c0-4b77-a507-251e29827ab4")
+		(property "Reference" "L_2_11"
+			(at 269.24 156.1464 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "LED_Small"
+			(at 269.24 158.6864 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "LED_SMD:LED_0805_2012Metric_Pad1.15x1.40mm_HandSolder"
+			(at 266.7 157.48 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 266.7 157.48 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Light emitting diode, small symbol"
+			(at 266.7 157.48 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "583970d1-b3c4-49cc-b154-2d0745593ec9")
+		)
+		(pin "2"
+			(uuid "8fbc2219-f1fb-4d27-b76c-4f652f16ca88")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "L_2_11")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:LED_Small")
+		(at 246.38 171.45 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "4df074f0-b8e7-4fd1-9644-b28617b475d5")
+		(property "Reference" "L_3_9"
+			(at 248.92 170.1164 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "LED_Small"
+			(at 248.92 172.6564 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "LED_SMD:LED_0805_2012Metric_Pad1.15x1.40mm_HandSolder"
+			(at 246.38 171.45 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 246.38 171.45 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Light emitting diode, small symbol"
+			(at 246.38 171.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "2086ce1b-759b-4a92-9934-19929c58d9d2")
+		)
+		(pin "2"
+			(uuid "638ed3de-fc64-4105-b419-2a60f1684373")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "L_3_9")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 175.26 48.26 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "4e14770a-b2b2-4dd4-a9b9-4975270382b1")
+		(property "Reference" "SW_2_1"
+			(at 175.26 43.18 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "Redragon Low Profile switches"
+			(at 175.26 43.3324 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "ProjectLocal:SW_Redragon_LowProfile_PCB_1.00u"
+			(at 175.26 43.18 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 175.26 43.18 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Mechanical Keyboard Switch"
+			(at 175.26 48.26 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" ""
+			(at 175.26 48.26 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "0a584cba-aec5-4d69-8913-6605ee63cc38")
+		)
+		(pin "2"
+			(uuid "add6529e-e120-469e-bfb0-3b83f0ec14d4")
+		)
+		(instances
+			(project "keyboard-ch552-48"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "SW_2_1")
+					(unit 1)
+				)
+			)
+			(project "PyKey40-HS"
+				(path "/6e68f0cd-800e-4167-9553-71fc59da1eeb"
+					(reference "SW_2_1")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R_Small")
+		(at 165.1 166.37 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "50184eeb-1f2a-46cd-9e00-6bd9132e74d1")
+		(property "Reference" "R_3_1"
+			(at 167.64 165.0999 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "560R"
+			(at 167.64 167.6399 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0805_2012Metric"
+			(at 165.1 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 165.1 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Resistor, small symbol"
+			(at 165.1 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "2"
+			(uuid "0dbc4d30-5555-4403-a001-1baeb38df630")
+		)
+		(pin "1"
+			(uuid "7b220c97-8be2-4b04-b12b-f037668a470c")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "R_3_1")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 373.38 64.77 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "50ba4e4a-bbcb-4501-9b58-3f47339163c5")
+		(property "Reference" "SW_3_14"
+			(at 373.38 59.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "Redragon Low Profile switches"
+			(at 373.38 59.8424 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "ProjectLocal:SW_Redragon_LowProfile_PCB_1.00u"
+			(at 373.38 59.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 373.38 59.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Mechanical Keyboard Switch"
+			(at 373.38 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" ""
+			(at 373.38 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "1262c022-336e-4291-bd80-ec9395662134")
+		)
+		(pin "2"
+			(uuid "2655228f-008f-4974-8940-8c0adb621085")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "SW_3_14")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 373.38 81.28 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "5129f248-ba43-4ace-814a-1f972b8abe6c")
+		(property "Reference" "SW_4_14"
+			(at 373.38 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "Redragon Low Profile switches"
+			(at 373.38 76.3524 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "ProjectLocal:SW_Redragon_LowProfile_PCB_1.00u"
+			(at 373.38 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 373.38 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Mechanical Keyboard Switch"
+			(at 373.38 81.28 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" ""
+			(at 373.38 81.28 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "71e38d9e-5703-4c99-a7d3-aad40f757963")
+		)
+		(pin "2"
+			(uuid "95118446-d454-4549-9c52-b2fa6f9e47d9")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "SW_4_14")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:D")
+		(at 378.46 68.58 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "51e6dafd-942e-4092-946f-ded126e72465")
+		(property "Reference" "D_3_14"
+			(at 370.84 68.58 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 380.492 69.723 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_SMD:D_1206_3216Metric"
+			(at 378.46 68.58 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 378.46 68.58 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Diode (Through-hole or 0805)"
+			(at 378.46 68.58 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" "C9808"
+			(at 378.46 68.58 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "6cc7e9b7-aabd-44f5-ba8d-3e02bd55ca2a")
+		)
+		(pin "2"
+			(uuid "fdeb6102-b5f0-4b21-92c0-0a793e0b9d7c")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "D_3_14")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:D")
+		(at 363.22 85.09 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "54db9772-afb4-4843-ae24-90275a83bde3")
+		(property "Reference" "D_4_13"
+			(at 355.6 85.09 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 365.252 86.233 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_SMD:D_1206_3216Metric"
+			(at 363.22 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 363.22 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Diode (Through-hole or 0805)"
+			(at 363.22 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" "C9808"
+			(at 363.22 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "155ac470-0c1b-4381-a405-2a1226fdadbe")
+		)
+		(pin "2"
+			(uuid "d1474493-71d7-4f35-b65e-c8552ac6935c")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "D_4_13")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 297.18 97.79 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "567ed275-21c6-4ad4-93d2-0fe297f3919d")
+		(property "Reference" "SW_5_9"
+			(at 297.18 92.71 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "Redragon Low Profile switches"
+			(at 297.18 92.8624 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "ProjectLocal:SW_Redragon_LowProfile_PCB_1.00u"
+			(at 297.18 92.71 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 297.18 92.71 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Mechanical Keyboard Switch"
+			(at 297.18 97.79 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" ""
+			(at 297.18 97.79 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "f3a28d75-7bbb-48e5-b2da-3584d360a007")
+		)
+		(pin "2"
+			(uuid "7fcec46c-237d-4314-a0f8-879e71b5548b")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "SW_5_9")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:D")
+		(at 210.82 85.09 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "56cbb3b5-33dc-4143-a6db-7518344b6f20")
+		(property "Reference" "D_4_3"
+			(at 203.2 85.09 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 212.852 86.233 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_SMD:D_1206_3216Metric"
+			(at 210.82 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 210.82 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Diode (Through-hole or 0805)"
+			(at 210.82 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" "C9808"
+			(at 210.82 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "9c712618-936c-4875-9c3e-7a176b1f844b")
+		)
+		(pin "2"
+			(uuid "15f0dfcd-33a5-4154-bce1-e8c073ebebaf")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "D_4_3")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:D")
+		(at 317.5 101.6 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "57b68435-4061-4429-9a3f-67ab2009dcb6")
+		(property "Reference" "D_5_10"
+			(at 309.88 101.6 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 319.532 102.743 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_SMD:D_1206_3216Metric"
+			(at 317.5 101.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 317.5 101.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Diode (Through-hole or 0805)"
+			(at 317.5 101.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" "C9808"
+			(at 317.5 101.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "46333c17-53f1-4a23-8730-0c0fdc216af3")
+		)
+		(pin "2"
+			(uuid "4b045049-f9dd-469b-ab0b-1842d45874a9")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "D_5_10")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:D")
+		(at 226.06 101.6 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "585d846a-6614-43a7-820f-51184b0d8413")
+		(property "Reference" "D_5_4"
+			(at 218.44 101.6 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 228.092 102.743 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_SMD:D_1206_3216Metric"
+			(at 226.06 101.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 226.06 101.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Diode (Through-hole or 0805)"
+			(at 226.06 101.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" "C9808"
+			(at 226.06 101.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "9d9a30ef-1ac1-4d68-b020-b08a5cc55284")
+		)
+		(pin "2"
+			(uuid "6816621c-0754-4b95-9203-b32ff9807012")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "D_5_4")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R_Small")
+		(at 236.22 152.4 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "587ee083-a055-4f2d-a9d6-6bd6c6add7fb")
+		(property "Reference" "R_2_8"
+			(at 238.76 151.1299 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "560R"
+			(at 238.76 153.6699 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0805_2012Metric"
+			(at 236.22 152.4 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 236.22 152.4 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Resistor, small symbol"
+			(at 236.22 152.4 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "2"
+			(uuid "1146c0cd-3304-45f7-83fd-66a6ac817dd3")
+		)
+		(pin "1"
+			(uuid "ca29d2dc-cf09-45ef-806f-6556dd43bf01")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "R_2_8")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R_Small")
+		(at 185.42 180.34 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "59a9feff-acc0-4784-b733-5aea2a205f13")
+		(property "Reference" "R_4_3"
+			(at 187.96 179.0699 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "560R"
+			(at 187.96 181.6099 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0805_2012Metric"
+			(at 185.42 180.34 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 185.42 180.34 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Resistor, small symbol"
+			(at 185.42 180.34 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "2"
+			(uuid "9870d02e-c7e5-4621-b7df-f99f62e36a14")
+		)
+		(pin "1"
+			(uuid "f913913a-5f97-43a0-a3d6-319eb3c749f8")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "R_4_3")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R_Small")
+		(at 195.58 180.34 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "5afce7eb-d61e-4743-a3f8-8c2472dff858")
+		(property "Reference" "R_4_4"
+			(at 198.12 179.0699 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "560R"
+			(at 198.12 181.6099 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0805_2012Metric"
+			(at 195.58 180.34 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 195.58 180.34 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Resistor, small symbol"
+			(at 195.58 180.34 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "2"
+			(uuid "800218a9-c5eb-4194-8e58-df850dccf39d")
+		)
+		(pin "1"
+			(uuid "616b33ef-23ff-47f6-9836-e88883fd3d6a")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "R_4_4")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R_Small")
+		(at 287.02 166.37 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "5d63a101-e601-4660-94b8-4b0d8b67da01")
+		(property "Reference" "R_3_13"
+			(at 289.56 165.0999 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "560R"
+			(at 289.56 167.6399 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0805_2012Metric"
+			(at 287.02 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 287.02 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Resistor, small symbol"
+			(at 287.02 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "2"
+			(uuid "5f313730-b69f-47e6-93e5-b726f6f0ff55")
+		)
+		(pin "1"
+			(uuid "76b1cdd7-4827-4822-b9f3-502b699358f6")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "R_3_13")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R_Small")
+		(at 215.9 194.31 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "5da62a83-5941-4188-b67d-7f2a90c5d3b0")
+		(property "Reference" "R_5_6"
+			(at 218.44 193.0399 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "560R"
+			(at 218.44 195.5799 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0805_2012Metric"
+			(at 215.9 194.31 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 215.9 194.31 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Resistor, small symbol"
+			(at 215.9 194.31 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "2"
+			(uuid "066e571f-641d-4339-b97b-ac7d9d24411e")
+		)
+		(pin "1"
+			(uuid "d210e284-2fd8-4e6d-8c49-65ec1991aed9")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "R_5_6")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:D")
+		(at 195.58 35.56 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "5e97505e-853e-408d-941f-9ac510867a42")
+		(property "Reference" "D_1_2"
+			(at 187.96 35.56 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 197.612 36.703 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_SMD:D_1206_3216Metric"
+			(at 195.58 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 195.58 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Diode (Through-hole or 0805)"
+			(at 195.58 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" "C9808"
+			(at 195.58 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "ed84c109-d8cf-42c9-bab3-fb2da2cf6ac3")
+		)
+		(pin "2"
+			(uuid "c0e8d6d5-2ebe-4f63-a5a1-e40ef1eb7233")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "D_1_2")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R_Small")
+		(at 246.38 152.4 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "5efcda94-8067-43c2-967f-a8e04bf13be9")
+		(property "Reference" "R_2_9"
+			(at 248.92 151.1299 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "560R"
+			(at 248.92 153.6699 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0805_2012Metric"
+			(at 246.38 152.4 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 246.38 152.4 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Resistor, small symbol"
+			(at 246.38 152.4 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "2"
+			(uuid "a34f4931-bcb4-4875-9d3d-c576ca6a2191")
+		)
+		(pin "1"
+			(uuid "faa6b8e0-1c66-4c16-bb3c-1cf241c25b29")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "R_2_9")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:D")
+		(at 180.34 52.07 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "5f8d78ea-3aad-43bc-8757-957e8cbeaf90")
+		(property "Reference" "D_2_1"
+			(at 172.72 52.07 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 182.372 53.213 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_SMD:D_1206_3216Metric"
+			(at 180.34 52.07 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 180.34 52.07 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Diode (Through-hole or 0805)"
+			(at 180.34 52.07 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" "C9808"
+			(at 180.34 52.07 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "ca01dd04-3225-4dc6-9e79-b7c4f29e120c")
+		)
+		(pin "2"
+			(uuid "0f3e83b8-d229-42f2-a6c9-1369c2095260")
+		)
+		(instances
+			(project "keyboard-ch552-48"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "D_2_1")
+					(unit 1)
+				)
+			)
+			(project "PyKey40-HS"
+				(path "/6e68f0cd-800e-4167-9553-71fc59da1eeb"
+					(reference "D_2_1")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:LED_Small")
+		(at 195.58 157.48 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "5fd20daf-774d-433f-9d9c-416c0f312f08")
+		(property "Reference" "L_2_4"
+			(at 198.12 156.1464 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "LED_Small"
+			(at 198.12 158.6864 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "LED_SMD:LED_0805_2012Metric_Pad1.15x1.40mm_HandSolder"
+			(at 195.58 157.48 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 195.58 157.48 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Light emitting diode, small symbol"
+			(at 195.58 157.48 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "f82e96c6-3854-46fd-9079-96e512696cdd")
+		)
+		(pin "2"
+			(uuid "b42679e8-86a0-42e2-8bd0-ad3e278c9883")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "L_2_4")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R_Small")
+		(at 256.54 166.37 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "60cacb33-16b7-4ed4-806a-05f4c331ebdb")
+		(property "Reference" "R_3_10"
+			(at 259.08 165.0999 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "560R"
+			(at 259.08 167.6399 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0805_2012Metric"
+			(at 256.54 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 256.54 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Resistor, small symbol"
+			(at 256.54 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "2"
+			(uuid "9a29faed-fd6c-4955-a5b4-ebd3e7ec7b6b")
+		)
+		(pin "1"
+			(uuid "34368479-6186-4fe7-b92c-4a3929d90a95")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "R_3_10")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R_Small")
+		(at 297.18 180.34 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "61326942-2a73-4ea3-8693-727684253377")
+		(property "Reference" "R_4_14"
+			(at 299.72 179.0699 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "560R"
+			(at 299.72 181.6099 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0805_2012Metric"
+			(at 297.18 180.34 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 297.18 180.34 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Resistor, small symbol"
+			(at 297.18 180.34 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "2"
+			(uuid "3f9f6cd8-1096-4d7a-b186-9572289162ef")
+		)
+		(pin "1"
+			(uuid "5353339f-95b0-4a44-a42c-833c5c7f0f5c")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "R_4_14")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:LED_Small")
+		(at 297.18 199.39 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "62e50bb1-61a6-4770-8fea-ecbf9aab2f5b")
+		(property "Reference" "L_5_14"
+			(at 299.72 198.0564 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "LED_Small"
+			(at 299.72 200.5964 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "LED_SMD:LED_0805_2012Metric_Pad1.15x1.40mm_HandSolder"
+			(at 297.18 199.39 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 297.18 199.39 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Light emitting diode, small symbol"
+			(at 297.18 199.39 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "d1cad0f6-efc1-4e50-ab1d-c4d0b232c714")
+		)
+		(pin "2"
+			(uuid "43795289-9970-4b37-ad4a-ced06ae9a158")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "L_5_14")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:D")
+		(at 302.26 85.09 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "6418c169-36fa-422d-8579-733603892eea")
+		(property "Reference" "D_4_9"
+			(at 294.64 85.09 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 304.292 86.233 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_SMD:D_1206_3216Metric"
+			(at 302.26 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 302.26 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Diode (Through-hole or 0805)"
+			(at 302.26 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" "C9808"
+			(at 302.26 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "a1792fd9-71da-4dde-a14f-e87913dc3a9f")
+		)
+		(pin "2"
+			(uuid "cb43815a-3c41-44cb-bf15-87ed215f58d6")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "D_4_9")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:LED_Small")
+		(at 276.86 157.48 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "6474ab8b-d2cd-4673-a25a-c8e903f5d736")
+		(property "Reference" "L_2_12"
+			(at 279.4 156.1464 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "LED_Small"
+			(at 279.4 158.6864 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "LED_SMD:LED_0805_2012Metric_Pad1.15x1.40mm_HandSolder"
+			(at 276.86 157.48 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 276.86 157.48 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Light emitting diode, small symbol"
+			(at 276.86 157.48 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "6521c858-967c-4cc1-82cd-4712614ce48d")
+		)
+		(pin "2"
+			(uuid "c08b8464-4786-47d0-b2aa-aa744e514d75")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "L_2_12")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:LED_Small")
+		(at 165.1 171.45 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "6668b112-37ef-4642-b46e-55093f21cfe2")
+		(property "Reference" "L_3_1"
+			(at 167.64 170.1164 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "LED_Small"
+			(at 167.64 172.6564 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "LED_SMD:LED_0805_2012Metric_Pad1.15x1.40mm_HandSolder"
+			(at 165.1 171.45 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 165.1 171.45 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Light emitting diode, small symbol"
+			(at 165.1 171.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "a0049e00-e20d-4c43-9ba5-e3ad24b0afce")
+		)
+		(pin "2"
+			(uuid "4404080d-32ac-41f8-8f4b-e3acc943e556")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "L_3_1")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:D")
+		(at 363.22 52.07 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "669db84d-0c60-46d6-8cac-37f622a9ee8c")
+		(property "Reference" "D_2_13"
+			(at 355.6 52.07 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 365.252 53.213 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_SMD:D_1206_3216Metric"
+			(at 363.22 52.07 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 363.22 52.07 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Diode (Through-hole or 0805)"
+			(at 363.22 52.07 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" "C9808"
+			(at 363.22 52.07 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "6c08d68a-9797-4ab7-b0ef-1b7d4f2bc139")
+		)
+		(pin "2"
+			(uuid "6d6dc471-d7e4-43c5-8576-35d0c27401bf")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "D_2_13")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:D")
+		(at 317.5 35.56 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "67ea5a28-ceec-4279-83d0-f5eef116b45f")
+		(property "Reference" "D_1_10"
+			(at 309.88 35.56 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 319.532 36.703 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_SMD:D_1206_3216Metric"
+			(at 317.5 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 317.5 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Diode (Through-hole or 0805)"
+			(at 317.5 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" "C9808"
+			(at 317.5 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "1cda02a1-257d-474a-8259-6985b00cee6a")
+		)
+		(pin "2"
+			(uuid "bf89bb5d-e7d6-4ec0-a0ab-9dd42eb49398")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "D_1_10")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:D")
+		(at 271.78 68.58 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "69588f0a-81d6-4f7f-8127-c8890c49c30b")
+		(property "Reference" "D_3_7"
+			(at 264.16 68.58 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 273.812 69.723 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_SMD:D_1206_3216Metric"
+			(at 271.78 68.58 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 271.78 68.58 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Diode (Through-hole or 0805)"
+			(at 271.78 68.58 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" "C9808"
+			(at 271.78 68.58 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "07ef73f8-3924-4f09-8619-624d7a9f4232")
+		)
+		(pin "2"
+			(uuid "287eb57e-b8ab-4bad-9f03-a5dbf5fcee9c")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "D_3_7")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 327.66 97.79 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "6986ab0d-5bf0-4d1b-b67a-1985765b3ba2")
+		(property "Reference" "SW_5_11"
+			(at 327.66 92.71 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "Redragon Low Profile switches"
+			(at 327.66 92.8624 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "ProjectLocal:SW_Redragon_LowProfile_PCB_1.00u"
+			(at 327.66 92.71 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 327.66 92.71 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Mechanical Keyboard Switch"
+			(at 327.66 97.79 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" ""
+			(at 327.66 97.79 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "d0a21116-9aa1-4982-99ce-0c01faaef912")
+		)
+		(pin "2"
+			(uuid "73e81c8c-f393-4641-8ad9-4340fe5c8cdb")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "SW_5_11")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:LED_Small")
+		(at 307.34 157.48 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "6b0d4f73-f1ee-44bb-998a-7f5d0aff0563")
+		(property "Reference" "L_2_15"
+			(at 309.88 156.1464 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "LED_Small"
+			(at 309.88 158.6864 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "LED_SMD:LED_0805_2012Metric_Pad1.15x1.40mm_HandSolder"
+			(at 307.34 157.48 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 307.34 157.48 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Light emitting diode, small symbol"
+			(at 307.34 157.48 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "5f7d01ad-8601-4fb6-9ca5-f7b2ab8df9b3")
+		)
+		(pin "2"
+			(uuid "e4d23ebc-5fc4-417d-89a1-ea5fe73b8828")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "L_2_15")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:D")
+		(at 271.78 101.6 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "6b2387bc-7072-4a9c-b551-f82626e3c762")
+		(property "Reference" "D_5_7"
+			(at 264.16 101.6 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 273.812 102.743 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_SMD:D_1206_3216Metric"
+			(at 271.78 101.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 271.78 101.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Diode (Through-hole or 0805)"
+			(at 271.78 101.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" "C9808"
+			(at 271.78 101.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "225778a3-4888-4d79-843d-d06e591aeb77")
+		)
+		(pin "2"
+			(uuid "a3ff3844-e4ff-4f7f-9754-f9bd0cd27294")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "D_5_7")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 312.42 64.77 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "6b62b350-ba5e-441d-8e33-d644bd2a29e9")
+		(property "Reference" "SW_3_10"
+			(at 312.42 59.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "Redragon Low Profile switches"
+			(at 312.42 59.8424 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "ProjectLocal:SW_Redragon_LowProfile_PCB_1.00u"
+			(at 312.42 59.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 312.42 59.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Mechanical Keyboard Switch"
+			(at 312.42 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" ""
+			(at 312.42 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "d2db6b49-94e8-475f-82df-55f162e48157")
+		)
+		(pin "2"
+			(uuid "ea222fdb-9b4c-40f1-a4e5-09c03af688d2")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "SW_3_10")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:LED_Small")
+		(at 165.1 143.51 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "6c57b410-6b38-45f4-9834-cc34d9d9b388")
+		(property "Reference" "L_1_1"
+			(at 167.64 142.1764 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "LED_Small"
+			(at 167.64 144.7164 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "LED_SMD:LED_0805_2012Metric_Pad1.15x1.40mm_HandSolder"
+			(at 165.1 143.51 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 165.1 143.51 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Light emitting diode, small symbol"
+			(at 165.1 143.51 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "05c89cdd-4bb1-4907-9930-41ff6a8b727e")
+		)
+		(pin "2"
+			(uuid "b5b9675f-e815-4235-aa84-808b9cd15e12")
+		)
+		(instances
+			(project ""
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "L_1_1")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R_Small")
+		(at 226.06 194.31 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "6e0c4bcb-84fe-461c-b712-0171dfdfb679")
+		(property "Reference" "R_5_7"
+			(at 228.6 193.0399 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "560R"
+			(at 228.6 195.5799 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0805_2012Metric"
+			(at 226.06 194.31 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 226.06 194.31 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Resistor, small symbol"
+			(at 226.06 194.31 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "2"
+			(uuid "eb83c198-2795-4baf-b478-e78f5e132c95")
+		)
+		(pin "1"
+			(uuid "2d8eb192-32af-45bd-bf6f-466d40aecd81")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "R_5_7")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 327.66 31.75 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "6e8112e8-9649-45f5-9186-cb09db85d6d4")
+		(property "Reference" "SW_1_11"
+			(at 327.66 26.67 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "Redragon Low Profile switches"
+			(at 327.66 26.8224 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "ProjectLocal:SW_Redragon_LowProfile_PCB_1.00u"
+			(at 327.66 26.67 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 327.66 26.67 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Mechanical Keyboard Switch"
+			(at 327.66 31.75 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" ""
+			(at 327.66 31.75 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "07a005b1-0945-4c19-bb0b-d03a7f24c604")
+		)
+		(pin "2"
+			(uuid "c40fedd7-b7ab-4e26-b81f-55a2f7c9c429")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "SW_1_11")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:D")
+		(at 363.22 68.58 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "6ec521b1-282a-4ddd-b605-ba0b1302f3aa")
+		(property "Reference" "D_3_13"
+			(at 355.6 68.58 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 365.252 69.723 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_SMD:D_1206_3216Metric"
+			(at 363.22 68.58 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 363.22 68.58 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Diode (Through-hole or 0805)"
+			(at 363.22 68.58 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" "C9808"
+			(at 363.22 68.58 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "faf5f0a7-7856-414d-8e6f-3af85cccdd0d")
+		)
+		(pin "2"
+			(uuid "cfc2020e-bb36-45cb-ae70-e1cb450c1ff6")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "D_3_13")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:LED_Small")
+		(at 297.18 171.45 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "6ec85c7b-21c8-4ab9-9efb-a345e501972c")
+		(property "Reference" "L_3_14"
+			(at 299.72 170.1164 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "LED_Small"
+			(at 299.72 172.6564 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "LED_SMD:LED_0805_2012Metric_Pad1.15x1.40mm_HandSolder"
+			(at 297.18 171.45 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 297.18 171.45 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Light emitting diode, small symbol"
+			(at 297.18 171.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "0e40cb89-ede2-42f6-afaa-ba076d8eefa3")
+		)
+		(pin "2"
+			(uuid "d79df42f-fc0b-434b-9801-ef79230d1c25")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "L_3_14")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:LED_Small")
+		(at 276.86 171.45 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "6f60c457-acb8-47b0-b5a3-6cfff9a7b5ae")
+		(property "Reference" "L_3_12"
+			(at 279.4 170.1164 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "LED_Small"
+			(at 279.4 172.6564 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "LED_SMD:LED_0805_2012Metric_Pad1.15x1.40mm_HandSolder"
+			(at 276.86 171.45 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 276.86 171.45 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Light emitting diode, small symbol"
+			(at 276.86 171.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "0392508e-18b5-4aa3-b63c-240827ad6ef1")
+		)
+		(pin "2"
+			(uuid "4b946826-72f8-416a-a2d8-91bc495dd3ed")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "L_3_12")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:LED_Small")
+		(at 287.02 185.42 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "6fea13f5-eb09-4230-969d-94c9dd1edd6e")
+		(property "Reference" "L_4_13"
+			(at 289.56 184.0864 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "LED_Small"
+			(at 289.56 186.6264 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "LED_SMD:LED_0805_2012Metric_Pad1.15x1.40mm_HandSolder"
+			(at 287.02 185.42 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 287.02 185.42 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Light emitting diode, small symbol"
+			(at 287.02 185.42 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "1ee4be1d-c7e0-4a10-beb5-7a48a33eafe2")
+		)
+		(pin "2"
+			(uuid "40f4959a-5f4f-4a58-857c-23d621f50df2")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "L_4_13")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 266.7 31.75 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "704c2cec-3a27-48d1-966f-0780deb1d95a")
+		(property "Reference" "SW_1_7"
+			(at 266.7 26.67 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "Redragon Low Profile switches"
+			(at 266.7 26.8224 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "ProjectLocal:SW_Redragon_LowProfile_PCB_1.00u"
+			(at 266.7 26.67 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 266.7 26.67 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Mechanical Keyboard Switch"
+			(at 266.7 31.75 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" ""
+			(at 266.7 31.75 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "8535d3b5-7c7c-4100-8ee1-ae5ad52a5f6e")
+		)
+		(pin "2"
+			(uuid "c5fb0559-bb97-4ed1-bb56-184943741201")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "SW_1_7")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:D")
+		(at 210.82 68.58 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "72e958b6-fd26-448c-9b5d-48bc7a03c48b")
+		(property "Reference" "D_3_3"
+			(at 203.2 68.58 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 212.852 69.723 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_SMD:D_1206_3216Metric"
+			(at 210.82 68.58 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 210.82 68.58 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Diode (Through-hole or 0805)"
+			(at 210.82 68.58 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" "C9808"
+			(at 210.82 68.58 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "458f5657-b741-4f5f-aac4-65c0254570d1")
+		)
+		(pin "2"
+			(uuid "81628d14-2876-4355-bacc-da227ec59dbf")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "D_3_3")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:LED_Small")
+		(at 287.02 199.39 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "7306cedd-4d63-4980-8742-a284b5b0f841")
+		(property "Reference" "L_5_13"
+			(at 289.56 198.0564 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "LED_Small"
+			(at 289.56 200.5964 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "LED_SMD:LED_0805_2012Metric_Pad1.15x1.40mm_HandSolder"
+			(at 287.02 199.39 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 287.02 199.39 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Light emitting diode, small symbol"
+			(at 287.02 199.39 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "30ce6d55-7462-4b86-9324-54cd137b8a32")
+		)
+		(pin "2"
+			(uuid "a2c15a6d-f0a8-44b1-8451-de7907d2fcc2")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "L_5_13")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R_Small")
+		(at 266.7 166.37 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "737face0-ac20-4ce4-8acd-5f99e367dec5")
+		(property "Reference" "R_3_11"
+			(at 269.24 165.0999 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "560R"
+			(at 269.24 167.6399 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0805_2012Metric"
+			(at 266.7 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 266.7 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Resistor, small symbol"
+			(at 266.7 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "2"
+			(uuid "02f028b2-2913-42eb-b520-7b91456fcc2d")
+		)
+		(pin "1"
+			(uuid "320598b4-f815-4745-bb58-db69ea794b94")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "R_3_11")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R_Small")
+		(at 205.74 138.43 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "73b276f0-ed0e-4726-8953-70ca36d6ce52")
+		(property "Reference" "R_1_5"
+			(at 208.28 137.1599 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "560R"
+			(at 208.28 139.6999 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0805_2012Metric"
+			(at 205.74 138.43 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 205.74 138.43 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Resistor, small symbol"
+			(at 205.74 138.43 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "2"
+			(uuid "fd4b1472-4655-4137-9ea2-20f9d536bac6")
+		)
+		(pin "1"
+			(uuid "0a8257fe-9c79-4b69-9a50-813fed31b892")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "R_1_5")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R_Small")
+		(at 276.86 138.43 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "75941b69-64f3-49ae-b170-03898a2cce97")
+		(property "Reference" "R_1_12"
+			(at 279.4 137.1599 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "560R"
+			(at 279.4 139.6999 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0805_2012Metric"
+			(at 276.86 138.43 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 276.86 138.43 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Resistor, small symbol"
+			(at 276.86 138.43 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "2"
+			(uuid "f6081e7c-f227-4beb-b6bc-17cf1f63fd0a")
+		)
+		(pin "1"
+			(uuid "ca514e3c-94a0-4129-80cc-9d9296f86218")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "R_1_12")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:D")
+		(at 317.5 68.58 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "75d88725-12c8-47ac-9199-c7224cc40542")
+		(property "Reference" "D_3_10"
+			(at 309.88 68.58 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 319.532 69.723 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_SMD:D_1206_3216Metric"
+			(at 317.5 68.58 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 317.5 68.58 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Diode (Through-hole or 0805)"
+			(at 317.5 68.58 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" "C9808"
+			(at 317.5 68.58 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "c39156b7-97b9-4ff4-bec4-2795ed818ac9")
+		)
+		(pin "2"
+			(uuid "15e4acbe-fd45-4fee-875d-0678dcb8a27d")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "D_3_10")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 266.7 64.77 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "76860970-2874-4395-a871-d90450741f5e")
+		(property "Reference" "SW_3_7"
+			(at 266.7 59.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "Redragon Low Profile switches"
+			(at 266.7 59.8424 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "ProjectLocal:SW_Redragon_LowProfile_PCB_1.00u"
+			(at 266.7 59.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 266.7 59.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Mechanical Keyboard Switch"
+			(at 266.7 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" ""
+			(at 266.7 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "b2e19080-95ed-48ae-8254-865376f3e1d5")
+		)
+		(pin "2"
+			(uuid "a63bf5d5-26f6-4ffe-83a5-735769ebad8b")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "SW_3_7")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:LED_Small")
+		(at 175.26 199.39 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "770127d6-7cac-454b-9f1d-4c4e52702fa0")
+		(property "Reference" "L_5_2"
+			(at 177.8 198.0564 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "LED_Small"
+			(at 177.8 200.5964 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "LED_SMD:LED_0805_2012Metric_Pad1.15x1.40mm_HandSolder"
+			(at 175.26 199.39 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 175.26 199.39 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Light emitting diode, small symbol"
+			(at 175.26 199.39 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "5a0e6849-d379-48ed-9660-bd6bf7b252ba")
+		)
+		(pin "2"
+			(uuid "6019a7bf-d793-4b1f-85c5-1de6a089fd6a")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "L_5_2")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 205.74 31.75 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "77e6e578-bd30-4ba6-80dd-91509353bd95")
+		(property "Reference" "SW_1_3"
+			(at 205.74 26.67 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "Redragon Low Profile switches"
+			(at 205.74 26.8224 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "ProjectLocal:SW_Redragon_LowProfile_PCB_1.00u"
+			(at 205.74 26.67 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 205.74 26.67 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Mechanical Keyboard Switch"
+			(at 205.74 31.75 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" ""
+			(at 205.74 31.75 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "6876ee8e-48c9-45a4-b97f-0e64770c3860")
+		)
+		(pin "2"
+			(uuid "10aca254-9d85-49bb-9a48-ae43b7a4923a")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "SW_1_3")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R_Small")
+		(at 195.58 152.4 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "787e3914-6754-4e15-98f3-6a2e18fa77df")
+		(property "Reference" "R_2_4"
+			(at 198.12 151.1299 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "560R"
+			(at 198.12 153.6699 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0805_2012Metric"
+			(at 195.58 152.4 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 195.58 152.4 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Resistor, small symbol"
+			(at 195.58 152.4 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "2"
+			(uuid "970aefe3-f98d-441d-ac99-4bd40e578790")
+		)
+		(pin "1"
+			(uuid "6c10d379-0134-4f56-b90c-0caa45380c71")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "R_2_4")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R_Small")
+		(at 195.58 166.37 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "78f87b03-d39b-4cd6-97df-fc200fe635b7")
+		(property "Reference" "R_3_4"
+			(at 198.12 165.0999 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "560R"
+			(at 198.12 167.6399 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0805_2012Metric"
+			(at 195.58 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 195.58 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Resistor, small symbol"
+			(at 195.58 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "2"
+			(uuid "4359b6f0-3c2e-4322-b03f-15f0f24a8885")
+		)
+		(pin "1"
+			(uuid "d7d98fc5-410e-4bf5-af65-2deaf111993a")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "R_3_4")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:D")
+		(at 271.78 85.09 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "7ac5f82a-f4a6-4adf-b076-12f5f03287fa")
+		(property "Reference" "D_4_7"
+			(at 264.16 85.09 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 273.812 86.233 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_SMD:D_1206_3216Metric"
+			(at 271.78 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 271.78 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Diode (Through-hole or 0805)"
+			(at 271.78 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" "C9808"
+			(at 271.78 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "2fefe61f-cfb2-40c7-a6b9-e578af449eec")
+		)
+		(pin "2"
+			(uuid "3fc4d69b-d0fb-419e-8a2f-ffc083289a25")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "D_4_7")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:LED_Small")
+		(at 266.7 143.51 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "7b6a988e-7559-418e-905a-0ecbfe2fa39a")
+		(property "Reference" "L_1_11"
+			(at 269.24 142.1764 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "LED_Small"
+			(at 269.24 144.7164 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "LED_SMD:LED_0805_2012Metric_Pad1.15x1.40mm_HandSolder"
+			(at 266.7 143.51 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 266.7 143.51 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Light emitting diode, small symbol"
+			(at 266.7 143.51 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "dd118448-76ed-4b9a-be8d-d30527f6266d")
+		)
+		(pin "2"
+			(uuid "0125a96f-d5c4-4546-8014-892756589945")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "L_1_11")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:C")
+		(at 59.69 177.8 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "7bf3040a-5d66-43c3-a3ba-9f6b6dc51c5b")
+		(property "Reference" "C3"
+			(at 63.5 176.5299 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "4.7uF"
+			(at 63.5 179.0699 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Capacitor_SMD:C_0805_2012Metric"
+			(at 60.6552 181.61 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 59.69 177.8 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 59.69 177.8 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" "C1779"
+			(at 59.69 177.8 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "bccccdc6-c7ee-46e9-9203-8fc68fd215cb")
+		)
+		(pin "2"
+			(uuid "836d984a-f568-4b1a-928f-b655ca5234e9")
+		)
+		(instances
+			(project "keyboard-ch32x-48"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "C3")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:LED_Small")
+		(at 205.74 171.45 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "7dd8d99d-bbb3-47f0-a928-c207a6e30e3a")
+		(property "Reference" "L_3_5"
+			(at 208.28 170.1164 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "LED_Small"
+			(at 208.28 172.6564 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "LED_SMD:LED_0805_2012Metric_Pad1.15x1.40mm_HandSolder"
+			(at 205.74 171.45 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 205.74 171.45 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Light emitting diode, small symbol"
+			(at 205.74 171.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "1fee19e5-5a52-41ec-8210-1080f57a6790")
+		)
+		(pin "2"
+			(uuid "09ca4218-0b1e-4320-91fe-6a608a67b6bf")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "L_3_5")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:LED_Small")
+		(at 287.02 171.45 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "7de2720f-4e1a-40ca-b6ec-25fcb35096aa")
+		(property "Reference" "L_3_13"
+			(at 289.56 170.1164 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "LED_Small"
+			(at 289.56 172.6564 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "LED_SMD:LED_0805_2012Metric_Pad1.15x1.40mm_HandSolder"
+			(at 287.02 171.45 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 287.02 171.45 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Light emitting diode, small symbol"
+			(at 287.02 171.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "aca31cec-e794-403d-b72a-48189d1d22bc")
+		)
+		(pin "2"
+			(uuid "7d0614a3-6ed1-4710-9636-8b561c15d014")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "L_3_13")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:LED_Small")
+		(at 256.54 171.45 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "7fdd8bb8-9e83-4ea5-a67d-f02a79ce35a1")
+		(property "Reference" "L_3_10"
+			(at 259.08 170.1164 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "LED_Small"
+			(at 259.08 172.6564 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "LED_SMD:LED_0805_2012Metric_Pad1.15x1.40mm_HandSolder"
+			(at 256.54 171.45 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 256.54 171.45 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Light emitting diode, small symbol"
+			(at 256.54 171.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "82a28b64-6b66-443f-8b0d-2c78187eadc8")
+		)
+		(pin "2"
+			(uuid "ca69886a-1ce8-49c4-b8e3-66c29e47889c")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "L_3_10")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:D")
+		(at 241.3 101.6 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "81e09238-7fa9-47d5-8430-8032bf9a97c6")
+		(property "Reference" "D_5_5"
+			(at 233.68 101.6 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 243.332 102.743 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_SMD:D_1206_3216Metric"
+			(at 241.3 101.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 241.3 101.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Diode (Through-hole or 0805)"
+			(at 241.3 101.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" "C9808"
+			(at 241.3 101.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "22b19d69-2108-45b6-8d13-9a36d29a3bde")
+		)
+		(pin "2"
+			(uuid "d81a29cb-7296-4171-b444-905dca4a55d2")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "D_5_5")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 43.18 208.28 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "8259958b-0fec-4944-b109-dd78a4e727dc")
+		(property "Reference" "R1"
+			(at 43.18 201.93 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "10K"
+			(at 43.18 204.47 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0805_2012Metric"
+			(at 43.18 210.058 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 43.18 208.28 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 43.18 208.28 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" "C17414"
+			(at 43.18 208.28 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "ca079be2-1776-4a9a-b7e2-8aecd8d0f3bd")
+		)
+		(pin "2"
+			(uuid "00e3a359-69d7-41a4-adfc-16311f9af084")
+		)
+		(instances
+			(project "keyboard-ch552-48"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "R1")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:LED_Small")
+		(at 246.38 185.42 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "8394fb0a-3bac-4975-aca3-fa727d2504d9")
+		(property "Reference" "L_4_9"
+			(at 248.92 184.0864 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "LED_Small"
+			(at 248.92 186.6264 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "LED_SMD:LED_0805_2012Metric_Pad1.15x1.40mm_HandSolder"
+			(at 246.38 185.42 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 246.38 185.42 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Light emitting diode, small symbol"
+			(at 246.38 185.42 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "c0ba7d6f-d345-482d-bb28-5f1a686221ce")
+		)
+		(pin "2"
+			(uuid "bf08efa0-a288-4c2c-87e4-b9ece346a96b")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "L_4_9")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:D")
+		(at 256.54 52.07 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "84535696-986f-44c1-abdc-5939b7db4aa9")
+		(property "Reference" "D_2_6"
+			(at 248.92 52.07 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 258.572 53.213 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_SMD:D_1206_3216Metric"
+			(at 256.54 52.07 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 256.54 52.07 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Diode (Through-hole or 0805)"
+			(at 256.54 52.07 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" "C9808"
+			(at 256.54 52.07 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "9be52d08-0069-4903-bd80-e58681587a88")
+		)
+		(pin "2"
+			(uuid "ded97020-aad5-461d-9659-8837a7f47d98")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "D_2_6")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R_Small")
+		(at 205.74 180.34 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "852c8643-7905-4042-b46c-616ed7f767f5")
+		(property "Reference" "R_4_5"
+			(at 208.28 179.0699 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "560R"
+			(at 208.28 181.6099 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0805_2012Metric"
+			(at 205.74 180.34 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 205.74 180.34 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Resistor, small symbol"
+			(at 205.74 180.34 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "2"
+			(uuid "d295cd6f-bac6-42b3-94fd-025ca2d919be")
+		)
+		(pin "1"
+			(uuid "0cf4709b-247a-489c-946c-c6d235cf8d2d")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "R_4_5")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R_Small")
+		(at 307.34 152.4 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "8567c04f-f9ba-4dfb-b2a6-b9c0f86f9463")
+		(property "Reference" "R_2_15"
+			(at 309.88 151.1299 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "560R"
+			(at 309.88 153.6699 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0805_2012Metric"
+			(at 307.34 152.4 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 307.34 152.4 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Resistor, small symbol"
+			(at 307.34 152.4 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "2"
+			(uuid "b9a985a4-b890-43c3-a423-d2aed618dd9f")
+		)
+		(pin "1"
+			(uuid "15cb74b1-2ab3-4569-bb3c-b0f444bd4333")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "R_2_15")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R_Small")
+		(at 205.74 166.37 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "87ff00e4-0948-4c48-91b6-23cf2a8010d9")
+		(property "Reference" "R_3_5"
+			(at 208.28 165.0999 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "560R"
+			(at 208.28 167.6399 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0805_2012Metric"
+			(at 205.74 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 205.74 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Resistor, small symbol"
+			(at 205.74 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "2"
+			(uuid "2626aee5-9090-4809-8eb3-ef87006422a5")
+		)
+		(pin "1"
+			(uuid "005a1281-8cc0-4f01-9f1a-2813ce197a34")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "R_3_5")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 205.74 48.26 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "881700f1-4375-44d5-aaef-e072469ec877")
+		(property "Reference" "SW_2_3"
+			(at 205.74 43.18 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "Redragon Low Profile switches"
+			(at 205.74 43.3324 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "ProjectLocal:SW_Redragon_LowProfile_PCB_1.00u"
+			(at 205.74 43.18 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 205.74 43.18 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Mechanical Keyboard Switch"
+			(at 205.74 48.26 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" ""
+			(at 205.74 48.26 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "904b8e78-cd72-4c23-89a0-dd97a1ffa52d")
+		)
+		(pin "2"
+			(uuid "505e8ab7-c6e7-4e7e-b894-8856a94dba0b")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "SW_2_3")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 297.18 64.77 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "8a45b836-bc1f-456f-9a48-46bf5745d638")
+		(property "Reference" "SW_3_9"
+			(at 297.18 59.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "Redragon Low Profile switches"
+			(at 297.18 59.8424 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "ProjectLocal:SW_Redragon_LowProfile_PCB_1.00u"
+			(at 297.18 59.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 297.18 59.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Mechanical Keyboard Switch"
+			(at 297.18 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" ""
+			(at 297.18 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "d0734713-0bb0-47b2-bc9f-03f507b589cd")
+		)
+		(pin "2"
+			(uuid "13cdf660-2bdc-4352-911d-9071d83b73e3")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "SW_3_9")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 342.9 81.28 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "8a4e3075-bc76-4c23-a3df-2db15170842d")
+		(property "Reference" "SW_4_12"
+			(at 342.9 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "Redragon Low Profile switches"
+			(at 342.9 76.3524 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "ProjectLocal:SW_Redragon_LowProfile_PCB_1.00u"
+			(at 342.9 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 342.9 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Mechanical Keyboard Switch"
+			(at 342.9 81.28 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" ""
+			(at 342.9 81.28 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "7108a56d-edd7-46ae-ad04-6e5635e6cf09")
+		)
+		(pin "2"
+			(uuid "2877ade7-3b86-467b-a76e-86b30e68d619")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "SW_4_12")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R_Small")
+		(at 236.22 194.31 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "8b1299ff-2357-4d0f-bd4b-b0ae94109843")
+		(property "Reference" "R_5_8"
+			(at 238.76 193.0399 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "560R"
+			(at 238.76 195.5799 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0805_2012Metric"
+			(at 236.22 194.31 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 236.22 194.31 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Resistor, small symbol"
+			(at 236.22 194.31 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "2"
+			(uuid "ba82c05e-4066-4057-adbc-dc517668929b")
+		)
+		(pin "1"
+			(uuid "c6805241-a93c-4f6a-9e44-a5903f51703f")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "R_5_8")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:LED_Small")
+		(at 246.38 143.51 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "8c66acdc-6dbd-4db9-ba18-006cc1d99176")
+		(property "Reference" "L_1_9"
+			(at 248.92 142.1764 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "LED_Small"
+			(at 248.92 144.7164 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "LED_SMD:LED_0805_2012Metric_Pad1.15x1.40mm_HandSolder"
+			(at 246.38 143.51 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 246.38 143.51 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Light emitting diode, small symbol"
+			(at 246.38 143.51 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "07e71a25-33fe-4baa-b2bb-879169f68516")
+		)
+		(pin "2"
+			(uuid "aace6865-5f32-4717-ade1-38e3816834b5")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "L_1_9")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 251.46 97.79 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "8d8153af-514a-4cf8-9418-c58d7dd837a0")
+		(property "Reference" "SW_5_6"
+			(at 251.46 92.71 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "Redragon Low Profile switches"
+			(at 251.46 92.8624 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "ProjectLocal:SW_Redragon_LowProfile_PCB_1.00u"
+			(at 251.46 92.71 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 251.46 92.71 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Mechanical Keyboard Switch"
+			(at 251.46 97.79 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" ""
+			(at 251.46 97.79 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "7d6620ed-dbfa-45e4-aaa4-0f7d06d39584")
+		)
+		(pin "2"
+			(uuid "58b3ece6-90d4-451e-a35e-168753250198")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "SW_5_6")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:D")
+		(at 317.5 85.09 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "8d8b55db-348a-4be5-a07e-6a2388c44021")
+		(property "Reference" "D_4_10"
+			(at 309.88 85.09 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 319.532 86.233 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_SMD:D_1206_3216Metric"
+			(at 317.5 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 317.5 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Diode (Through-hole or 0805)"
+			(at 317.5 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" "C9808"
+			(at 317.5 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "ab556992-0cdb-4dac-b0ab-588908fbaba1")
+		)
+		(pin "2"
+			(uuid "1475734c-0280-40bd-9fdd-2696a9cf35c5")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "D_4_10")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 342.9 31.75 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "8de53e71-e438-45d8-8e39-238ce14203dd")
+		(property "Reference" "SW_1_12"
+			(at 342.9 26.67 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "Redragon Low Profile switches"
+			(at 342.9 26.8224 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "ProjectLocal:SW_Redragon_LowProfile_PCB_1.00u"
+			(at 342.9 26.67 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 342.9 26.67 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Mechanical Keyboard Switch"
+			(at 342.9 31.75 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" ""
+			(at 342.9 31.75 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "ae41abc4-1e37-4eff-a44a-7a06eb2c54c7")
+		)
+		(pin "2"
+			(uuid "598656ba-a0b9-4ef3-a7c2-ec455f5b1815")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "SW_1_12")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:D")
+		(at 226.06 52.07 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "8ef50f3b-b1f1-4b60-addd-088810044568")
+		(property "Reference" "D_2_4"
+			(at 218.44 52.07 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 228.092 53.213 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_SMD:D_1206_3216Metric"
+			(at 226.06 52.07 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 226.06 52.07 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Diode (Through-hole or 0805)"
+			(at 226.06 52.07 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" "C9808"
+			(at 226.06 52.07 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "850bbba6-4f83-4544-a2c5-da52734d86b2")
+		)
+		(pin "2"
+			(uuid "739ec282-01d6-4539-9238-8839e6e94b59")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "D_2_4")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:D")
+		(at 256.54 35.56 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "90181941-a872-47b1-b715-c2cc823a6538")
+		(property "Reference" "D_1_6"
+			(at 248.92 35.56 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 258.572 36.703 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_SMD:D_1206_3216Metric"
+			(at 256.54 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 256.54 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Diode (Through-hole or 0805)"
+			(at 256.54 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" "C9808"
+			(at 256.54 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "fe6a9c18-ac73-4161-861c-0008698170a0")
+		)
+		(pin "2"
+			(uuid "4d92d980-40fc-4155-8abb-913b6db2c95c")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "D_1_6")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 220.98 97.79 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "90d7539e-d908-483a-8214-f64c482b26ae")
+		(property "Reference" "SW_5_4"
+			(at 220.98 92.71 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "Redragon Low Profile switches"
+			(at 220.98 92.8624 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "ProjectLocal:SW_Redragon_LowProfile_PCB_1.00u"
+			(at 220.98 92.71 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 220.98 92.71 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Mechanical Keyboard Switch"
+			(at 220.98 97.79 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" ""
+			(at 220.98 97.79 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "340d411d-3541-45d6-b717-c4a00c7b7432")
+		)
+		(pin "2"
+			(uuid "6d990cf3-1b6a-4d04-8324-12d34a440431")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "SW_5_4")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:Q_NMOS_GSD")
+		(at 118.11 133.35 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "923b3e30-dc0c-472e-a229-4c355aa7b9e6")
+		(property "Reference" "Q1"
+			(at 124.46 132.0799 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "AO3400A"
+			(at 124.46 134.6199 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Package_TO_SOT_SMD:SOT-23"
+			(at 123.19 130.81 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 118.11 133.35 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "N-MOSFET transistor, gate/source/drain"
+			(at 118.11 133.35 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "2"
+			(uuid "085f4645-88be-4d01-b53b-91e81fbb7b94")
+		)
+		(pin "3"
+			(uuid "d8f1c27c-54e4-4344-a935-e819d55d617f")
+		)
+		(pin "1"
+			(uuid "4ed42e45-2f3b-4b7f-a7b8-9b1ecbe8dd6d")
+		)
+		(instances
+			(project ""
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "Q1")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 236.22 97.79 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "92b87b43-8cf1-40e9-bf26-edea4a910133")
+		(property "Reference" "SW_5_5"
+			(at 236.22 92.71 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "Redragon Low Profile switches"
+			(at 236.22 92.8624 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "ProjectLocal:SW_Redragon_LowProfile_PCB_1.00u"
+			(at 236.22 92.71 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 236.22 92.71 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Mechanical Keyboard Switch"
+			(at 236.22 97.79 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" ""
+			(at 236.22 97.79 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "7a39c16e-85c6-40e1-8c43-13da9c0259f4")
+		)
+		(pin "2"
+			(uuid "3d8ad899-1e39-4668-a477-efc2c4475950")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "SW_5_5")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:LED_Small")
+		(at 215.9 143.51 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "92e1bd72-ffc3-46b3-b8d9-f7611a822da2")
+		(property "Reference" "L_1_6"
+			(at 218.44 142.1764 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "LED_Small"
+			(at 218.44 144.7164 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "LED_SMD:LED_0805_2012Metric_Pad1.15x1.40mm_HandSolder"
+			(at 215.9 143.51 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 215.9 143.51 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Light emitting diode, small symbol"
+			(at 215.9 143.51 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "de760ac3-aec3-4b0f-82e8-382eded2c9a9")
+		)
+		(pin "2"
+			(uuid "cb029334-4b40-4ecc-b51a-ea8e49cf664a")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "L_1_6")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:LED")
+		(at 138.43 161.29 180)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "94411731-83c1-4fcd-b085-79d7c64dd1b4")
+		(property "Reference" "D2"
+			(at 140.0175 153.67 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "LED"
+			(at 140.0175 156.21 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "LED_SMD:LED_0805_2012Metric"
+			(at 138.43 161.29 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 138.43 161.29 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Light emitting diode"
+			(at 138.43 161.29 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "2"
+			(uuid "a4221da3-cc58-43b2-8707-83f3e2a9c634")
+		)
+		(pin "1"
+			(uuid "a1b8f0ad-f04e-4cbf-a223-a906f0877af2")
+		)
+		(instances
+			(project "keyboard-ch32x-48"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "D2")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:D")
+		(at 195.58 52.07 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "9790740e-28e5-4e1e-83eb-6734613b4013")
+		(property "Reference" "D_2_2"
+			(at 187.96 52.07 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 197.612 53.213 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_SMD:D_1206_3216Metric"
+			(at 195.58 52.07 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 195.58 52.07 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Diode (Through-hole or 0805)"
+			(at 195.58 52.07 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" "C9808"
+			(at 195.58 52.07 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "905c14cf-4ea2-4e99-a7e6-b23260f3e88a")
+		)
+		(pin "2"
+			(uuid "3ab16969-d4e3-460b-8732-c9ec1996fbc6")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "D_2_2")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:LED_Small")
+		(at 287.02 143.51 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "9830aee0-3df6-43a8-bfb2-1c533fcb7ee6")
+		(property "Reference" "L_1_13"
+			(at 289.56 142.1764 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "LED_Small"
+			(at 289.56 144.7164 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "LED_SMD:LED_0805_2012Metric_Pad1.15x1.40mm_HandSolder"
+			(at 287.02 143.51 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 287.02 143.51 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Light emitting diode, small symbol"
+			(at 287.02 143.51 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "79102403-b409-4adc-9255-4d732da6d9ff")
+		)
+		(pin "2"
+			(uuid "0f0f0dd4-a0bc-4ba8-994f-c4bb6ee08db0")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "L_1_13")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 312.42 97.79 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "984c25c3-2905-4840-bdcd-ed7252d5d9cf")
+		(property "Reference" "SW_5_10"
+			(at 312.42 92.71 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "Redragon Low Profile switches"
+			(at 312.42 92.8624 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "ProjectLocal:SW_Redragon_LowProfile_PCB_1.00u"
+			(at 312.42 92.71 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 312.42 92.71 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Mechanical Keyboard Switch"
+			(at 312.42 97.79 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" ""
+			(at 312.42 97.79 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "8dacef08-1144-4e6f-bac8-0f699d7a349e")
+		)
+		(pin "2"
+			(uuid "b6c1b210-717d-4aa2-bac8-759d98d6d113")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "SW_5_10")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:D")
+		(at 256.54 85.09 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "98ee142c-236e-4228-aef9-a79f25ae0a7e")
+		(property "Reference" "D_4_6"
+			(at 248.92 85.09 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 258.572 86.233 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_SMD:D_1206_3216Metric"
+			(at 256.54 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 256.54 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Diode (Through-hole or 0805)"
+			(at 256.54 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" "C9808"
+			(at 256.54 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "a655bc1a-2797-4fb5-be9e-47b000fd949c")
+		)
+		(pin "2"
+			(uuid "169b6b18-4b57-4742-96d6-2ac0fcf320fd")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "D_4_6")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:D")
+		(at 180.34 101.6 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "9915d583-98e9-4409-b8cb-41e4eb2cc695")
+		(property "Reference" "D_5_1"
+			(at 172.72 101.6 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 182.372 102.743 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_SMD:D_1206_3216Metric"
+			(at 180.34 101.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 180.34 101.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Diode (Through-hole or 0805)"
+			(at 180.34 101.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" "C9808"
+			(at 180.34 101.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "9b7b21c5-ca77-4358-94a4-c4aa8f24e5bd")
+		)
+		(pin "2"
+			(uuid "1207c25a-10f6-4f50-9d43-a9ae5bb86957")
+		)
+		(instances
+			(project "keyboard-ch552-48"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "D_5_1")
+					(unit 1)
+				)
+			)
+			(project "PyKey40-HS"
+				(path "/6e68f0cd-800e-4167-9553-71fc59da1eeb"
+					(reference "D_4_1")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:D")
+		(at 393.7 35.56 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "9a4c810f-2162-454e-9040-05c304639dd7")
+		(property "Reference" "D_1_15"
+			(at 386.08 35.56 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 395.732 36.703 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_SMD:D_1206_3216Metric"
+			(at 393.7 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 393.7 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Diode (Through-hole or 0805)"
+			(at 393.7 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" "C9808"
+			(at 393.7 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "d38b5014-f0f9-44b8-a3ed-c12c118ecaff")
+		)
+		(pin "2"
+			(uuid "460fd129-f466-457f-bf2e-d0ed075f2e9c")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "D_1_15")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 297.18 81.28 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "9cb3d8cf-1e5c-459c-863d-609fb3536bc1")
+		(property "Reference" "SW_4_9"
+			(at 297.18 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "Redragon Low Profile switches"
+			(at 297.18 76.3524 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "ProjectLocal:SW_Redragon_LowProfile_PCB_1.00u"
+			(at 297.18 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 297.18 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Mechanical Keyboard Switch"
+			(at 297.18 81.28 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" ""
+			(at 297.18 81.28 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "d0987d5e-a4bd-43d8-89d2-1d7f89051217")
+		)
+		(pin "2"
+			(uuid "301aa273-1072-4862-864f-8c78c38d1743")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "SW_4_9")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R_Small")
+		(at 175.26 180.34 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "9d24691e-cf57-4faa-8daa-c15c30e9974e")
+		(property "Reference" "R_4_2"
+			(at 177.8 179.0699 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "560R"
+			(at 177.8 181.6099 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0805_2012Metric"
+			(at 175.26 180.34 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 175.26 180.34 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Resistor, small symbol"
+			(at 175.26 180.34 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "2"
+			(uuid "7e71aa5a-15e2-49ff-9f20-dbdad871bd26")
+		)
+		(pin "1"
+			(uuid "3ba9b1c1-14a0-46ed-817c-ea286c2299f0")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "R_4_2")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R_Small")
+		(at 226.06 180.34 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "9da07682-8cc3-498c-8ba9-89f1dfc2fc54")
+		(property "Reference" "R_4_7"
+			(at 228.6 179.0699 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "560R"
+			(at 228.6 181.6099 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0805_2012Metric"
+			(at 226.06 180.34 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 226.06 180.34 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Resistor, small symbol"
+			(at 226.06 180.34 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "2"
+			(uuid "c1070a0b-84e2-4a63-94a1-b23b60a404bc")
+		)
+		(pin "1"
+			(uuid "4831b46f-b02c-41be-b304-43127fb09eb4")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "R_4_7")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Mechanical:MountingHole")
+		(at 256.54 266.7 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "9e055034-7746-4475-9c17-64a52285e662")
+		(property "Reference" "H1"
+			(at 259.08 265.5316 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "MountingHole"
+			(at 259.08 267.843 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "MountingHole:MountingHole_2.2mm_M2_DIN965"
+			(at 256.54 266.7 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 256.54 266.7 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 256.54 266.7 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(instances
+			(project "keyboard-ch552-48"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "H1")
+					(unit 1)
+				)
+			)
+			(project "PyKey40-HS"
+				(path "/6e68f0cd-800e-4167-9553-71fc59da1eeb"
+					(reference "H3")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R_Small")
+		(at 185.42 152.4 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "9e4eefbd-6468-4349-819a-cd469225684b")
+		(property "Reference" "R_2_3"
+			(at 187.96 151.1299 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "560R"
+			(at 187.96 153.6699 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0805_2012Metric"
+			(at 185.42 152.4 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 185.42 152.4 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Resistor, small symbol"
+			(at 185.42 152.4 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "2"
+			(uuid "a1b5c183-41c1-46f0-a074-8d6ff10b3c5e")
+		)
+		(pin "1"
+			(uuid "f6ae4638-e93d-4161-a6dd-6bf1e19c2af2")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "R_2_3")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 358.14 31.75 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "9f8ceb00-3d7b-4837-b604-8985fc46ca98")
+		(property "Reference" "SW_1_13"
+			(at 358.14 26.67 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "Redragon Low Profile switches"
+			(at 358.14 26.8224 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "ProjectLocal:SW_Redragon_LowProfile_PCB_1.00u"
+			(at 358.14 26.67 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 358.14 26.67 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Mechanical Keyboard Switch"
+			(at 358.14 31.75 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" ""
+			(at 358.14 31.75 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "680f28ab-6aca-4d5c-a1b7-1e350a799f79")
+		)
+		(pin "2"
+			(uuid "8768b207-0587-48e8-ab63-e011bfd53de8")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "SW_1_13")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:LED_Small")
+		(at 276.86 199.39 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "9fbc2b9d-f8f1-4e23-a716-3555939c80c0")
+		(property "Reference" "L_5_12"
+			(at 279.4 198.0564 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "LED_Small"
+			(at 279.4 200.5964 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "LED_SMD:LED_0805_2012Metric_Pad1.15x1.40mm_HandSolder"
+			(at 276.86 199.39 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 276.86 199.39 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Light emitting diode, small symbol"
+			(at 276.86 199.39 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "a7341c91-6180-4d60-a68b-8eda00491c3e")
+		)
+		(pin "2"
+			(uuid "fab2d4cb-fb86-45c7-a4e7-ab59e88d1a1f")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "L_5_12")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:D")
+		(at 378.46 52.07 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "a18faab0-03cc-443d-a87e-1a6e6bb929fd")
+		(property "Reference" "D_2_14"
+			(at 370.84 52.07 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 380.492 53.213 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_SMD:D_1206_3216Metric"
+			(at 378.46 52.07 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 378.46 52.07 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Diode (Through-hole or 0805)"
+			(at 378.46 52.07 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" "C9808"
+			(at 378.46 52.07 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "0ff48a54-6654-466f-aed5-a00fc52f1865")
+		)
+		(pin "2"
+			(uuid "613d8d03-b27e-4a16-b015-4f3c3b8c0245")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "D_2_14")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R_Small")
+		(at 256.54 138.43 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "a2ca4880-1a48-4dc8-8e10-109a22c53f27")
+		(property "Reference" "R_1_10"
+			(at 259.08 137.1599 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "560R"
+			(at 259.08 139.6999 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0805_2012Metric"
+			(at 256.54 138.43 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 256.54 138.43 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Resistor, small symbol"
+			(at 256.54 138.43 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "2"
+			(uuid "89f07727-8a81-4b62-b3b9-d86d7a51dc96")
+		)
+		(pin "1"
+			(uuid "cd7cd59a-9fe4-4da7-a41a-c54f5d870d7b")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "R_1_10")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 251.46 31.75 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "a2f79ed7-86cf-405f-841c-2a6bcc3de6eb")
+		(property "Reference" "SW_1_6"
+			(at 251.46 26.67 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "Redragon Low Profile switches"
+			(at 251.46 26.8224 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "ProjectLocal:SW_Redragon_LowProfile_PCB_1.00u"
+			(at 251.46 26.67 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 251.46 26.67 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Mechanical Keyboard Switch"
+			(at 251.46 31.75 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" ""
+			(at 251.46 31.75 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "ffa622ec-8f12-437b-a5c3-6036de7c24a5")
+		)
+		(pin "2"
+			(uuid "13a17d12-8170-42de-ac88-f09e823c10f9")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "SW_1_6")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 109.22 133.35 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "a2fde70d-770a-4537-95e8-305b142f1737")
+		(property "Reference" "R6"
+			(at 109.22 127 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "220R"
+			(at 109.22 129.54 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0805_2012Metric"
+			(at 109.22 135.128 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 109.22 133.35 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 109.22 133.35 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" "C17414"
+			(at 109.22 133.35 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "b9007fa0-d02e-420d-a4c6-d8a57d4b61d8")
+		)
+		(pin "2"
+			(uuid "3584f82e-7384-4f4a-b81e-895af09ec160")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "R6")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:D")
+		(at 332.74 68.58 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "a4daaa9f-3d43-4ee2-8676-7a084a9242d1")
+		(property "Reference" "D_3_11"
+			(at 325.12 68.58 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 334.772 69.723 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_SMD:D_1206_3216Metric"
+			(at 332.74 68.58 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 332.74 68.58 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Diode (Through-hole or 0805)"
+			(at 332.74 68.58 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" "C9808"
+			(at 332.74 68.58 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "7da3b7b5-d6b5-4e8a-8268-6b744521e08f")
+		)
+		(pin "2"
+			(uuid "ffe97b5f-b0f1-470e-bf49-90520789e7e4")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "D_3_11")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:LED_Small")
+		(at 205.74 157.48 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "a54cbf30-4831-4366-abb1-76f7ffa241b4")
+		(property "Reference" "L_2_5"
+			(at 208.28 156.1464 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "LED_Small"
+			(at 208.28 158.6864 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "LED_SMD:LED_0805_2012Metric_Pad1.15x1.40mm_HandSolder"
+			(at 205.74 157.48 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 205.74 157.48 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Light emitting diode, small symbol"
+			(at 205.74 157.48 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "c54e1a74-d79f-446b-a60e-e8b5dbbad12a")
+		)
+		(pin "2"
+			(uuid "a732cde5-26be-44f6-b7ab-9266e66b064a")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "L_2_5")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 190.5 81.28 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "a585c825-1cd2-45c0-bde3-35dc83ef110a")
+		(property "Reference" "SW_4_2"
+			(at 190.5 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "Redragon Low Profile switches"
+			(at 190.5 76.3524 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "ProjectLocal:SW_Redragon_LowProfile_PCB_1.00u"
+			(at 190.5 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 190.5 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Mechanical Keyboard Switch"
+			(at 190.5 81.28 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" ""
+			(at 190.5 81.28 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "d2dd1bff-7493-406c-ad0c-e9c9ed5952ed")
+		)
+		(pin "2"
+			(uuid "b6157d94-51fe-499c-bb06-beb3a1bdee74")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "SW_4_2")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:LED_Small")
+		(at 236.22 171.45 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "a652f4b7-eb0d-4246-9360-bc2f9743647b")
+		(property "Reference" "L_3_8"
+			(at 238.76 170.1164 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "LED_Small"
+			(at 238.76 172.6564 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "LED_SMD:LED_0805_2012Metric_Pad1.15x1.40mm_HandSolder"
+			(at 236.22 171.45 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 236.22 171.45 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Light emitting diode, small symbol"
+			(at 236.22 171.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "f1faad40-1cd8-4220-9890-b2ab0c0350ac")
+		)
+		(pin "2"
+			(uuid "779ff49e-bf69-48ed-8f99-21abcc3fafb1")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "L_3_8")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 130.81 161.29 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "a67b5024-b0c7-44ae-a664-6f4f08eb2e76")
+		(property "Reference" "R5"
+			(at 130.81 154.94 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "10K"
+			(at 130.81 157.48 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0805_2012Metric"
+			(at 130.81 163.068 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 130.81 161.29 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 130.81 161.29 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" "C17414"
+			(at 130.81 161.29 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "ac7c51a1-dcae-43f1-bbbb-283656f17939")
+		)
+		(pin "2"
+			(uuid "a0a584cf-36a2-44c7-942e-89a3925137b9")
+		)
+		(instances
+			(project "keyboard-ch32x-48"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "R5")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:D")
+		(at 347.98 101.6 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "a76507e0-a8db-4751-9aa8-e8e0ad149ccc")
+		(property "Reference" "D_5_12"
+			(at 340.36 101.6 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 350.012 102.743 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_SMD:D_1206_3216Metric"
+			(at 347.98 101.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 347.98 101.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Diode (Through-hole or 0805)"
+			(at 347.98 101.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" "C9808"
+			(at 347.98 101.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "14215ee1-c5ab-45dd-9483-b9ac4059c10b")
+		)
+		(pin "2"
+			(uuid "c09a3b71-86aa-4135-9082-5799dff7a2e2")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "D_5_12")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:D")
+		(at 180.34 68.58 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "a80867e0-c0fc-4777-a995-076d9780de88")
+		(property "Reference" "D_3_1"
+			(at 172.72 68.58 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 182.372 69.723 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_SMD:D_1206_3216Metric"
+			(at 180.34 68.58 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 180.34 68.58 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Diode (Through-hole or 0805)"
+			(at 180.34 68.58 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" "C9808"
+			(at 180.34 68.58 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "2455ab20-e6f9-4dbc-9758-dd51a3ffe4f4")
+		)
+		(pin "2"
+			(uuid "cd9105d6-5e4f-41e8-bc8d-218ff55ac103")
+		)
+		(instances
+			(project "keyboard-ch552-48"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "D_3_1")
+					(unit 1)
+				)
+			)
+			(project "PyKey40-HS"
+				(path "/6e68f0cd-800e-4167-9553-71fc59da1eeb"
+					(reference "D_3_1")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 358.14 48.26 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "a93f9923-49ac-4534-978b-bc6c119634e2")
+		(property "Reference" "SW_2_13"
+			(at 358.14 43.18 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "Redragon Low Profile switches"
+			(at 358.14 43.3324 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "ProjectLocal:SW_Redragon_LowProfile_PCB_1.00u"
+			(at 358.14 43.18 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 358.14 43.18 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Mechanical Keyboard Switch"
+			(at 358.14 48.26 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" ""
+			(at 358.14 48.26 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "15021443-8fc7-4f56-b53a-441ea1a41ce3")
+		)
+		(pin "2"
+			(uuid "a4fadea0-12a8-4639-8efd-2a7113858398")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "SW_2_13")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R_Small")
+		(at 215.9 166.37 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "aa52faf6-d8ef-4d31-9bb5-83e7037628e7")
+		(property "Reference" "R_3_6"
+			(at 218.44 165.0999 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "560R"
+			(at 218.44 167.6399 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0805_2012Metric"
+			(at 215.9 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 215.9 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Resistor, small symbol"
+			(at 215.9 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "2"
+			(uuid "509e8d19-4098-4583-a7df-746aba25e04c")
+		)
+		(pin "1"
+			(uuid "d760cb50-3453-4515-917a-92c8745fba1a")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "R_3_6")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:LED_Small")
+		(at 185.42 199.39 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "ab420c0e-a2a9-4ea3-a7bd-7d334bb4907b")
+		(property "Reference" "L_5_3"
+			(at 187.96 198.0564 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "LED_Small"
+			(at 187.96 200.5964 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "LED_SMD:LED_0805_2012Metric_Pad1.15x1.40mm_HandSolder"
+			(at 185.42 199.39 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 185.42 199.39 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Light emitting diode, small symbol"
+			(at 185.42 199.39 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "c97dcedb-c0a1-4299-b046-28e125e69e3f")
+		)
+		(pin "2"
+			(uuid "5848ee7b-209d-4b12-acdd-2b852422a81e")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "L_5_3")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 388.62 64.77 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "ab4886b0-a73f-40ec-a1d5-4f90374f3f3f")
+		(property "Reference" "SW_3_15"
+			(at 388.62 59.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "Redragon Low Profile switches"
+			(at 388.62 59.8424 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "ProjectLocal:SW_Redragon_LowProfile_PCB_1.00u"
+			(at 388.62 59.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 388.62 59.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Mechanical Keyboard Switch"
+			(at 388.62 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" ""
+			(at 388.62 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "2e0f9372-a4a2-4129-8d70-3d69a2a2a74c")
+		)
+		(pin "2"
+			(uuid "7673dfd6-fba6-4985-8a14-2f786b30ea43")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "SW_3_15")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 220.98 64.77 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "abc94b11-03b6-49bc-8cb0-684393ddb70a")
+		(property "Reference" "SW_3_4"
+			(at 220.98 59.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "Redragon Low Profile switches"
+			(at 220.98 59.8424 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "ProjectLocal:SW_Redragon_LowProfile_PCB_1.00u"
+			(at 220.98 59.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 220.98 59.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Mechanical Keyboard Switch"
+			(at 220.98 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" ""
+			(at 220.98 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "ea0ae0e3-7f75-4783-a5d3-fa928eb5aba2")
+		)
+		(pin "2"
+			(uuid "0aecd192-4193-44a5-8ca7-84a9c6c0d504")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "SW_3_4")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 373.38 48.26 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "ac369906-fda8-4012-9857-3c18352529a7")
+		(property "Reference" "SW_2_14"
+			(at 373.38 43.18 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "Redragon Low Profile switches"
+			(at 373.38 43.3324 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "ProjectLocal:SW_Redragon_LowProfile_PCB_1.00u"
+			(at 373.38 43.18 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 373.38 43.18 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Mechanical Keyboard Switch"
+			(at 373.38 48.26 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" ""
+			(at 373.38 48.26 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "5006d2e8-2c86-4c44-976c-e1f9f41891fe")
+		)
+		(pin "2"
+			(uuid "87fad87e-7e54-4df9-a5c3-00e88a78703a")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "SW_2_14")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 358.14 81.28 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "ad5b7709-e538-4581-b8f0-55cb62056aa1")
+		(property "Reference" "SW_4_13"
+			(at 358.14 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "Redragon Low Profile switches"
+			(at 358.14 76.3524 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "ProjectLocal:SW_Redragon_LowProfile_PCB_1.00u"
+			(at 358.14 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 358.14 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Mechanical Keyboard Switch"
+			(at 358.14 81.28 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" ""
+			(at 358.14 81.28 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "a75487ea-a1af-41c2-923f-d78f4a14bee3")
+		)
+		(pin "2"
+			(uuid "2a8e41bb-3c62-469c-910e-33b5a07322ab")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "SW_4_13")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 327.66 64.77 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "ad9107d5-bfbc-41c7-8f09-18261894a4ef")
+		(property "Reference" "SW_3_11"
+			(at 327.66 59.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "Redragon Low Profile switches"
+			(at 327.66 59.8424 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "ProjectLocal:SW_Redragon_LowProfile_PCB_1.00u"
+			(at 327.66 59.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 327.66 59.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Mechanical Keyboard Switch"
+			(at 327.66 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" ""
+			(at 327.66 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "5d332c3a-8038-4910-8a51-27d898698877")
+		)
+		(pin "2"
+			(uuid "a205511f-a5b7-471a-ab97-d35f63cbab56")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "SW_3_11")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:D")
+		(at 226.06 85.09 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "adb68a19-926b-4cdd-904e-da344d9dfa6d")
+		(property "Reference" "D_4_4"
+			(at 218.44 85.09 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 228.092 86.233 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_SMD:D_1206_3216Metric"
+			(at 226.06 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 226.06 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Diode (Through-hole or 0805)"
+			(at 226.06 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" "C9808"
+			(at 226.06 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "5a9bf3f8-6700-4e6b-a99f-4de2e5cb7c68")
+		)
+		(pin "2"
+			(uuid "90cb7372-4fee-48ab-8162-d42d1a319e60")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "D_4_4")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 312.42 81.28 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "b072bc0d-5695-4a39-8a29-30b6fd134ac7")
+		(property "Reference" "SW_4_10"
+			(at 312.42 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "Redragon Low Profile switches"
+			(at 312.42 76.3524 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "ProjectLocal:SW_Redragon_LowProfile_PCB_1.00u"
+			(at 312.42 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 312.42 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Mechanical Keyboard Switch"
+			(at 312.42 81.28 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" ""
+			(at 312.42 81.28 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "707f2c28-a7aa-4e91-9889-debc5eb0ef0c")
+		)
+		(pin "2"
+			(uuid "fa953319-6a7a-4192-b967-b1102c21d6f7")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "SW_4_10")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:LED_Small")
+		(at 175.26 143.51 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "b0770104-ab19-43c0-97d5-95b32cf5042d")
+		(property "Reference" "L_1_2"
+			(at 177.8 142.1764 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "LED_Small"
+			(at 177.8 144.7164 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "LED_SMD:LED_0805_2012Metric_Pad1.15x1.40mm_HandSolder"
+			(at 175.26 143.51 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 175.26 143.51 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Light emitting diode, small symbol"
+			(at 175.26 143.51 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "84f45e21-3426-4585-a3d9-a066826bdc6d")
+		)
+		(pin "2"
+			(uuid "5a97430b-ff2e-4416-9ffd-a12fa674aa94")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "L_1_2")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 236.22 31.75 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "b17b1043-e44c-4be4-8aae-ad0a4a6a2d7d")
+		(property "Reference" "SW_1_5"
+			(at 236.22 26.67 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "Redragon Low Profile switches"
+			(at 236.22 26.8224 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "ProjectLocal:SW_Redragon_LowProfile_PCB_1.00u"
+			(at 236.22 26.67 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 236.22 26.67 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Mechanical Keyboard Switch"
+			(at 236.22 31.75 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" ""
+			(at 236.22 31.75 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "7e9d2975-9b2b-44e4-935c-697c1060df1f")
+		)
+		(pin "2"
+			(uuid "dc71016c-bfe1-4e98-815c-3c39a1b5abc7")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "SW_1_5")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R_Small")
+		(at 307.34 194.31 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "b1c47fde-3134-4916-8006-807e39ca319a")
+		(property "Reference" "R_5_15"
+			(at 309.88 193.0399 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "560R"
+			(at 309.88 195.5799 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0805_2012Metric"
+			(at 307.34 194.31 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 307.34 194.31 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Resistor, small symbol"
+			(at 307.34 194.31 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "2"
+			(uuid "9487fff6-403e-469c-8c56-c6b95706415a")
+		)
+		(pin "1"
+			(uuid "982cbf51-fcdf-431c-bd70-93458d449990")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "R_5_15")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:LED_Small")
+		(at 215.9 199.39 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "b239dacf-d0bb-435c-b08f-50c039e11731")
+		(property "Reference" "L_5_6"
+			(at 218.44 198.0564 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "LED_Small"
+			(at 218.44 200.5964 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "LED_SMD:LED_0805_2012Metric_Pad1.15x1.40mm_HandSolder"
+			(at 215.9 199.39 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 215.9 199.39 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Light emitting diode, small symbol"
+			(at 215.9 199.39 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "a74b9bee-c00b-4918-88d7-8c605d0d1c95")
+		)
+		(pin "2"
+			(uuid "e008c64c-449f-4b36-bfa6-96de12d49225")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "L_5_6")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:D")
+		(at 241.3 68.58 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "b2de466e-8b9c-40f0-9446-f13cafa28713")
+		(property "Reference" "D_3_5"
+			(at 233.68 68.58 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 243.332 69.723 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_SMD:D_1206_3216Metric"
+			(at 241.3 68.58 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 241.3 68.58 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Diode (Through-hole or 0805)"
+			(at 241.3 68.58 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" "C9808"
+			(at 241.3 68.58 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "c5fd9542-2e3d-4013-91b2-3be4baf856fe")
+		)
+		(pin "2"
+			(uuid "100e0c9d-954a-4392-b723-c9bae3a6df92")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "D_3_5")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:D")
+		(at 393.7 68.58 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "b2e04cc7-e931-43f1-8c0b-cf0b61436ced")
+		(property "Reference" "D_3_15"
+			(at 386.08 68.58 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 395.732 69.723 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_SMD:D_1206_3216Metric"
+			(at 393.7 68.58 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 393.7 68.58 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Diode (Through-hole or 0805)"
+			(at 393.7 68.58 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" "C9808"
+			(at 393.7 68.58 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "9c223538-7a48-4544-8812-51f287604938")
+		)
+		(pin "2"
+			(uuid "b2f22a57-17fc-48d5-849f-926f4042d69d")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "D_3_15")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:LED_Small")
+		(at 226.06 143.51 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "b3c10f6d-0649-4df4-a808-4e69668e2ed9")
+		(property "Reference" "L_1_7"
+			(at 228.6 142.1764 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "LED_Small"
+			(at 228.6 144.7164 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "LED_SMD:LED_0805_2012Metric_Pad1.15x1.40mm_HandSolder"
+			(at 226.06 143.51 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 226.06 143.51 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Light emitting diode, small symbol"
+			(at 226.06 143.51 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "49a50163-8684-4a2b-853c-d43117f5e60e")
+		)
+		(pin "2"
+			(uuid "c6b5166d-8ce5-4edd-be51-797d276e8069")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "L_1_7")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 266.7 81.28 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "b3f53b27-dc75-469f-b6d7-530a3b586f36")
+		(property "Reference" "SW_4_7"
+			(at 266.7 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "Redragon Low Profile switches"
+			(at 266.7 76.3524 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "ProjectLocal:SW_Redragon_LowProfile_PCB_1.00u"
+			(at 266.7 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 266.7 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Mechanical Keyboard Switch"
+			(at 266.7 81.28 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" ""
+			(at 266.7 81.28 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "1910de1d-5f14-40ca-9297-f92a9446d896")
+		)
+		(pin "2"
+			(uuid "41f864c3-2311-4811-9cca-5808bed3d6aa")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "SW_4_7")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:D")
+		(at 393.7 85.09 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "b45e0aef-2118-4bac-ae05-fe7bb2bfd33f")
+		(property "Reference" "D_4_15"
+			(at 386.08 85.09 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 395.732 86.233 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_SMD:D_1206_3216Metric"
+			(at 393.7 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 393.7 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Diode (Through-hole or 0805)"
+			(at 393.7 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" "C9808"
+			(at 393.7 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "a4fd670b-a57e-479f-bed8-e7fadadee924")
+		)
+		(pin "2"
+			(uuid "ef734d60-db50-4074-8733-dfd5bad168ea")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "D_4_15")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:LED_Small")
+		(at 185.42 143.51 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "b61b297a-0f82-41a5-83d1-4664df327595")
+		(property "Reference" "L_1_3"
+			(at 187.96 142.1764 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "LED_Small"
+			(at 187.96 144.7164 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "LED_SMD:LED_0805_2012Metric_Pad1.15x1.40mm_HandSolder"
+			(at 185.42 143.51 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 185.42 143.51 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Light emitting diode, small symbol"
+			(at 185.42 143.51 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "82b80d01-ce9c-4e9c-aa13-113d55f69b9e")
+		)
+		(pin "2"
+			(uuid "b7a05dcf-80e6-497f-bd1b-5414c585fbb2")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "L_1_3")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:LED_Small")
+		(at 246.38 157.48 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "b626db77-71c9-4040-93e3-5e4b0ab1396f")
+		(property "Reference" "L_2_9"
+			(at 248.92 156.1464 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "LED_Small"
+			(at 248.92 158.6864 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "LED_SMD:LED_0805_2012Metric_Pad1.15x1.40mm_HandSolder"
+			(at 246.38 157.48 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 246.38 157.48 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Light emitting diode, small symbol"
+			(at 246.38 157.48 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "fdd47cbd-2ba4-47cc-9d00-31e3660c9f97")
+		)
+		(pin "2"
+			(uuid "fbd90aec-4abc-4d88-afb8-2e348baf7c14")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "L_2_9")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R_Small")
+		(at 215.9 138.43 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "b6538e16-5080-42c9-8f45-fd50938a93e7")
+		(property "Reference" "R_1_6"
+			(at 218.44 137.1599 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "560R"
+			(at 218.44 139.6999 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0805_2012Metric"
+			(at 215.9 138.43 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 215.9 138.43 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Resistor, small symbol"
+			(at 215.9 138.43 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "2"
+			(uuid "1d3a3a4c-d1bf-4bf5-a495-843784b509f0")
+		)
+		(pin "1"
+			(uuid "8e5a6daa-a66b-4b74-9f82-5f85f16d9f26")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "R_1_6")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R_Small")
+		(at 297.18 138.43 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "b6b91b34-65e6-468d-aee9-7a37195f01a7")
+		(property "Reference" "R_1_14"
+			(at 299.72 137.1599 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "560R"
+			(at 299.72 139.6999 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0805_2012Metric"
+			(at 297.18 138.43 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 297.18 138.43 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Resistor, small symbol"
+			(at 297.18 138.43 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "2"
+			(uuid "fae6de21-025e-43cc-9c99-ea7410c58f09")
+		)
+		(pin "1"
+			(uuid "e9fefa56-e451-41c1-af22-b6a9e2b565bc")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "R_1_14")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 373.38 97.79 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "b7b6d16a-5304-4536-80b7-12abd2425993")
+		(property "Reference" "SW_5_14"
+			(at 373.38 92.71 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "Redragon Low Profile switches"
+			(at 373.38 92.8624 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "ProjectLocal:SW_Redragon_LowProfile_PCB_1.00u"
+			(at 373.38 92.71 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 373.38 92.71 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Mechanical Keyboard Switch"
+			(at 373.38 97.79 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" ""
+			(at 373.38 97.79 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "89d0a36d-f5f7-4f9a-ac03-baf706921220")
+		)
+		(pin "2"
+			(uuid "9ccbfd7d-5a7f-467d-8939-54e9b785c24c")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "SW_5_14")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 175.26 64.77 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "b814fe0e-bca6-432c-84f8-119c0e7a58cc")
+		(property "Reference" "SW_3_1"
+			(at 175.26 59.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "Redragon Low Profile switches"
+			(at 175.26 59.8424 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "ProjectLocal:SW_Redragon_LowProfile_PCB_1.00u"
+			(at 175.26 59.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 175.26 59.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Mechanical Keyboard Switch"
+			(at 175.26 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" ""
+			(at 175.26 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "aee3a5c3-ebe2-4d14-8d07-8cceea7b4fee")
+		)
+		(pin "2"
+			(uuid "e3db7273-6971-4c6b-ad94-970fd4e3d062")
+		)
+		(instances
+			(project "keyboard-ch552-48"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "SW_3_1")
+					(unit 1)
+				)
+			)
+			(project "PyKey40-HS"
+				(path "/6e68f0cd-800e-4167-9553-71fc59da1eeb"
+					(reference "SW_3_1")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:LED_Small")
+		(at 276.86 143.51 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "b8d86328-ae2b-4943-bb01-d89599560670")
+		(property "Reference" "L_1_12"
+			(at 279.4 142.1764 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "LED_Small"
+			(at 279.4 144.7164 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "LED_SMD:LED_0805_2012Metric_Pad1.15x1.40mm_HandSolder"
+			(at 276.86 143.51 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 276.86 143.51 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Light emitting diode, small symbol"
+			(at 276.86 143.51 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "8ef6002a-5486-4d81-8a39-db572871c104")
+		)
+		(pin "2"
+			(uuid "1c29d302-7a27-43a0-bb5f-813903e5b4a3")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "L_1_12")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R_Small")
+		(at 205.74 152.4 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "b99c3417-65ad-4f16-b160-6c4c4a9019a1")
+		(property "Reference" "R_2_5"
+			(at 208.28 151.1299 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "560R"
+			(at 208.28 153.6699 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0805_2012Metric"
+			(at 205.74 152.4 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 205.74 152.4 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Resistor, small symbol"
+			(at 205.74 152.4 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "2"
+			(uuid "67366c7d-b7dc-42ef-aa80-87877e766a07")
+		)
+		(pin "1"
+			(uuid "5032f14a-e1ea-466c-9118-13f636da6aab")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "R_2_5")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 76.2 133.35 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "ba19255e-129a-472d-8d93-06b7008dceb8")
+		(property "Reference" "R3"
+			(at 78.74 132.0799 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "5.1k"
+			(at 78.74 134.6199 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0805_2012Metric"
+			(at 74.422 133.35 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 76.2 133.35 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 76.2 133.35 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" "C27834"
+			(at 76.2 133.35 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "8b89cea2-11d9-4d12-9426-70fa8ced21a5")
+		)
+		(pin "2"
+			(uuid "2f27951b-91e3-4386-8adf-da31963cdcfb")
+		)
+		(instances
+			(project "keyboard-ch552-48"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "R3")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 297.18 31.75 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "bb705ef1-8dea-4fa1-b111-5ad16035e617")
+		(property "Reference" "SW_1_9"
+			(at 297.18 26.67 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "Redragon Low Profile switches"
+			(at 297.18 26.8224 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "ProjectLocal:SW_Redragon_LowProfile_PCB_1.00u"
+			(at 297.18 26.67 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 297.18 26.67 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Mechanical Keyboard Switch"
+			(at 297.18 31.75 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" ""
+			(at 297.18 31.75 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "2d732bde-5262-433a-920a-be2852371f03")
+		)
+		(pin "2"
+			(uuid "04644f48-a47c-4c9d-b311-afd98d986e6e")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "SW_1_9")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R_Small")
+		(at 165.1 138.43 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "bbad6c93-20a6-4743-8440-a7a67b01374f")
+		(property "Reference" "R_1_1"
+			(at 167.64 137.1599 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "560R"
+			(at 167.64 139.6999 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0805_2012Metric"
+			(at 165.1 138.43 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 165.1 138.43 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Resistor, small symbol"
+			(at 165.1 138.43 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "2"
+			(uuid "00469df9-9dd8-4c83-aaf3-3e35668130d6")
+		)
+		(pin "1"
+			(uuid "b40931cc-f480-46d3-b68c-ee79fdb2326e")
+		)
+		(instances
+			(project ""
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "R_1_1")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R_Small")
+		(at 175.26 166.37 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "bbe8ae00-4614-45e4-b933-6442bae4310a")
+		(property "Reference" "R_3_2"
+			(at 177.8 165.0999 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "560R"
+			(at 177.8 167.6399 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0805_2012Metric"
+			(at 175.26 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 175.26 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Resistor, small symbol"
+			(at 175.26 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "2"
+			(uuid "9eef2f86-4c86-4a61-b8bf-bdcbe9a108ac")
+		)
+		(pin "1"
+			(uuid "2bbe66fa-3928-4f40-a772-d609c6446a69")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "R_3_2")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:D")
+		(at 195.58 68.58 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "bdc2b24c-9d04-41e8-9c4f-5fd37ec2809c")
+		(property "Reference" "D_3_2"
+			(at 187.96 68.58 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 197.612 69.723 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_SMD:D_1206_3216Metric"
+			(at 195.58 68.58 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 195.58 68.58 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Diode (Through-hole or 0805)"
+			(at 195.58 68.58 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" "C9808"
+			(at 195.58 68.58 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "d7fb16ec-f293-4ded-960a-2e65085d1346")
+		)
+		(pin "2"
+			(uuid "2bce3c71-1a2f-4c88-a4fb-a1d007d842f0")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "D_3_2")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 388.62 97.79 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "be3b0935-f6e0-477b-9439-c35b77cadcca")
+		(property "Reference" "SW_5_15"
+			(at 388.62 92.71 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "Redragon Low Profile switches"
+			(at 388.62 92.8624 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "ProjectLocal:SW_Redragon_LowProfile_PCB_1.00u"
+			(at 388.62 92.71 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 388.62 92.71 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Mechanical Keyboard Switch"
+			(at 388.62 97.79 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" ""
+			(at 388.62 97.79 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "eafebfaf-3608-4c59-b25f-5f029ffa8fed")
+		)
+		(pin "2"
+			(uuid "da205517-c0a8-4f4d-ba1d-cb7ba10c5eee")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "SW_5_15")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:LED")
+		(at 109.22 161.29 180)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "beb9aa56-ed7a-4465-8dd9-92c6a87401c9")
+		(property "Reference" "D1"
+			(at 110.8075 153.67 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "LED"
+			(at 110.8075 156.21 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "LED_SMD:LED_0805_2012Metric"
+			(at 109.22 161.29 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 109.22 161.29 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Light emitting diode"
+			(at 109.22 161.29 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "2"
+			(uuid "8dbef3ab-aa38-4da9-9657-21b8fa39ea61")
+		)
+		(pin "1"
+			(uuid "9b28ab72-2246-4355-bdbe-8a5d4cd0c5ae")
+		)
+		(instances
+			(project ""
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "D1")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R_Small")
+		(at 195.58 194.31 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "bf962518-29a6-4e08-9231-7181ee7f9c03")
+		(property "Reference" "R_5_4"
+			(at 198.12 193.0399 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "560R"
+			(at 198.12 195.5799 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0805_2012Metric"
+			(at 195.58 194.31 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 195.58 194.31 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Resistor, small symbol"
+			(at 195.58 194.31 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "2"
+			(uuid "cb5cc69d-e70a-4e09-b129-c125425929e6")
+		)
+		(pin "1"
+			(uuid "0b7dd163-4f9a-40f1-a95a-af273e371875")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "R_5_4")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:D")
+		(at 226.06 35.56 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "bfef1f1a-dc50-4785-8e51-76c45e0c0980")
+		(property "Reference" "D_1_4"
+			(at 218.44 35.56 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 228.092 36.703 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_SMD:D_1206_3216Metric"
+			(at 226.06 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 226.06 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Diode (Through-hole or 0805)"
+			(at 226.06 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" "C9808"
+			(at 226.06 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "b7a2719e-f1a6-41ce-9f8e-bd956370aecc")
+		)
+		(pin "2"
+			(uuid "c1ad6b94-d7df-4974-a291-3de815551659")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "D_1_4")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 236.22 81.28 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "c033fc34-c7f6-475a-a72f-ea8a08f685ab")
+		(property "Reference" "SW_4_5"
+			(at 236.22 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "Redragon Low Profile switches"
+			(at 236.22 76.3524 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "ProjectLocal:SW_Redragon_LowProfile_PCB_1.00u"
+			(at 236.22 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 236.22 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Mechanical Keyboard Switch"
+			(at 236.22 81.28 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" ""
+			(at 236.22 81.28 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "05212eab-95b5-49dd-8085-9ffd725a00b7")
+		)
+		(pin "2"
+			(uuid "375d3be0-02b2-48bc-a14a-9559943902ac")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "SW_4_5")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:D")
+		(at 195.58 101.6 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "c03fa05d-7005-4f92-a619-52f4e14a917c")
+		(property "Reference" "D_5_2"
+			(at 187.96 101.6 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 197.612 102.743 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_SMD:D_1206_3216Metric"
+			(at 195.58 101.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 195.58 101.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Diode (Through-hole or 0805)"
+			(at 195.58 101.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" "C9808"
+			(at 195.58 101.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "1bc26513-e7d6-4478-87ea-16ce6eb7052f")
+		)
+		(pin "2"
+			(uuid "52d61544-3ec6-430e-a868-d5bf971cacf0")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "D_5_2")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:LED_Small")
+		(at 266.7 171.45 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "c1a2b2d0-9a6f-4661-8b9e-2d24359e7c7e")
+		(property "Reference" "L_3_11"
+			(at 269.24 170.1164 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "LED_Small"
+			(at 269.24 172.6564 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "LED_SMD:LED_0805_2012Metric_Pad1.15x1.40mm_HandSolder"
+			(at 266.7 171.45 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 266.7 171.45 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Light emitting diode, small symbol"
+			(at 266.7 171.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "a62ce161-3008-4682-ae66-db458654525c")
+		)
+		(pin "2"
+			(uuid "dc9276cb-f134-400d-b1ad-e3ddf4c93d67")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "L_3_11")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R_Small")
+		(at 185.42 194.31 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "c1bfba46-fb69-418f-a16e-e6a3034c5afa")
+		(property "Reference" "R_5_3"
+			(at 187.96 193.0399 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "560R"
+			(at 187.96 195.5799 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0805_2012Metric"
+			(at 185.42 194.31 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 185.42 194.31 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Resistor, small symbol"
+			(at 185.42 194.31 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "2"
+			(uuid "1c87fb40-f346-4aba-ace0-2ce7011f71c8")
+		)
+		(pin "1"
+			(uuid "554fed83-28ab-4aa9-b72a-fadc60cbb37d")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "R_5_3")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R_Small")
+		(at 246.38 138.43 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "c300c2cc-d5f1-40e7-ab14-ac53d1615cec")
+		(property "Reference" "R_1_9"
+			(at 248.92 137.1599 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "560R"
+			(at 248.92 139.6999 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0805_2012Metric"
+			(at 246.38 138.43 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 246.38 138.43 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Resistor, small symbol"
+			(at 246.38 138.43 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "2"
+			(uuid "e16fc052-dc7b-4259-aed1-f06e88d8cdc1")
+		)
+		(pin "1"
+			(uuid "45feef28-5971-490e-a0f9-2b415458da51")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "R_1_9")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:D")
+		(at 241.3 52.07 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "c38063e3-c628-4dbf-b8b4-cce55a79db35")
+		(property "Reference" "D_2_5"
+			(at 233.68 52.07 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 243.332 53.213 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_SMD:D_1206_3216Metric"
+			(at 241.3 52.07 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 241.3 52.07 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Diode (Through-hole or 0805)"
+			(at 241.3 52.07 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" "C9808"
+			(at 241.3 52.07 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "17b5ff53-c41c-4198-b43f-a1d2797699c1")
+		)
+		(pin "2"
+			(uuid "36f24a75-bc3c-4e47-a747-2a697b43bc71")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "D_2_5")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 388.62 31.75 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "c3c00711-5bc4-49c4-a746-43a5c6c25369")
+		(property "Reference" "SW_1_15"
+			(at 388.62 26.67 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "Redragon Low Profile switches"
+			(at 388.62 26.8224 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "ProjectLocal:SW_Redragon_LowProfile_PCB_1.00u"
+			(at 388.62 26.67 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 388.62 26.67 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Mechanical Keyboard Switch"
+			(at 388.62 31.75 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" ""
+			(at 388.62 31.75 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "a74df98c-5287-4c32-8d9b-5a2bce5af818")
+		)
+		(pin "2"
+			(uuid "b4ef5406-3b58-49f6-bc13-6c7d7025309a")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "SW_1_15")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R_Small")
+		(at 297.18 166.37 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "c4d20b02-9926-4a5e-9684-de0bce1c9b64")
+		(property "Reference" "R_3_14"
+			(at 299.72 165.0999 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "560R"
+			(at 299.72 167.6399 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0805_2012Metric"
+			(at 297.18 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 297.18 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Resistor, small symbol"
+			(at 297.18 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "2"
+			(uuid "0cf60a2c-6b88-4973-94f6-b78cecae257f")
+		)
+		(pin "1"
+			(uuid "778c6a81-dd5a-4efe-81f6-f98a24678e53")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "R_3_14")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:D")
+		(at 347.98 52.07 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "c50277a8-bcfa-437a-a37b-f4778d85c2d9")
+		(property "Reference" "D_2_12"
+			(at 340.36 52.07 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 350.012 53.213 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_SMD:D_1206_3216Metric"
+			(at 347.98 52.07 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 347.98 52.07 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Diode (Through-hole or 0805)"
+			(at 347.98 52.07 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" "C9808"
+			(at 347.98 52.07 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "13759d48-71a5-4c7b-bf77-5fdf857f46c3")
+		)
+		(pin "2"
+			(uuid "b4d4bea0-0de5-40af-b2ed-a2552e4b15a0")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "D_2_12")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R_Small")
+		(at 276.86 166.37 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "c575819a-fd9a-4e3e-8bf3-1eac2062d3a0")
+		(property "Reference" "R_3_12"
+			(at 279.4 165.0999 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "560R"
+			(at 279.4 167.6399 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0805_2012Metric"
+			(at 276.86 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 276.86 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Resistor, small symbol"
+			(at 276.86 166.37 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "2"
+			(uuid "c148e9a7-6255-406b-918c-2365db4f9220")
+		)
+		(pin "1"
+			(uuid "933757da-3a43-46f5-8b99-68b511192e2e")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "R_3_12")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:D")
+		(at 347.98 35.56 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "c821916d-ecbd-463f-bfa0-7957c41c7f4c")
+		(property "Reference" "D_1_12"
+			(at 340.36 35.56 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 350.012 36.703 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_SMD:D_1206_3216Metric"
+			(at 347.98 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 347.98 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Diode (Through-hole or 0805)"
+			(at 347.98 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" "C9808"
+			(at 347.98 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "2dbd1448-eab4-45ec-9c65-2b14ecdc739d")
+		)
+		(pin "2"
+			(uuid "d3e9f307-15cd-48ef-aea4-2999289c7417")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "D_1_12")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:D")
+		(at 378.46 101.6 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "c837dbe6-f684-47ab-b6f5-2da9270f6946")
+		(property "Reference" "D_5_14"
+			(at 370.84 101.6 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 380.492 102.743 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_SMD:D_1206_3216Metric"
+			(at 378.46 101.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 378.46 101.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Diode (Through-hole or 0805)"
+			(at 378.46 101.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" "C9808"
+			(at 378.46 101.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "3d8c7849-80bc-40fa-a702-292340572ea4")
+		)
+		(pin "2"
+			(uuid "4fd8acf6-5469-4ebd-9e9c-8bc98352a697")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "D_5_14")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:LED_Small")
+		(at 236.22 199.39 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "c871bd35-f51f-437b-94e6-e0414c210a1c")
+		(property "Reference" "L_5_8"
+			(at 238.76 198.0564 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "LED_Small"
+			(at 238.76 200.5964 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "LED_SMD:LED_0805_2012Metric_Pad1.15x1.40mm_HandSolder"
+			(at 236.22 199.39 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 236.22 199.39 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Light emitting diode, small symbol"
+			(at 236.22 199.39 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "e51ebcb8-d86e-4761-b561-afee5ef7f548")
+		)
+		(pin "2"
+			(uuid "b618c8cc-972c-4e52-8089-817d8964d8c0")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "L_5_8")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R_Small")
+		(at 287.02 194.31 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "c8e0874e-8ca3-4abd-a53f-dcabbc4e49c9")
+		(property "Reference" "R_5_13"
+			(at 289.56 193.0399 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "560R"
+			(at 289.56 195.5799 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0805_2012Metric"
+			(at 287.02 194.31 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 287.02 194.31 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Resistor, small symbol"
+			(at 287.02 194.31 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "2"
+			(uuid "ca83a81c-416a-4939-99a6-4fa9a7e75f68")
+		)
+		(pin "1"
+			(uuid "8406ed5b-700b-41f4-beac-7499bb07c7e3")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "R_5_13")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:D")
+		(at 332.74 35.56 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "ca26accc-90f3-4715-911e-f76496834af1")
+		(property "Reference" "D_1_11"
+			(at 325.12 35.56 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 334.772 36.703 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_SMD:D_1206_3216Metric"
+			(at 332.74 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 332.74 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Diode (Through-hole or 0805)"
+			(at 332.74 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" "C9808"
+			(at 332.74 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "11bd1a68-3b11-4425-a591-32096c2c97ee")
+		)
+		(pin "2"
+			(uuid "092d89ee-f73f-4377-8736-71266b643d35")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "D_1_11")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 281.94 97.79 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "cbb4f194-cb15-4ccf-a0fe-c15fa8670cda")
+		(property "Reference" "SW_5_8"
+			(at 281.94 92.71 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "Redragon Low Profile switches"
+			(at 281.94 92.8624 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "ProjectLocal:SW_Redragon_LowProfile_PCB_1.00u"
+			(at 281.94 92.71 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 281.94 92.71 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Mechanical Keyboard Switch"
+			(at 281.94 97.79 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" ""
+			(at 281.94 97.79 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "89c4bcf0-a71d-456f-a160-c8e2025dbe7b")
+		)
+		(pin "2"
+			(uuid "e43367ae-5bbc-4bd4-a74d-1d3bfa3e1842")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "SW_5_8")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:D")
+		(at 332.74 85.09 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "cbb747f8-3aed-444f-96d6-3964c16f0786")
+		(property "Reference" "D_4_11"
+			(at 325.12 85.09 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 334.772 86.233 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_SMD:D_1206_3216Metric"
+			(at 332.74 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 332.74 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Diode (Through-hole or 0805)"
+			(at 332.74 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" "C9808"
+			(at 332.74 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "a47c2446-d40f-4d7b-8252-86b4969479ce")
+		)
+		(pin "2"
+			(uuid "c77bb56b-fadf-4064-9db4-31a4a930bc1a")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "D_4_11")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 342.9 97.79 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "ce273303-dc52-40f1-bb68-ae4101c0a323")
+		(property "Reference" "SW_5_12"
+			(at 342.9 92.71 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "Redragon Low Profile switches"
+			(at 342.9 92.8624 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "ProjectLocal:SW_Redragon_LowProfile_PCB_1.00u"
+			(at 342.9 92.71 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 342.9 92.71 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Mechanical Keyboard Switch"
+			(at 342.9 97.79 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" ""
+			(at 342.9 97.79 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "233db016-1c3b-4ce1-9665-59445e57c894")
+		)
+		(pin "2"
+			(uuid "26bb2ce9-3086-491a-95c1-8b83ec2761d3")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "SW_5_12")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R_Small")
+		(at 175.26 152.4 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "ceef2201-af68-4f03-b102-248a0672e7f1")
+		(property "Reference" "R_2_2"
+			(at 177.8 151.1299 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "560R"
+			(at 177.8 153.6699 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0805_2012Metric"
+			(at 175.26 152.4 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 175.26 152.4 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Resistor, small symbol"
+			(at 175.26 152.4 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "2"
+			(uuid "7af66e1e-6953-4ca0-996b-53e96901e2b9")
+		)
+		(pin "1"
+			(uuid "c54cf67a-7255-411f-bdba-e0443dd03ee2")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "R_2_2")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:LED_Small")
+		(at 236.22 185.42 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "cf58afd1-ecc3-4724-a4c4-35e39840ef6c")
+		(property "Reference" "L_4_8"
+			(at 238.76 184.0864 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "LED_Small"
+			(at 238.76 186.6264 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "LED_SMD:LED_0805_2012Metric_Pad1.15x1.40mm_HandSolder"
+			(at 236.22 185.42 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 236.22 185.42 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Light emitting diode, small symbol"
+			(at 236.22 185.42 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "c73675b8-f9f8-4eb0-8fab-84e2c6989a7c")
+		)
+		(pin "2"
+			(uuid "4c1805d3-76aa-4caa-bd99-6dbe9437e7bf")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "L_4_8")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R_Small")
+		(at 287.02 138.43 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "d31cb2ff-492b-4e57-ae89-4d4baf437ba3")
+		(property "Reference" "R_1_13"
+			(at 289.56 137.1599 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "560R"
+			(at 289.56 139.6999 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0805_2012Metric"
+			(at 287.02 138.43 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 287.02 138.43 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Resistor, small symbol"
+			(at 287.02 138.43 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "2"
+			(uuid "b56ccc0e-a716-4133-97cb-bf7546082d6f")
+		)
+		(pin "1"
+			(uuid "96286efc-0079-4d4f-b6cd-00bb196b422a")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "R_1_13")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R_Small")
+		(at 266.7 180.34 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "d343a09b-d2f0-4d88-85cf-8222aa55f6c4")
+		(property "Reference" "R_4_11"
+			(at 269.24 179.0699 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "560R"
+			(at 269.24 181.6099 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0805_2012Metric"
+			(at 266.7 180.34 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 266.7 180.34 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Resistor, small symbol"
+			(at 266.7 180.34 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "2"
+			(uuid "eb5e9546-df34-450c-8ea4-25fbe680b19e")
+		)
+		(pin "1"
+			(uuid "e414edae-1eb1-4a0a-8458-ad87032f535c")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "R_4_11")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:D")
+		(at 241.3 35.56 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "d3baa701-71ec-4ec5-b44f-eaecdafe12d7")
+		(property "Reference" "D_1_5"
+			(at 233.68 35.56 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 243.332 36.703 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_SMD:D_1206_3216Metric"
+			(at 241.3 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 241.3 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Diode (Through-hole or 0805)"
+			(at 241.3 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" "C9808"
+			(at 241.3 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "239c2bc9-9064-44dd-ae7f-d3895ac468f8")
+		)
+		(pin "2"
+			(uuid "f65da182-4a5c-45de-8fa7-a257bd578ecc")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "D_1_5")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:D")
+		(at 347.98 68.58 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "d4099929-a480-4be0-b71b-ac24ac5cd847")
+		(property "Reference" "D_3_12"
+			(at 340.36 68.58 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 350.012 69.723 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_SMD:D_1206_3216Metric"
+			(at 347.98 68.58 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 347.98 68.58 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Diode (Through-hole or 0805)"
+			(at 347.98 68.58 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" "C9808"
+			(at 347.98 68.58 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "2eccbed8-e674-47fd-90d5-ab5caa4395f6")
+		)
+		(pin "2"
+			(uuid "544f8a94-8e30-46af-8026-56e93ad9ed77")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "D_3_12")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:LED_Small")
+		(at 205.74 199.39 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "d4818ac6-0072-41be-a836-1013eb2f8331")
+		(property "Reference" "L_5_5"
+			(at 208.28 198.0564 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "LED_Small"
+			(at 208.28 200.5964 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "LED_SMD:LED_0805_2012Metric_Pad1.15x1.40mm_HandSolder"
+			(at 205.74 199.39 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 205.74 199.39 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Light emitting diode, small symbol"
+			(at 205.74 199.39 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "a9c3c1b8-f9a5-4ddd-bd9c-a66221ac497d")
+		)
+		(pin "2"
+			(uuid "d3d2dbe9-b999-4878-8bfc-862b1cd859de")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "L_5_5")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R_Small")
+		(at 307.34 138.43 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "d513c9d9-25ce-448f-89db-e6880082b52f")
+		(property "Reference" "R_1_15"
+			(at 309.88 137.1599 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "560R"
+			(at 309.88 139.6999 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0805_2012Metric"
+			(at 307.34 138.43 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 307.34 138.43 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Resistor, small symbol"
+			(at 307.34 138.43 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "2"
+			(uuid "a193fcce-33ce-4451-b6a5-cc47c9617d40")
+		)
+		(pin "1"
+			(uuid "1d93ad2e-3c7d-4b53-97ac-d346c905af28")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "R_1_15")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 373.38 31.75 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "d529f9a3-147a-4726-b23e-0ac8df1737c3")
+		(property "Reference" "SW_1_14"
+			(at 373.38 26.67 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "Redragon Low Profile switches"
+			(at 373.38 26.8224 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "ProjectLocal:SW_Redragon_LowProfile_PCB_1.00u"
+			(at 373.38 26.67 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 373.38 26.67 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Mechanical Keyboard Switch"
+			(at 373.38 31.75 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" ""
+			(at 373.38 31.75 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "4c08d857-adf3-49ee-a1fd-e58f1974a469")
+		)
+		(pin "2"
+			(uuid "fefbeec4-44cc-4a9d-811c-3aba6fce7e1c")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "SW_1_14")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Connector_Generic:Conn_01x02")
+		(at 49.53 236.22 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom no)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "d5801add-c465-446e-8aca-4e9b93becfcf")
+		(property "Reference" "J2"
+			(at 52.07 236.2199 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "Conn_01x02"
+			(at 52.07 238.7599 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Connector_PinHeader_2.54mm:PinHeader_1x02_P2.54mm_Vertical"
+			(at 49.53 236.22 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 49.53 236.22 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Generic connector, single row, 01x02, script generated (kicad-library-utils/schlib/autogen/connector/)"
+			(at 49.53 236.22 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "c866f07a-a3b5-4241-9093-3d84f7a608fb")
+		)
+		(pin "2"
+			(uuid "9b8089f4-3b2e-4261-a5d1-44797e2aaecd")
+		)
+		(instances
+			(project ""
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "J2")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R_Small")
+		(at 226.06 152.4 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "d5e04a24-a459-4675-bd38-20598be9b442")
+		(property "Reference" "R_2_7"
+			(at 228.6 151.1299 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "560R"
+			(at 228.6 153.6699 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0805_2012Metric"
+			(at 226.06 152.4 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 226.06 152.4 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Resistor, small symbol"
+			(at 226.06 152.4 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "2"
+			(uuid "85f79c74-a6b9-4d20-9ba1-3e20cd59b49b")
+		)
+		(pin "1"
+			(uuid "dfa3e5bc-2197-4143-83d1-03ecc0f93e51")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "R_2_7")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 281.94 64.77 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "d61092b6-69fa-4cdb-8445-e067b60a5edd")
+		(property "Reference" "SW_3_8"
+			(at 281.94 59.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "Redragon Low Profile switches"
+			(at 281.94 59.8424 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "ProjectLocal:SW_Redragon_LowProfile_PCB_1.00u"
+			(at 281.94 59.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 281.94 59.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Mechanical Keyboard Switch"
+			(at 281.94 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" ""
+			(at 281.94 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "59ff47c9-b58b-4ce8-b909-b79869be063f")
+		)
+		(pin "2"
+			(uuid "8722bc18-774d-4327-b336-8ce050b7f55b")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "SW_3_8")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:LED_Small")
+		(at 266.7 185.42 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "d9907f85-a40d-4eee-8615-1641792927ff")
+		(property "Reference" "L_4_11"
+			(at 269.24 184.0864 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "LED_Small"
+			(at 269.24 186.6264 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "LED_SMD:LED_0805_2012Metric_Pad1.15x1.40mm_HandSolder"
+			(at 266.7 185.42 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 266.7 185.42 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Light emitting diode, small symbol"
+			(at 266.7 185.42 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "fb9d6c5d-96ff-43e3-9242-9f6ad9f8c60a")
+		)
+		(pin "2"
+			(uuid "04398705-b0b1-4e0d-bae3-0fd6ca828bd8")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "L_4_11")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R_Small")
+		(at 205.74 194.31 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "da08482d-941b-45f0-a42b-c6a8424c3978")
+		(property "Reference" "R_5_5"
+			(at 208.28 193.0399 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "560R"
+			(at 208.28 195.5799 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0805_2012Metric"
+			(at 205.74 194.31 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 205.74 194.31 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Resistor, small symbol"
+			(at 205.74 194.31 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "2"
+			(uuid "392c9a6e-14c8-4fb8-b30c-6b5aae405fdf")
+		)
+		(pin "1"
+			(uuid "d42b1983-ee4f-4240-9607-78aee27765f2")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "R_5_5")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 220.98 31.75 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "db52f83f-0b67-455d-b57b-e9468b6d21b1")
+		(property "Reference" "SW_1_4"
+			(at 220.98 26.67 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "Redragon Low Profile switches"
+			(at 220.98 26.8224 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "ProjectLocal:SW_Redragon_LowProfile_PCB_1.00u"
+			(at 220.98 26.67 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 220.98 26.67 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Mechanical Keyboard Switch"
+			(at 220.98 31.75 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" ""
+			(at 220.98 31.75 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "b05cf2a7-24de-4676-adb5-1ca6d91343a6")
+		)
+		(pin "2"
+			(uuid "b6a61666-d6a7-4dee-b3ba-b01224a0448e")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "SW_1_4")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Mechanical:MountingHole")
+		(at 276.86 266.7 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "db8f2589-89d9-4b7f-9ecb-33a3e95f2a7f")
+		(property "Reference" "H4"
+			(at 279.4 265.5316 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "MountingHole"
+			(at 279.4 267.843 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "MountingHole:MountingHole_2.2mm_M2_DIN965"
+			(at 276.86 266.7 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 276.86 266.7 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 276.86 266.7 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(instances
+			(project "keyboard-ch552-48"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "H4")
+					(unit 1)
+				)
+			)
+			(project "PyKey40-HS"
+				(path "/6e68f0cd-800e-4167-9553-71fc59da1eeb"
+					(reference "H2")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:LED_Small")
+		(at 236.22 157.48 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "dc168552-27b7-4a02-8c0a-7743edb92a31")
+		(property "Reference" "L_2_8"
+			(at 238.76 156.1464 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "LED_Small"
+			(at 238.76 158.6864 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "LED_SMD:LED_0805_2012Metric_Pad1.15x1.40mm_HandSolder"
+			(at 236.22 157.48 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 236.22 157.48 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Light emitting diode, small symbol"
+			(at 236.22 157.48 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "cabb7620-c42b-4d2e-aa6c-638ee73ae39a")
+		)
+		(pin "2"
+			(uuid "12dc570d-341e-41ab-8f4f-c30c060628d9")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "L_2_8")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Mechanical:MountingHole")
+		(at 276.86 271.78 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "dd7bf95e-5dac-43a6-9cfd-6282a684a01d")
+		(property "Reference" "H5"
+			(at 279.4 270.6116 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "MountingHole"
+			(at 279.4 272.923 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "MountingHole:MountingHole_2.2mm_M2_DIN965"
+			(at 276.86 271.78 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 276.86 271.78 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" ""
+			(at 276.86 271.78 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(instances
+			(project "keyboard-ch552-48"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "H5")
+					(unit 1)
+				)
+			)
+			(project "PyKey40-HS"
+				(path "/6e68f0cd-800e-4167-9553-71fc59da1eeb"
+					(reference "H5")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:LED_Small")
+		(at 165.1 157.48 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "ddcb2d38-bbef-46a4-aa32-68a2b97bd14a")
+		(property "Reference" "L_2_1"
+			(at 167.64 156.1464 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "LED_Small"
+			(at 167.64 158.6864 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "LED_SMD:LED_0805_2012Metric_Pad1.15x1.40mm_HandSolder"
+			(at 165.1 157.48 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 165.1 157.48 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Light emitting diode, small symbol"
+			(at 165.1 157.48 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "675e3e8e-fdef-4fae-94ac-3bec77e82c01")
+		)
+		(pin "2"
+			(uuid "c016c3f7-ec3e-41cf-b1c1-b00b9d63c5e8")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "L_2_1")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R_Small")
+		(at 256.54 180.34 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "dddc61a5-bea4-41ed-a886-dd32b29773bf")
+		(property "Reference" "R_4_10"
+			(at 259.08 179.0699 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "560R"
+			(at 259.08 181.6099 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0805_2012Metric"
+			(at 256.54 180.34 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 256.54 180.34 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Resistor, small symbol"
+			(at 256.54 180.34 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "2"
+			(uuid "6525b2ae-4e96-4a51-958e-2071da47deec")
+		)
+		(pin "1"
+			(uuid "3329a619-fe74-4b74-add1-e3719fa0d414")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "R_4_10")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 297.18 48.26 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "dddfe780-cf03-4bd5-8b94-c2275bf49700")
+		(property "Reference" "SW_2_9"
+			(at 297.18 43.18 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "Redragon Low Profile switches"
+			(at 297.18 43.3324 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "ProjectLocal:SW_Redragon_LowProfile_PCB_1.00u"
+			(at 297.18 43.18 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 297.18 43.18 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Mechanical Keyboard Switch"
+			(at 297.18 48.26 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" ""
+			(at 297.18 48.26 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "a1fd1b94-9368-42e6-9cc8-ec3bdee3b760")
+		)
+		(pin "2"
+			(uuid "306708f8-842c-4468-9ded-c586730d67bc")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "SW_2_9")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 175.26 31.75 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "dea85b80-bbd1-48b8-b02f-07a51890df6e")
+		(property "Reference" "SW_1_1"
+			(at 175.26 26.67 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "Redragon Low Profile switches"
+			(at 175.26 26.8224 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "ProjectLocal:SW_Redragon_LowProfile_PCB_1.00u"
+			(at 175.26 26.67 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 175.26 26.67 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Mechanical Keyboard Switch"
+			(at 175.26 31.75 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" ""
+			(at 175.26 31.75 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "3397927c-bf2f-4bc3-a073-f5ed0f281851")
+		)
+		(pin "2"
+			(uuid "6e0d0265-8473-427b-9313-504d2e72f14c")
+		)
+		(instances
+			(project "keyboard-ch552-48"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "SW_1_1")
+					(unit 1)
+				)
+			)
+			(project "PyKey40-HS"
+				(path "/6e68f0cd-800e-4167-9553-71fc59da1eeb"
+					(reference "SW_1_1")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:D")
+		(at 256.54 68.58 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "dec0eaec-85e7-4a7b-9842-0baa716dcc74")
+		(property "Reference" "D_3_6"
+			(at 248.92 68.58 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 258.572 69.723 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_SMD:D_1206_3216Metric"
+			(at 256.54 68.58 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 256.54 68.58 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Diode (Through-hole or 0805)"
+			(at 256.54 68.58 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" "C9808"
+			(at 256.54 68.58 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "a9e298dd-202f-48aa-ac67-8515e11287f9")
+		)
+		(pin "2"
+			(uuid "37f0665e-62bb-47ab-b342-ff7a270a0d6f")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "D_3_6")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:LED_Small")
+		(at 185.42 171.45 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "e04a41be-53a9-484f-abd4-7fe800fa528a")
+		(property "Reference" "L_3_3"
+			(at 187.96 170.1164 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "LED_Small"
+			(at 187.96 172.6564 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "LED_SMD:LED_0805_2012Metric_Pad1.15x1.40mm_HandSolder"
+			(at 185.42 171.45 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 185.42 171.45 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Light emitting diode, small symbol"
+			(at 185.42 171.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "51817da3-d33c-43c6-8ac6-af28401b0dae")
+		)
+		(pin "2"
+			(uuid "0149fc0c-a757-49b2-95d8-1176806ee429")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "L_3_3")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 251.46 48.26 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "e0d04b9e-a95d-4a2b-9fa4-f6729ec5d9ce")
+		(property "Reference" "SW_2_6"
+			(at 251.46 43.18 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "Redragon Low Profile switches"
+			(at 251.46 43.3324 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "ProjectLocal:SW_Redragon_LowProfile_PCB_1.00u"
+			(at 251.46 43.18 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 251.46 43.18 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Mechanical Keyboard Switch"
+			(at 251.46 48.26 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" ""
+			(at 251.46 48.26 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "9c3afad5-7228-4640-9d52-02dadab00d3d")
+		)
+		(pin "2"
+			(uuid "715fd8ad-e375-48e9-bdb2-77172f44e4ce")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "SW_2_6")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R_Small")
+		(at 287.02 152.4 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "e14ff728-76c4-40bd-a7e3-6a331befde9e")
+		(property "Reference" "R_2_13"
+			(at 289.56 151.1299 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "560R"
+			(at 289.56 153.6699 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0805_2012Metric"
+			(at 287.02 152.4 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 287.02 152.4 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Resistor, small symbol"
+			(at 287.02 152.4 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "2"
+			(uuid "d0ccf358-d415-4d2d-8d8f-27aa676c6de1")
+		)
+		(pin "1"
+			(uuid "35da5865-4ce6-421b-94a7-7319005a2881")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "R_2_13")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 205.74 81.28 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "e27d99ab-1663-4ede-b493-93b8faf6a0fd")
+		(property "Reference" "SW_4_3"
+			(at 205.74 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "Redragon Low Profile switches"
+			(at 205.74 76.3524 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "ProjectLocal:SW_Redragon_LowProfile_PCB_1.00u"
+			(at 205.74 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 205.74 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Mechanical Keyboard Switch"
+			(at 205.74 81.28 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" ""
+			(at 205.74 81.28 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "6a7e7762-1ab3-464e-9e7d-3fe86934a89e")
+		)
+		(pin "2"
+			(uuid "8929d158-05a7-4408-8979-02050506e1e1")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "SW_4_3")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:LED_Small")
+		(at 205.74 143.51 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "e615c450-cea2-4447-a566-6f03317cde13")
+		(property "Reference" "L_1_5"
+			(at 208.28 142.1764 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "LED_Small"
+			(at 208.28 144.7164 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "LED_SMD:LED_0805_2012Metric_Pad1.15x1.40mm_HandSolder"
+			(at 205.74 143.51 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 205.74 143.51 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Light emitting diode, small symbol"
+			(at 205.74 143.51 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "6ef8e605-9f68-4644-9984-cb90874c7391")
+		)
+		(pin "2"
+			(uuid "23db3806-c97e-484c-9dea-6ad23158726f")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "L_1_5")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R_Small")
+		(at 215.9 180.34 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "e6deb71b-eed1-4f85-acd1-a40b34e3c76f")
+		(property "Reference" "R_4_6"
+			(at 218.44 179.0699 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "560R"
+			(at 218.44 181.6099 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0805_2012Metric"
+			(at 215.9 180.34 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 215.9 180.34 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Resistor, small symbol"
+			(at 215.9 180.34 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "2"
+			(uuid "5aec94fb-794e-4c6e-ad34-dfca1dd11fbb")
+		)
+		(pin "1"
+			(uuid "e1c8d143-d0e3-4eff-ae5f-22d27aa54f53")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "R_4_6")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:LED_Small")
+		(at 307.34 171.45 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "e805cbe2-710b-4c11-ad73-ea939614535f")
+		(property "Reference" "L_3_15"
+			(at 309.88 170.1164 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "LED_Small"
+			(at 309.88 172.6564 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "LED_SMD:LED_0805_2012Metric_Pad1.15x1.40mm_HandSolder"
+			(at 307.34 171.45 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 307.34 171.45 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Light emitting diode, small symbol"
+			(at 307.34 171.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "516dae17-c8e5-4cbc-8580-45990ccf0718")
+		)
+		(pin "2"
+			(uuid "fbc0f33c-acb0-4271-b4bc-a0653f088e86")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "L_3_15")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:D")
+		(at 332.74 101.6 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "e8bf8282-df50-4fab-90e7-cc5a6f1d6b1e")
+		(property "Reference" "D_5_11"
+			(at 325.12 101.6 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 334.772 102.743 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_SMD:D_1206_3216Metric"
+			(at 332.74 101.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 332.74 101.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Diode (Through-hole or 0805)"
+			(at 332.74 101.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" "C9808"
+			(at 332.74 101.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "c99b74b8-8bbd-40a2-ba2c-1c6c44fe0949")
+		)
+		(pin "2"
+			(uuid "231be756-35dd-46d0-b5ac-cfeb7ca36328")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "D_5_11")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 175.26 81.28 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "eafcb2ec-c334-4cca-a503-42913c07ca14")
+		(property "Reference" "SW_4_1"
+			(at 175.26 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "Redragon Low Profile switches"
+			(at 175.26 76.3524 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "ProjectLocal:SW_Redragon_LowProfile_PCB_1.00u"
+			(at 175.26 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 175.26 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Mechanical Keyboard Switch"
+			(at 175.26 81.28 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" ""
+			(at 175.26 81.28 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "5eae3a30-e450-4ffb-a656-f5822653cdd4")
+		)
+		(pin "2"
+			(uuid "0cb0fdf1-3463-4f86-80ae-6b18f5c65620")
+		)
+		(instances
+			(project "keyboard-ch552-48"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "SW_4_1")
+					(unit 1)
+				)
+			)
+			(project "PyKey40-HS"
+				(path "/6e68f0cd-800e-4167-9553-71fc59da1eeb"
+					(reference "SW_4_1")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R_Small")
+		(at 276.86 152.4 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "eb30eef7-3217-4953-93b9-ba617b93fe9e")
+		(property "Reference" "R_2_12"
+			(at 279.4 151.1299 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "560R"
+			(at 279.4 153.6699 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0805_2012Metric"
+			(at 276.86 152.4 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 276.86 152.4 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Resistor, small symbol"
+			(at 276.86 152.4 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "2"
+			(uuid "458eaf74-e2b5-4ee1-8a3b-48ff28edef77")
+		)
+		(pin "1"
+			(uuid "735b10fc-f89f-4bfb-ab71-ecd9125ce7f6")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "R_2_12")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:LED_Small")
+		(at 175.26 171.45 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "eb895729-a156-41c6-b329-d1b0de150056")
+		(property "Reference" "L_3_2"
+			(at 177.8 170.1164 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "LED_Small"
+			(at 177.8 172.6564 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "LED_SMD:LED_0805_2012Metric_Pad1.15x1.40mm_HandSolder"
+			(at 175.26 171.45 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 175.26 171.45 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Light emitting diode, small symbol"
+			(at 175.26 171.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "d5e33217-98d5-42e7-a691-6bea49b3df03")
+		)
+		(pin "2"
+			(uuid "061275b0-dee7-4dae-98cb-77b9553adc49")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "L_3_2")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R_Small")
+		(at 297.18 194.31 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "ebfc7103-f124-4a8e-9344-ed7263d2d3db")
+		(property "Reference" "R_5_14"
+			(at 299.72 193.0399 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "560R"
+			(at 299.72 195.5799 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0805_2012Metric"
+			(at 297.18 194.31 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 297.18 194.31 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Resistor, small symbol"
+			(at 297.18 194.31 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "2"
+			(uuid "6a979303-fad7-4439-b0a4-832666f4c17d")
+		)
+		(pin "1"
+			(uuid "a56db91d-a8bd-46bf-9bc4-f47056c8526c")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "R_5_14")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:LED_Small")
+		(at 297.18 185.42 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "ed4e7868-ca43-4728-ab5c-f21dc0c5e9eb")
+		(property "Reference" "L_4_14"
+			(at 299.72 184.0864 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "LED_Small"
+			(at 299.72 186.6264 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "LED_SMD:LED_0805_2012Metric_Pad1.15x1.40mm_HandSolder"
+			(at 297.18 185.42 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 297.18 185.42 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Light emitting diode, small symbol"
+			(at 297.18 185.42 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "e1711564-9af1-4ed5-adf3-48ddc45d71bd")
+		)
+		(pin "2"
+			(uuid "ac7be137-33d8-4a4b-81b9-5b12fcee9d87")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "L_4_14")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 388.62 81.28 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "ed70c7fb-8c00-412b-8efa-da50830eca0b")
+		(property "Reference" "SW_4_15"
+			(at 388.62 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "Redragon Low Profile switches"
+			(at 388.62 76.3524 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "ProjectLocal:SW_Redragon_LowProfile_PCB_1.00u"
+			(at 388.62 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 388.62 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Mechanical Keyboard Switch"
+			(at 388.62 81.28 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" ""
+			(at 388.62 81.28 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "faf66917-4844-4741-96a9-4aaf398af448")
+		)
+		(pin "2"
+			(uuid "776bdcec-c549-44e9-8443-8ef17579b32c")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "SW_4_15")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R_Small")
+		(at 256.54 194.31 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "edbf0743-e1d7-46b1-95c4-bac372a24caa")
+		(property "Reference" "R_5_10"
+			(at 259.08 193.0399 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "560R"
+			(at 259.08 195.5799 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0805_2012Metric"
+			(at 256.54 194.31 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 256.54 194.31 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Resistor, small symbol"
+			(at 256.54 194.31 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "2"
+			(uuid "cb1b85f9-c786-4ed4-bcdc-4951fc378782")
+		)
+		(pin "1"
+			(uuid "19073b84-02be-48e9-9bdd-da91d76066ff")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "R_5_10")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 281.94 31.75 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "ee36c192-d771-45e5-bfb3-cfb8a68c56ac")
+		(property "Reference" "SW_1_8"
+			(at 281.94 26.67 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "Redragon Low Profile switches"
+			(at 281.94 26.8224 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "ProjectLocal:SW_Redragon_LowProfile_PCB_1.00u"
+			(at 281.94 26.67 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 281.94 26.67 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Mechanical Keyboard Switch"
+			(at 281.94 31.75 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" ""
+			(at 281.94 31.75 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "f9e384fe-c379-466f-af43-46cd073a3897")
+		)
+		(pin "2"
+			(uuid "4a735465-a7b1-4948-a7e7-9bd9f3d1df22")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "SW_1_8")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:LED_Small")
+		(at 195.58 185.42 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "ef511c50-5b92-4355-aaa5-c0564d4e34e4")
+		(property "Reference" "L_4_4"
+			(at 198.12 184.0864 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "LED_Small"
+			(at 198.12 186.6264 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "LED_SMD:LED_0805_2012Metric_Pad1.15x1.40mm_HandSolder"
+			(at 195.58 185.42 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 195.58 185.42 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Light emitting diode, small symbol"
+			(at 195.58 185.42 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "9f8e4d5a-caee-4c98-87f1-8dff49d16716")
+		)
+		(pin "2"
+			(uuid "1065c7ec-7cb9-407e-b0bc-b289222558ac")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "L_4_4")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 358.14 97.79 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "ef532c9b-0d10-4eec-a8f3-e719209c95cb")
+		(property "Reference" "SW_5_13"
+			(at 358.14 92.71 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "Redragon Low Profile switches"
+			(at 358.14 92.8624 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "ProjectLocal:SW_Redragon_LowProfile_PCB_1.00u"
+			(at 358.14 92.71 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 358.14 92.71 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Mechanical Keyboard Switch"
+			(at 358.14 97.79 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" ""
+			(at 358.14 97.79 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "2e8b735e-66da-49dc-8977-e42d47db0fc9")
+		)
+		(pin "2"
+			(uuid "987a12e4-515f-4a8d-ad7c-208915035f54")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "SW_5_13")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:D")
+		(at 241.3 85.09 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "efdc542a-f3c2-4cd9-84ad-f527fbc09457")
+		(property "Reference" "D_4_5"
+			(at 233.68 85.09 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 243.332 86.233 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_SMD:D_1206_3216Metric"
+			(at 241.3 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 241.3 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Diode (Through-hole or 0805)"
+			(at 241.3 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" "C9808"
+			(at 241.3 85.09 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "9122e76c-0ba8-48e2-84d9-6cb22e914a9a")
+		)
+		(pin "2"
+			(uuid "a1e344ea-d156-4d9a-982b-16f460bc1718")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "D_4_5")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R_Small")
+		(at 175.26 138.43 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "f0218e43-5d18-4d74-a1ae-442dbbf718de")
+		(property "Reference" "R_1_2"
+			(at 177.8 137.1599 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "560R"
+			(at 177.8 139.6999 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0805_2012Metric"
+			(at 175.26 138.43 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 175.26 138.43 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Resistor, small symbol"
+			(at 175.26 138.43 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "2"
+			(uuid "4d3821fe-0459-4cdc-b58c-150fa35ed52d")
+		)
+		(pin "1"
+			(uuid "7a670867-d62b-4061-9243-95841ce1c085")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "R_1_2")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:LED_Small")
+		(at 215.9 185.42 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "f052fdd1-a924-4c05-bf15-8e37eb42710f")
+		(property "Reference" "L_4_6"
+			(at 218.44 184.0864 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "LED_Small"
+			(at 218.44 186.6264 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "LED_SMD:LED_0805_2012Metric_Pad1.15x1.40mm_HandSolder"
+			(at 215.9 185.42 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 215.9 185.42 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Light emitting diode, small symbol"
+			(at 215.9 185.42 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "6661bb4e-d3b5-497c-996f-313b817cae7e")
+		)
+		(pin "2"
+			(uuid "6e6a944f-1e6f-46dd-ab46-e238777afa01")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "L_4_6")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 236.22 64.77 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "f1525813-121d-4983-9076-7bd29f23f4f9")
+		(property "Reference" "SW_3_5"
+			(at 236.22 59.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "Redragon Low Profile switches"
+			(at 236.22 59.8424 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "ProjectLocal:SW_Redragon_LowProfile_PCB_1.00u"
+			(at 236.22 59.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 236.22 59.69 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Mechanical Keyboard Switch"
+			(at 236.22 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" ""
+			(at 236.22 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "cd072494-a02c-433a-86d8-9490f89256b0")
+		)
+		(pin "2"
+			(uuid "3333fe0e-a7a5-4394-835d-e66a5b3be7de")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "SW_3_5")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:D")
+		(at 180.34 35.56 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "f2ca1d6e-b07c-4ef1-b7ce-ca22136cc034")
+		(property "Reference" "D_1_1"
+			(at 172.72 35.56 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 182.372 36.703 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_SMD:D_1206_3216Metric"
+			(at 180.34 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 180.34 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Diode (Through-hole or 0805)"
+			(at 180.34 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" "C9808"
+			(at 180.34 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "b3fe1af6-0af3-4e18-a5e6-6bcbfa66297f")
+		)
+		(pin "2"
+			(uuid "8d94252f-d796-4406-a957-df02ee471c3f")
+		)
+		(instances
+			(project "keyboard-ch552-48"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "D_1_1")
+					(unit 1)
+				)
+			)
+			(project "PyKey40-HS"
+				(path "/6e68f0cd-800e-4167-9553-71fc59da1eeb"
+					(reference "D_1_1")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:LED_Small")
+		(at 175.26 157.48 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "f2e3372d-5468-43a2-9030-5a39208e3f8a")
+		(property "Reference" "L_2_2"
+			(at 177.8 156.1464 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "LED_Small"
+			(at 177.8 158.6864 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "LED_SMD:LED_0805_2012Metric_Pad1.15x1.40mm_HandSolder"
+			(at 175.26 157.48 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 175.26 157.48 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Light emitting diode, small symbol"
+			(at 175.26 157.48 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "a801f594-2c46-42c0-8681-ad760a593e7e")
+		)
+		(pin "2"
+			(uuid "3ef9099f-6dc6-4bbc-8cd4-b0122a5fb535")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "L_2_2")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R_Small")
+		(at 307.34 180.34 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "f338572b-20b9-4f94-a0db-0f48741ea756")
+		(property "Reference" "R_4_15"
+			(at 309.88 179.0699 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "560R"
+			(at 309.88 181.6099 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0805_2012Metric"
+			(at 307.34 180.34 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 307.34 180.34 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Resistor, small symbol"
+			(at 307.34 180.34 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "2"
+			(uuid "14a726ed-4f74-4afa-b1db-ddde99c4e73f")
+		)
+		(pin "1"
+			(uuid "131f4992-4769-4fb4-a5a0-1e45dac94d65")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "R_4_15")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R_Small")
+		(at 276.86 180.34 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "f36e9d72-9bc3-4c2a-9275-4cb0741723c6")
+		(property "Reference" "R_4_12"
+			(at 279.4 179.0699 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "560R"
+			(at 279.4 181.6099 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0805_2012Metric"
+			(at 276.86 180.34 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 276.86 180.34 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Resistor, small symbol"
+			(at 276.86 180.34 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "2"
+			(uuid "4c61a013-7181-4df0-960d-dabdccb873df")
+		)
+		(pin "1"
+			(uuid "3ad7ed41-a481-49b9-9c05-453d18078431")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "R_4_12")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R_Small")
+		(at 185.42 138.43 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "f4cd5910-af49-4c7e-ace1-3bfc7875c43a")
+		(property "Reference" "R_1_3"
+			(at 187.96 137.1599 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "560R"
+			(at 187.96 139.6999 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0805_2012Metric"
+			(at 185.42 138.43 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 185.42 138.43 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Resistor, small symbol"
+			(at 185.42 138.43 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "2"
+			(uuid "b633f4d7-5e4e-4a2d-943e-e19a07c202be")
+		)
+		(pin "1"
+			(uuid "6318e405-2b3b-448c-9345-5de13c3b98c1")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "R_1_3")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:LED_Small")
+		(at 165.1 199.39 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "f51e01b1-0fa6-4339-9d4b-52333a0eaa81")
+		(property "Reference" "L_5_1"
+			(at 167.64 198.0564 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "LED_Small"
+			(at 167.64 200.5964 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "LED_SMD:LED_0805_2012Metric_Pad1.15x1.40mm_HandSolder"
+			(at 165.1 199.39 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 165.1 199.39 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Light emitting diode, small symbol"
+			(at 165.1 199.39 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "b4a0b0c1-a595-419c-949e-2fb02adc9f4e")
+		)
+		(pin "2"
+			(uuid "890d87ad-f7b8-4ad9-a53f-515bbda10bfb")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "L_5_1")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:LED_Small")
+		(at 307.34 199.39 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "f59a7e67-cd1b-4f5d-86fc-eb354a59bb31")
+		(property "Reference" "L_5_15"
+			(at 309.88 198.0564 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "LED_Small"
+			(at 309.88 200.5964 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "LED_SMD:LED_0805_2012Metric_Pad1.15x1.40mm_HandSolder"
+			(at 307.34 199.39 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 307.34 199.39 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Light emitting diode, small symbol"
+			(at 307.34 199.39 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "b21f7e0c-c1e2-4485-a86a-29f1e7d15e40")
+		)
+		(pin "2"
+			(uuid "bf3d9265-58bb-4c95-81da-461d295c94e6")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "L_5_15")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:LED_Small")
+		(at 226.06 185.42 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "f70eaf47-dc5a-4a4b-97d1-5009fc501626")
+		(property "Reference" "L_4_7"
+			(at 228.6 184.0864 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "LED_Small"
+			(at 228.6 186.6264 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "LED_SMD:LED_0805_2012Metric_Pad1.15x1.40mm_HandSolder"
+			(at 226.06 185.42 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 226.06 185.42 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Light emitting diode, small symbol"
+			(at 226.06 185.42 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "6024df93-e134-43ed-a846-56ba6c08717b")
+		)
+		(pin "2"
+			(uuid "9df6abcd-0f30-4db2-ba9a-8e9adc6022ef")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "L_4_7")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 236.22 48.26 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "f8433374-f61a-4be1-8ca7-c6bab9ba8436")
+		(property "Reference" "SW_2_5"
+			(at 236.22 43.18 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "Redragon Low Profile switches"
+			(at 236.22 43.3324 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "ProjectLocal:SW_Redragon_LowProfile_PCB_1.00u"
+			(at 236.22 43.18 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 236.22 43.18 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Mechanical Keyboard Switch"
+			(at 236.22 48.26 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" ""
+			(at 236.22 48.26 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "4c96e0ba-8989-4ca9-9f86-398bd4cd4c9b")
+		)
+		(pin "2"
+			(uuid "c9c17a1c-a3a2-4d45-9e8f-e65896c2d599")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "SW_2_5")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 220.98 81.28 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "f8b902c4-9dba-499f-8eda-95722e9894c9")
+		(property "Reference" "SW_4_4"
+			(at 220.98 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "Redragon Low Profile switches"
+			(at 220.98 76.3524 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "ProjectLocal:SW_Redragon_LowProfile_PCB_1.00u"
+			(at 220.98 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 220.98 76.2 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Mechanical Keyboard Switch"
+			(at 220.98 81.28 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" ""
+			(at 220.98 81.28 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "5554e1a5-9c80-4821-9f4f-f7836a987929")
+		)
+		(pin "2"
+			(uuid "d0de28ee-1c42-4310-b694-a1e303c3fc72")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "SW_4_4")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Switch:SW_Push")
+		(at 312.42 31.75 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "f98eacb1-7d99-48ce-8776-37022813048f")
+		(property "Reference" "SW_1_10"
+			(at 312.42 26.67 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "Redragon Low Profile switches"
+			(at 312.42 26.8224 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "ProjectLocal:SW_Redragon_LowProfile_PCB_1.00u"
+			(at 312.42 26.67 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 312.42 26.67 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Mechanical Keyboard Switch"
+			(at 312.42 31.75 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" ""
+			(at 312.42 31.75 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "956dd406-5cb3-4211-bc12-2e501feb34f9")
+		)
+		(pin "2"
+			(uuid "f18bc67c-7074-44b2-ab83-c07d71e1ef5e")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "SW_1_10")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:D")
+		(at 332.74 52.07 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "fa7d4035-110d-495d-9717-bb48c9a81639")
+		(property "Reference" "D_2_11"
+			(at 325.12 52.07 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 334.772 53.213 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_SMD:D_1206_3216Metric"
+			(at 332.74 52.07 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 332.74 52.07 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Diode (Through-hole or 0805)"
+			(at 332.74 52.07 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" "C9808"
+			(at 332.74 52.07 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "101673e1-7b82-43bd-af79-c65c7464aa4f")
+		)
+		(pin "2"
+			(uuid "43c73f1b-d273-4906-b506-75af059b99d6")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "D_2_11")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:LED_Small")
+		(at 215.9 171.45 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "fc0379a8-8026-4912-a364-c10e7e605eb7")
+		(property "Reference" "L_3_6"
+			(at 218.44 170.1164 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "LED_Small"
+			(at 218.44 172.6564 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "LED_SMD:LED_0805_2012Metric_Pad1.15x1.40mm_HandSolder"
+			(at 215.9 171.45 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 215.9 171.45 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Light emitting diode, small symbol"
+			(at 215.9 171.45 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "f12afdc9-b8f3-452d-9d2a-5e371c8a4259")
+		)
+		(pin "2"
+			(uuid "132e9aef-5283-4de9-9581-da9fadc3b3c1")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "L_3_6")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:LED_Small")
+		(at 256.54 199.39 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "fd618202-8190-4cb6-8714-e8cee1ae1147")
+		(property "Reference" "L_5_10"
+			(at 259.08 198.0564 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "LED_Small"
+			(at 259.08 200.5964 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "LED_SMD:LED_0805_2012Metric_Pad1.15x1.40mm_HandSolder"
+			(at 256.54 199.39 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 256.54 199.39 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Light emitting diode, small symbol"
+			(at 256.54 199.39 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "e486fbfc-858f-44b0-86d4-e9f7dd0eb1d9")
+		)
+		(pin "2"
+			(uuid "e0e5e718-6996-42c6-8e12-215c29bd2d61")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "L_5_10")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R_Small")
+		(at 165.1 180.34 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "fddd6661-6698-4b2d-87a5-1d8ac33f2672")
+		(property "Reference" "R_4_1"
+			(at 167.64 179.0699 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "560R"
+			(at 167.64 181.6099 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_0805_2012Metric"
+			(at 165.1 180.34 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 165.1 180.34 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Resistor, small symbol"
+			(at 165.1 180.34 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "2"
+			(uuid "863cdfea-7e1e-4a33-b0e4-88d4061884e2")
+		)
+		(pin "1"
+			(uuid "a5da0393-d1ab-4f61-a5ea-e10f63263300")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "R_4_1")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:D")
+		(at 363.22 35.56 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "fe819b05-8826-4b10-9e21-b107fc7409cb")
+		(property "Reference" "D_1_13"
+			(at 355.6 35.56 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Value" "1N4148"
+			(at 365.252 36.703 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+				(hide yes)
+			)
+		)
+		(property "Footprint" "Diode_SMD:D_1206_3216Metric"
+			(at 363.22 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 363.22 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Diode (Through-hole or 0805)"
+			(at 363.22 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "LCSC" "C9808"
+			(at 363.22 35.56 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "5dcc17ad-7e52-4dc9-88df-bce2022a4166")
+		)
+		(pin "2"
+			(uuid "7613d3b5-2c54-4fcd-9534-41a1879a8fa9")
+		)
+		(instances
+			(project "keyboard-ch32x-75"
+				(path "/491af640-c615-48ab-84d8-9b166bc1ab37"
+					(reference "D_1_13")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(sheet_instances
+		(path "/"
+			(page "1")
+		)
+	)
+)

--- a/scripts/kicad_helpers/ch32x_75.py
+++ b/scripts/kicad_helpers/ch32x_75.py
@@ -1,0 +1,172 @@
+# Helper script for CH32X-75
+# to be used with Kicad scripting console.
+#
+# Use with:
+#    import sys
+#    sys.path.append('/Users/richardgoulter/github/keyboard-labs--ch32x/scripts/kicad_helpers')
+#    import pykey40 as p
+
+# pcbnew.GetBoard().FindFootprintByReference("J2").SetPosition(pcbnew.VECTOR2I_MM(100, 100))
+
+import pcbnew
+from pcbnew import VECTOR2I_MM
+
+import kicad_common
+
+
+ROWS = 5
+COLS = 15
+
+
+def position_SWs():
+    kicad_common.position_on_grid(
+        ref_prefix = "SW",
+        rows = ROWS,
+        cols = COLS,
+    )
+    kicad_common.set_rotations(
+        ref_prefix = "SW",
+        rows = ROWS,
+        cols = COLS,
+        rotation_degrees = 0
+    )
+
+def position_Rs():
+    kicad_common.position_on_grid(
+        ref_prefix = "R",
+        rows = ROWS,
+        cols = COLS,
+        except_refs = ["R_1_2", "R_3_7"],
+    )
+    kicad_common.set_rotations(
+        ref_prefix = "R",
+        rows = ROWS,
+        cols = COLS,
+        except_refs = ["R_1_2", "R_3_7"],
+        rotation_degrees = -90
+    )
+
+def position_Hs():
+    # Get position footprint by ref SW_1_1
+    sw_1_1 = pcbnew.GetBoard().FindFootprintByReference("SW_1_1")
+    sw_1_1_pos = sw_1_1.GetPosition()
+
+    mounts = [
+        ("H1", (0.5, 0.5)),
+        ("H2", (15 - 1 - 0.5, 0.5)),
+        ("H3", (7, 1.515)),
+        ("H4", (0.5, 3.5)),
+        ("H5", (15 - 1 - 0.5, 3.5)),
+    ]
+
+    # set position of all SWs relative to SW_1_1
+    for (ref, (c, r)) in mounts:
+        fp = pcbnew.GetBoard().FindFootprintByReference(ref)
+        if fp is None:
+            continue
+        fp.SetPosition(sw_1_1_pos + VECTOR2I_MM(19.05 * c, 19.05 * r))
+
+def position_Ls():
+    kicad_common.position_on_grid(
+        ref_prefix = "L",
+        rows = ROWS,
+        cols = COLS,
+    )
+    kicad_common.set_rotations(
+        ref_prefix = "L",
+        rows = ROWS,
+        cols = COLS,
+        rotation_degrees = 180
+    )
+
+# position the Ds
+#
+# Ds are spaced apart by 19.05mm in rows and columns
+# starting from where D_1_1 and D_1_2 are placed.
+def position_Ds():
+    # kicad_common.position_pairs_on_grid(
+    #     ref_prefix = "D",
+    #     rows = ROWS,
+    #     cols = COLS,
+    #     col_spacing_mm = 19.05,
+    #     row_spacing_mm = 19.05
+    # )
+    kicad_common.position_on_grid(
+        ref_prefix = "D",
+        rows = ROWS,
+        cols = COLS,
+        except_refs = ["D_1_2", "D_1_5", "D_1_6", "D_1_9", "D_1_10", "D_3_7"],
+    )
+    kicad_common.set_rotations(
+        ref_prefix = "D",
+        rows = ROWS,
+        cols = COLS,
+        rotation_degrees = 270
+    )
+
+
+def position_all():
+    position_SWs()
+    position_Ds()
+    position_Rs()
+    position_Hs()
+    position_Ls()
+    pcbnew.Refresh()
+
+def hide_d_labels():
+    kicad_common.hide_references(
+        refs = kicad_common.grid_refs(
+            ref_prefix = "D",
+            rows = ROWS,
+            cols = COLS,
+        ),
+    )
+    pcbnew.Refresh()
+
+def hide_sw_labels():
+    kicad_common.hide_references(
+        refs = kicad_common.grid_refs(
+            ref_prefix = "SW",
+            rows = ROWS,
+            cols = COLS,
+        ),
+    )
+    pcbnew.Refresh()
+
+# H1-5
+def hide_h_labels():
+    # H1-19, because there are surely less than 20 H footprints.
+    refs = ["H" + str(n) for n in range(1, 20)]
+    kicad_common.hide_references(refs = refs)
+    pcbnew.Refresh()
+
+def hide_l_labels():
+    kicad_common.hide_references(
+        refs = kicad_common.grid_refs(
+            ref_prefix = "L",
+            rows = ROWS,
+            cols = COLS,
+        ),
+    )
+    pcbnew.Refresh()
+
+def hide_r_labels():
+    kicad_common.hide_references(
+        refs = kicad_common.grid_refs(
+            ref_prefix = "R",
+            rows = ROWS,
+            cols = COLS,
+        ),
+    )
+    pcbnew.Refresh()
+
+def hide_labels():
+    hide_d_labels()
+    hide_sw_labels()
+    hide_h_labels()
+    hide_l_labels()
+    hide_r_labels()
+
+def fixup():
+    position_all()
+    hide_labels()

--- a/scripts/kicad_helpers/kicad_common.py
+++ b/scripts/kicad_helpers/kicad_common.py
@@ -224,8 +224,9 @@ def hide_fp_texts(
         if footprint is None:
             continue
         for t in footprint.GraphicalItems():
-            if isinstance(t, pcbnew.FP_TEXT) and t.GetLayerName() in layer_names:
-                t.SetVisible(False)
+            pass
+            ## if isinstance(t, pcbnew.FP_TEXT) and t.GetLayerName() in layer_names:
+            ##     t.SetVisible(False)
 
 
 def delete_fp_shapes(


### PR DESCRIPTION
Uses the LQFP-48 CH32X MCU for a 5x15 ortho board, for GH-60 cases, using Redragon Low Profile switches. With 0805 LED backlighting.

I've sent this for fabrication.