### PR TITLE
Restore pcbdraw

### DIFF
--- a/nix/pkgs/kibot/default.nix
+++ b/nix/pkgs/kibot/default.nix
@@ -13,16 +13,16 @@
         kicad
         ;
     },
-  # pcbdraw ?
-  #   import ../pcbdraw {
-  #     inherit
-  #       lib
-  #       fetchFromGitHub
-  #       python3Packages
-  #       python3
-  #       kicad
-  #       ;
-  #   },
+  pcbdraw ?
+    import ../pcbdraw {
+      inherit
+        lib
+        fetchFromGitHub
+        python3Packages
+        python3
+        kicad
+        ;
+    },
   qrcodegenPythonModule ?
     import ../pythonPackages/qrcodegen {
       inherit
@@ -59,7 +59,7 @@ in
       lark
       lxml
       markdown2
-      # pcbdraw
+      pcbdraw
       pyyaml
       qrcodegenPythonModule
       requests

--- a/nix/pkgs/pcbdraw/default.nix
+++ b/nix/pkgs/pcbdraw/default.nix
@@ -4,7 +4,7 @@
   python3Packages,
   python3,
   kicad,
-  pcbnewTransition ? import ../pythonPackages/pcbnewTransition {inherit kicad python3 python3Packages;},
+  mistune ? import ../pythonPackages/mistune {inherit python3Packages;},
   pybars3 ? import ../pythonPackages/pybars3 {inherit python3Packages;},
   svgpathtools ? import ../pythonPackages/svgpathtools {inherit python3Packages;},
 }:
@@ -25,16 +25,20 @@ with python3Packages;
       mistune
       numpy
       PyVirtualDisplay
-      pcbnewTransition
+      pcbnewtransition
       pillow
       pybars3
       pyyaml
       svgpathtools
       Wand
       wxPython_4_2
+      versioneer
     ];
 
-    patches = [./allow-polygon-board-outlines.patch];
+    patches = [
+      ./allow-polygon-board-outlines.patch
+      ./pr-180.patch
+    ];
 
     # INTI-CMNB (GitHub owner of KiBot) also maintains a fork
     # https://github.com/INTI-CMNB/PcbDraw

--- a/nix/pkgs/pcbdraw/pr-180.patch
+++ b/nix/pkgs/pcbdraw/pr-180.patch
@@ -1,0 +1,82 @@
+From 0a993655e49613a56cdfe4a5f1b27b98d1bb26a5 Mon Sep 17 00:00:00 2001
+From: "Luke T. Shumaker" <lukeshu@lukeshu.com>
+Date: Sun, 21 Sep 2025 11:07:40 -0600
+Subject: [PATCH] Get it installing and passing with Python 3.13 and KiCad 9
+
+I haven't verified that everything works beyond that it installs and
+`make test-unit test-system` passes.
+---
+ .gitignore          | 3 +++
+ pcbdraw/plot.py     | 4 ++--
+ pcbdraw/renderer.py | 2 ++
+ setup.py            | 4 ++--
+ 4 files changed, 9 insertions(+), 4 deletions(-)
+
+diff --git a/.gitignore b/.gitignore
+index 4b9fb4d..dcbd05e 100644
+--- a/.gitignore
++++ b/.gitignore
+@@ -93,3 +93,6 @@ ENV/
+ 
+ # PyCharm settings
+ .idea
++
++# KiCad stuff:
++*.lck
+diff --git a/pcbdraw/plot.py b/pcbdraw/plot.py
+index e7f1fc6..4be0b21 100644
+--- a/pcbdraw/plot.py
++++ b/pcbdraw/plot.py
+@@ -29,7 +29,7 @@
+ from pcbdraw.unit import read_resistance
+ import svgpathtools # type: ignore
+ from lxml import etree, objectify # type: ignore
+-from pcbnewTransition import KICAD_VERSION, isV6, isV7, isV8, pcbnew # type: ignore
++from pcbnewTransition import KICAD_VERSION, isV6, isV7, pcbnew # type: ignore
+ 
+ T = TypeVar("T")
+ Numeric = Union[int, float]
+@@ -41,7 +41,7 @@
+ 
+ etree.register_namespace("xlink", "http://www.w3.org/1999/xlink")
+ 
+-LEGACY_KICAD = not isV6() and not isV7() and not isV8()
++LEGACY_KICAD = KICAD_VERSION[0] < 6 and not isV6()
+ 
+ default_style = {
+     "copper": "#417e5a",
+diff --git a/pcbdraw/renderer.py b/pcbdraw/renderer.py
+index 7486f53..eeaaaa3 100644
+--- a/pcbdraw/renderer.py
++++ b/pcbdraw/renderer.py
+@@ -112,6 +112,8 @@ def waitForWindows(self, titlePatterns: List[str], timeout: int=60,
+             for title, id in windows.items():
+                 if any([pattern in title.lower() for pattern in titlePatterns]):
+                     return id
++                if "kicad pcb editor warning" in title.lower():
++                    self._xdotool(["key", "--window", str(id), "Return"])
+             time.sleep(1)
+         windows_list = "\n".join([f"- {t}" for t in windows.keys()])
+         raise TimeoutError(f"None of '{titlePatterns}' didn't appear within timeout. Available windows:\n{windows_list}")
+diff --git a/setup.py b/setup.py
+index f9514a0..723ba24 100644
+--- a/setup.py
++++ b/setup.py
+@@ -26,14 +26,14 @@
+     install_requires=[
+         "numpy",
+         "lxml",
+-        "mistune>=2.0.2",
++        "mistune>=2.0.2,<3",
+         "pybars3",
+         "pyyaml",
+         "svgpathtools==1.4.1",
+         "pcbnewTransition>=0.4",
+         "LnkParse3; platform_system=='Windows'",
+         "pyVirtualDisplay~=3.0; platform_system!='Windows'",
+-        "Pillow~=9.0",
++        "Pillow>=9.0",
+         "click>=7.1"
+     ],
+     setup_requires=[
+

--- a/nix/pkgs/pythonPackages/mistune/default.nix
+++ b/nix/pkgs/pythonPackages/mistune/default.nix
@@ -1,0 +1,19 @@
+{python3Packages}:
+with python3Packages;
+  buildPythonPackage rec {
+    pname = "mistune";
+    version = "2.0.5";
+
+    pyproject = true;
+    build-system = [python3Packages.setuptools];
+
+    propagatedBuildInputs = [
+    ];
+
+    doCheck = false;
+
+    src = fetchPypi {
+      inherit pname version;
+      sha256 = "sha256-AkYRPLJJLbh1xr5Wl0p8iTMzvybNkokchfYxUc7gnTQ=";
+    };
+  }

--- a/pcb/config.kibot.yaml
+++ b/pcb/config.kibot.yaml
@@ -62,22 +62,22 @@ outputs:
       use_gerber_net_attributes: false
       use_gerber_x2_attributes: false
 
-  # - name: "pcbdraw_top"
-  #   type: pcbdraw
-  #   dir: "+docs/images/"
-  #   comment: "Pretty 2D render of the top of the PCB, using pcbdraw"
-  #   options:
-  #     # Include revision (-%r) to the output
-  #     output: "%f-%r-%i%v.%x"
+  - name: "pcbdraw_top"
+    type: pcbdraw
+    dir: "+docs/images/"
+    comment: "Pretty 2D render of the top of the PCB, using pcbdraw"
+    options:
+      # Include revision (-%r) to the output
+      output: "%f-%r-%i%v.%x"
 
-  # - name: "pcbdraw_bottom"
-  #   type: pcbdraw
-  #   comment: "Pretty 2D render of the bottom of the PCB, using pcbdraw"
-  #   dir: "+docs/images/"
-  #   options:
-  #     bottom: true
-  #     # Include revision (-%r) to the output
-  #     output: "%f-%r-%i%v.%x"
+  - name: "pcbdraw_bottom"
+    type: pcbdraw
+    comment: "Pretty 2D render of the bottom of the PCB, using pcbdraw"
+    dir: "+docs/images/"
+    options:
+      bottom: true
+      # Include revision (-%r) to the output
+      output: "%f-%r-%i%v.%x"
 
   - name: "schematic_print"
     type: pdf_sch_print

--- a/pcb/shell.nix
+++ b/pcb/shell.nix
@@ -5,7 +5,7 @@
   # Kludge: on NixOS desktop, need virtualgl for the pcbnew
   # to be able to show 3D preview.
   kibot ? pkgs.callPackage ../nix/pkgs/kibot {},
-  # pcbdraw ? pkgs.callPackage ../nix/pkgs/pcbdraw {},
+  pcbdraw ? pkgs.callPackage ../nix/pkgs/pcbdraw {},
   # recordmydesktop ? pkgs.callPackage ../nix/pkgs/recordmydesktop {},
 }:
 pkgs.mkShell {
@@ -39,7 +39,7 @@ pkgs.mkShell {
     fluxbox
     interactive-html-bom
     kibot
-    # pcbdraw
+    pcbdraw
     # recordmydesktop
     turbovnc
     virtualgl


### PR DESCRIPTION
This PR restores the nix package for pcbdraw.

1. adds an older `mistune` package for pcbdraw.
2. applies one of the patches which fixes pcbdraw for kicad9's python package.