### PR TITLE
CAD: 3DP Case: increase margin for USB connector

### DIFF
--- a/cad/keyboard_case/3dp-constants.scad
+++ b/cad/keyboard_case/3dp-constants.scad
@@ -1,7 +1,7 @@
 // Constants for Cases for 3D Printing
 
 // For 3D Printing, make the holes a bit bigger
-USB_CONNECTOR_HOLE_WIDTH_3DP = 12 + 1;
+USB_CONNECTOR_HOLE_WIDTH_3DP = 12 + 3;
 
 // For 3D Printing, using M2x3mm knurled threaded inserts.
 MOUNT_HOLE_POST_DIA_3DP = 8;

--- a/cad/keyboard_plates/keyboard-pykey40/jj40_constants.scad
+++ b/cad/keyboard_plates/keyboard-pykey40/jj40_constants.scad
@@ -21,6 +21,7 @@ PCB_SW_1_1_POSITION = [7.5, 8.5];
 SWITCH_GRID_UNIT = 19.05;
 
 PCB_USB_CONNECTOR_MID_X = PCB_SW_1_1_POSITION[0] + 1.5 * SWITCH_GRID_UNIT;
+echo("PCB_USB_CONNECTOR_MID_X (relative to PCB origin)", PCB_USB_CONNECTOR_MID_X);
 
 switch_grid_cols = 12;
 switch_grid_rows = 4;


### PR DESCRIPTION
The margin around the USB connector for the 3DP case is pretty close. It's better to increase it a bit.

Though, I haven't printed a case with this new adjustment.