### PR TITLE
pcb: kibot: UX improvements: use fabrication dir

### DIFF
--- a/pcb/.gitignore
+++ b/pcb/.gitignore
@@ -1,6 +1,7 @@
 *-backups/
 *-bak
 bom
+fabrication
 gerber
 pcba
 *.net

--- a/pcb/config.kibot.yaml
+++ b/pcb/config.kibot.yaml
@@ -18,8 +18,9 @@ outputs:
   - name: "gerber_zip"
     type: compress
     comment: "ZIP file of gerber and drill files for PCB fabrication"
-    dir: "+gerbers/%f/"
+    dir: "+fabrication/%f/"
     options:
+      output: '%f_%r_gerber.%x'
       files:
         - from_output: gerbers
           dest: /
@@ -100,7 +101,7 @@ outputs:
   - name: 'pcba_position'
     comment: "Pick and place file, JLC style"
     type: position
-    dir: "+pcba"
+    dir: "+fabrication/%f/"
     run_by_default: false
     options:
       output: '%f_cpl_jlc_%i.%x'
@@ -127,7 +128,7 @@ outputs:
   - name: 'pcba_bom'
     comment: "BoM for JLC"
     type: bom
-    dir: "+pcba"
+    dir: "+fabrication/%f/"
     run_by_default: false
     options:
       output: '%f_%i_jlc.%x'


### PR DESCRIPTION
This updates the Kibot config so the zip of Gerber files, the PCBA BOM and CPL files are put in `pcb/fabrication/{board}/`.

This makes it nicer to fabricate the PCB, since the output files are all in one dir.