### PR TITLE
pcb: makefile: factor kibot to KIBOT variable

### DIFF
--- a/pcb/Makefile
+++ b/pcb/Makefile
@@ -1,3 +1,10 @@
+# Kibot runner - override to use container when native kibot is not on PATH.
+# Default: native `kibot` (via `nix develop .#pcb`).
+#   make KIBOT=./run-kibot.sh <target>
+#   make KIBOT=./docker-run-kibot.sh <target>
+#   make KIBOT=./container-run-kibot.sh <target>
+KIBOT ?= kibot
+
 kicad_pcbs := $(wildcard *.kicad_pcb)
 boards := $(basename $(kicad_pcbs))
 
@@ -18,18 +25,18 @@ iboms: $(ibom_targets)
 
 .PHONY: %-kibot
 %-kibot:
-	kibot --board-file "$*.kicad_pcb"
+	$(KIBOT) --board-file "$*.kicad_pcb"
 
 .PHONY: %-pcba
 %-pcba:
-	kibot --board-file "$*.kicad_pcb" pcba_bom pcba_position
+	$(KIBOT) --board-file "$*.kicad_pcb" pcba_bom pcba_position
 
 .PHONY: demo-usb-16pin-ibom
 demo-usb-16pin-ibom:
 	true
 
 %.net: %.kicad_pcb
-	kibot --board-file "$*.kicad_pcb" netlist
+	$(KIBOT) --board-file "$*.kicad_pcb" netlist
 
 .PHONY: keyboard-100x100-minif4-dual-rgb-reversible-ibom
 keyboard-100x100-minif4-dual-rgb-reversible-ibom: keyboard-100x100-minif4-dual-rgb-reversible.net


### PR DESCRIPTION
Factor use of `kibot` in the `pcb/Makefile` out to a `KIBOT` variable.

The motivation for this:
- The Nix shell definition which provides `kibot` only works on x86_64 linux. (The flake only supports the Linux system largely because `kicad` definition in nixpkgs only works for Linux).
- The codebase provides `docker-run-kibot.sh` which runs `kibot` using an OCI container. By using `KIBOT`, the makefile can use this.