### PR TITLE
Update nix kibot package for kicad 9

### DIFF
--- a/nix/pkgs/kibot/default.nix
+++ b/nix/pkgs/kibot/default.nix
@@ -13,16 +13,16 @@
         kicad
         ;
     },
-  pcbdraw ?
-    import ../pcbdraw {
-      inherit
-        lib
-        fetchFromGitHub
-        python3Packages
-        python3
-        kicad
-        ;
-    },
+  # pcbdraw ?
+  #   import ../pcbdraw {
+  #     inherit
+  #       lib
+  #       fetchFromGitHub
+  #       python3Packages
+  #       python3
+  #       kicad
+  #       ;
+  #   },
   qrcodegenPythonModule ?
     import ../pythonPackages/qrcodegen {
       inherit
@@ -58,7 +58,7 @@ in
       kicadPythonModule
       lark
       markdown2
-      pcbdraw
+      # pcbdraw
       pyyaml
       qrcodegenPythonModule
       requests

--- a/nix/pkgs/kibot/default.nix
+++ b/nix/pkgs/kibot/default.nix
@@ -41,7 +41,7 @@
 in
   python3Packages.buildPythonApplication rec {
     pname = "kibot";
-    version = "1.7.0";
+    version = "1.8.4";
 
     pyproject = true;
     build-system = [python3Packages.setuptools];
@@ -69,6 +69,6 @@ in
 
     src = python3Packages.fetchPypi {
       inherit pname version;
-      sha256 = "sha256-/eaQXggNam/Wv/us7jahVklCm5Agm4+aQvsbSzoTwEY";
+      sha256 = "sha256-ko649d7JPbRJj2OmZ9mVwB5TLmXyZ0sEINWUg4MRwIE=";
     };
   }

--- a/nix/pkgs/kibot/default.nix
+++ b/nix/pkgs/kibot/default.nix
@@ -57,6 +57,7 @@ in
       kiauto
       kicadPythonModule
       lark
+      lxml
       markdown2
       # pcbdraw
       pyyaml

--- a/pcb/config.kibot.yaml
+++ b/pcb/config.kibot.yaml
@@ -62,22 +62,22 @@ outputs:
       use_gerber_net_attributes: false
       use_gerber_x2_attributes: false
 
-  - name: "pcbdraw_top"
-    type: pcbdraw
-    dir: "+docs/images/"
-    comment: "Pretty 2D render of the top of the PCB, using pcbdraw"
-    options:
-      # Include revision (-%r) to the output
-      output: "%f-%r-%i%v.%x"
+  # - name: "pcbdraw_top"
+  #   type: pcbdraw
+  #   dir: "+docs/images/"
+  #   comment: "Pretty 2D render of the top of the PCB, using pcbdraw"
+  #   options:
+  #     # Include revision (-%r) to the output
+  #     output: "%f-%r-%i%v.%x"
 
-  - name: "pcbdraw_bottom"
-    type: pcbdraw
-    comment: "Pretty 2D render of the bottom of the PCB, using pcbdraw"
-    dir: "+docs/images/"
-    options:
-      bottom: true
-      # Include revision (-%r) to the output
-      output: "%f-%r-%i%v.%x"
+  # - name: "pcbdraw_bottom"
+  #   type: pcbdraw
+  #   comment: "Pretty 2D render of the bottom of the PCB, using pcbdraw"
+  #   dir: "+docs/images/"
+  #   options:
+  #     bottom: true
+  #     # Include revision (-%r) to the output
+  #     output: "%f-%r-%i%v.%x"
 
   - name: "schematic_print"
     type: pdf_sch_print

--- a/pcb/shell.nix
+++ b/pcb/shell.nix
@@ -6,7 +6,7 @@
   # to be able to show 3D preview.
   kibot ? pkgs.callPackage ../nix/pkgs/kibot {},
   pcbdraw ? pkgs.callPackage ../nix/pkgs/pcbdraw {},
-  recordmydesktop ? pkgs.callPackage ../nix/pkgs/recordmydesktop {},
+  # recordmydesktop ? pkgs.callPackage ../nix/pkgs/recordmydesktop {},
 }:
 pkgs.mkShell {
   # The environment variables KiBot uses for its
@@ -40,7 +40,7 @@ pkgs.mkShell {
     interactive-html-bom
     kibot
     pcbdraw
-    recordmydesktop
+    # recordmydesktop
     turbovnc
     virtualgl
     wmctrl

--- a/pcb/shell.nix
+++ b/pcb/shell.nix
@@ -5,7 +5,7 @@
   # Kludge: on NixOS desktop, need virtualgl for the pcbnew
   # to be able to show 3D preview.
   kibot ? pkgs.callPackage ../nix/pkgs/kibot {},
-  pcbdraw ? pkgs.callPackage ../nix/pkgs/pcbdraw {},
+  # pcbdraw ? pkgs.callPackage ../nix/pkgs/pcbdraw {},
   # recordmydesktop ? pkgs.callPackage ../nix/pkgs/recordmydesktop {},
 }:
 pkgs.mkShell {
@@ -39,7 +39,7 @@ pkgs.mkShell {
     fluxbox
     interactive-html-bom
     kibot
-    pcbdraw
+    # pcbdraw
     # recordmydesktop
     turbovnc
     virtualgl


### PR DESCRIPTION
In order to work with kicad 9, kibot needs to be updated.

`pcbdraw` needs some further patches to work with kicad 9 (PRs have been made against upstream). Though, it also depends on an older version of `mistune` than `nixpkgs` offers, so that'll need to be provided, too. -- For now, am disabling use of pcbdraw.