### PR TITLE
scripts: refactor kicad helpers for Kicad 10

### DIFF
--- a/scripts/kicad_helpers/action_plugin.py
+++ b/scripts/kicad_helpers/action_plugin.py
@@ -1,0 +1,70 @@
+"""
+KiCad 10 Action Plugins - keyboard-labs.
+
+Linux: ~/.config/kicad/10.0/scripting/plugins/
+macOS: ~/Library/Preferences/kicad/10.0/scripting/plugins
+Windows: %APPDATA%/kicad/10.0/scripting/plugins/
+
+Install (KiCad 10, macOS):
+  mkdir -p ~/Library/Preferences/kicad/10.0/scripting/plugins
+  cp scripts/kicad_helpers/action_plugin.py ~/Library/Preferences/kicad/10.0/scripting/plugins/
+  cp -r scripts/kicad_helpers ~/Library/Preferences/kicad/10.0/scripting/plugins/kicad_helpers
+
+After restart: PCB Editor → Tools → External Plugins → Place pico42 / pykey40 / …
+"""
+
+import pcbnew
+
+
+class _BasePlacePlugin(pcbnew.ActionPlugin):
+    helper_name = None
+    helper_func = "fixup"
+
+    def defaults(self):
+        self.name = f"Place {self.helper_name}"
+        self.category = "Keyboard Labs"
+        self.description = f"Run {self.helper_name}.{self.helper_func} (KiCad 10, board-aware)"
+        self.show_toolbar_button = False
+        self.icon_file_name = ""
+
+    def Run(self):
+        import importlib
+
+        mod = importlib.import_module(f"kicad_helpers.{self.helper_name}")
+
+        board = pcbnew.GetBoard()
+
+        fn = getattr(mod, self.helper_func, None) or getattr(mod, "fixup", None) or getattr(mod, "position_all", None)
+
+        if fn is None:
+            raise RuntimeError(f"{self.helper_name} has no {self.helper_func}/fixup/position_all")
+
+        fn(board)
+
+
+class PlacePyKey40Plugin(_BasePlacePlugin):
+    helper_name = "pykey40"
+
+class PlacePico42Plugin(_BasePlacePlugin):
+    helper_name = "pico42"
+
+class PlaceCh55248Plugin(_BasePlacePlugin):
+    helper_name = "ch552_48"
+
+class PlaceCh55236Plugin(_BasePlacePlugin):
+    helper_name = "ch552_36"
+
+class PlaceCh55244Plugin(_BasePlacePlugin):
+    helper_name = "ch552_44"
+
+class PlaceCh32x75Plugin(_BasePlacePlugin):
+    helper_name = "ch32x_75"
+
+class PlaceCh59260Plugin(_BasePlacePlugin):
+    helper_name = "ch592_60"
+
+for _cls in [PlacePyKey40Plugin, PlacePico42Plugin, PlaceCh55248Plugin, PlaceCh55236Plugin, PlaceCh55244Plugin, PlaceCh32x75Plugin, PlaceCh59260Plugin]:
+    try:
+        _cls().register()
+    except Exception:
+        pass

--- a/scripts/kicad_helpers/ch32x_75.py
+++ b/scripts/kicad_helpers/ch32x_75.py
@@ -1,172 +1,47 @@
-# Helper script for CH32X-75
-# to be used with Kicad scripting console.
-#
-# Use with:
-#    import sys
-#    sys.path.append('/Users/richardgoulter/github/keyboard-labs--ch32x/scripts/kicad_helpers')
-#    import pykey40 as p
-
-# pcbnew.GetBoard().FindFootprintByReference("J2").SetPosition(pcbnew.VECTOR2I_MM(100, 100))
+# Helper for CH32X-75
 
 import pcbnew
 from pcbnew import VECTOR2I_MM
-
-import kicad_common
-
+from . import engine
 
 ROWS = 5
 COLS = 15
 
+SPEC = {
+    "anchor": "SW_1_1",
+    "grids": [
+        {"prefix": "SW", "rows": ROWS, "cols": COLS},
+        {"prefix": "R", "rows": ROWS, "cols": COLS, "except": ["R_1_2", "R_3_7"]},
+        {"prefix": "L", "rows": ROWS, "cols": COLS},
+        {"prefix": "D", "rows": ROWS, "cols": COLS, "except": ["D_1_2","D_1_5","D_1_6","D_1_9","D_1_10","D_3_7"]},
+    ],
+    "rotations": [
+        {"prefix": "SW", "rows": ROWS, "cols": COLS, "degrees": 0},
+        {"prefix": "R", "rows": ROWS, "cols": COLS, "except": ["R_1_2","R_3_7"], "degrees": -90},
+        {"prefix": "L", "rows": ROWS, "cols": COLS, "degrees": 180},
+        {"prefix": "D", "rows": ROWS, "cols": COLS, "degrees": 270},
+    ],
+    "mounts": [
+        {"ref": "H1", "c": 0.5, "r": 0.5},
+        {"ref": "H2", "c": 13.5, "r": 0.5}, # 15-1-0.5
+        {"ref": "H3", "c": 7, "r": 1.515},
+        {"ref": "H4", "c": 0.5, "r": 3.5},
+        {"ref": "H5", "c": 13.5, "r": 3.5},
+    ],
+    "hide": [
+        {"type": "references", "prefix": "D", "rows": ROWS, "cols": COLS},
+        {"type": "references", "prefix": "SW", "rows": ROWS, "cols": COLS},
+        {"type": "references", "prefix": "L", "rows": ROWS, "cols": COLS},
+        {"type": "references", "prefix": "R", "rows": ROWS, "cols": COLS},
+        {"type": "references", "refs": [f"H{n}" for n in range(1,20)]},
+    ],
+}
 
-def position_SWs():
-    kicad_common.position_on_grid(
-        ref_prefix = "SW",
-        rows = ROWS,
-        cols = COLS,
-    )
-    kicad_common.set_rotations(
-        ref_prefix = "SW",
-        rows = ROWS,
-        cols = COLS,
-        rotation_degrees = 0
-    )
-
-def position_Rs():
-    kicad_common.position_on_grid(
-        ref_prefix = "R",
-        rows = ROWS,
-        cols = COLS,
-        except_refs = ["R_1_2", "R_3_7"],
-    )
-    kicad_common.set_rotations(
-        ref_prefix = "R",
-        rows = ROWS,
-        cols = COLS,
-        except_refs = ["R_1_2", "R_3_7"],
-        rotation_degrees = -90
-    )
-
-def position_Hs():
-    # Get position footprint by ref SW_1_1
-    sw_1_1 = pcbnew.GetBoard().FindFootprintByReference("SW_1_1")
-    sw_1_1_pos = sw_1_1.GetPosition()
-
-    mounts = [
-        ("H1", (0.5, 0.5)),
-        ("H2", (15 - 1 - 0.5, 0.5)),
-        ("H3", (7, 1.515)),
-        ("H4", (0.5, 3.5)),
-        ("H5", (15 - 1 - 0.5, 3.5)),
-    ]
-
-    # set position of all SWs relative to SW_1_1
-    for (ref, (c, r)) in mounts:
-        fp = pcbnew.GetBoard().FindFootprintByReference(ref)
-        if fp is None:
-            continue
-        fp.SetPosition(sw_1_1_pos + VECTOR2I_MM(19.05 * c, 19.05 * r))
-
-def position_Ls():
-    kicad_common.position_on_grid(
-        ref_prefix = "L",
-        rows = ROWS,
-        cols = COLS,
-    )
-    kicad_common.set_rotations(
-        ref_prefix = "L",
-        rows = ROWS,
-        cols = COLS,
-        rotation_degrees = 180
-    )
-
-# position the Ds
-#
-# Ds are spaced apart by 19.05mm in rows and columns
-# starting from where D_1_1 and D_1_2 are placed.
-def position_Ds():
-    # kicad_common.position_pairs_on_grid(
-    #     ref_prefix = "D",
-    #     rows = ROWS,
-    #     cols = COLS,
-    #     col_spacing_mm = 19.05,
-    #     row_spacing_mm = 19.05
-    # )
-    kicad_common.position_on_grid(
-        ref_prefix = "D",
-        rows = ROWS,
-        cols = COLS,
-        except_refs = ["D_1_2", "D_1_5", "D_1_6", "D_1_9", "D_1_10", "D_3_7"],
-    )
-    kicad_common.set_rotations(
-        ref_prefix = "D",
-        rows = ROWS,
-        cols = COLS,
-        rotation_degrees = 270
-    )
-
-
-def position_all():
-    position_SWs()
-    position_Ds()
-    position_Rs()
-    position_Hs()
-    position_Ls()
-    pcbnew.Refresh()
-
-def hide_d_labels():
-    kicad_common.hide_references(
-        refs = kicad_common.grid_refs(
-            ref_prefix = "D",
-            rows = ROWS,
-            cols = COLS,
-        ),
-    )
-    pcbnew.Refresh()
-
-def hide_sw_labels():
-    kicad_common.hide_references(
-        refs = kicad_common.grid_refs(
-            ref_prefix = "SW",
-            rows = ROWS,
-            cols = COLS,
-        ),
-    )
-    pcbnew.Refresh()
-
-# H1-5
-def hide_h_labels():
-    # H1-19, because there are surely less than 20 H footprints.
-    refs = ["H" + str(n) for n in range(1, 20)]
-    kicad_common.hide_references(refs = refs)
-    pcbnew.Refresh()
-
-def hide_l_labels():
-    kicad_common.hide_references(
-        refs = kicad_common.grid_refs(
-            ref_prefix = "L",
-            rows = ROWS,
-            cols = COLS,
-        ),
-    )
-    pcbnew.Refresh()
-
-def hide_r_labels():
-    kicad_common.hide_references(
-        refs = kicad_common.grid_refs(
-            ref_prefix = "R",
-            rows = ROWS,
-            cols = COLS,
-        ),
-    )
-    pcbnew.Refresh()
-
-def hide_labels():
-    hide_d_labels()
-    hide_sw_labels()
-    hide_h_labels()
-    hide_l_labels()
-    hide_r_labels()
-
-def fixup():
-    position_all()
-    hide_labels()
+def position_SWs(board): engine.apply_spec(board, {"anchor": SPEC["anchor"], "grids": [SPEC["grids"][0]], "rotations": [SPEC["rotations"][0]]})
+def position_Rs(board): engine.apply_spec(board, {"anchor": SPEC["anchor"], "grids": [SPEC["grids"][1]], "rotations": [SPEC["rotations"][1]]})
+def position_Ls(board): engine.apply_spec(board, {"anchor": SPEC["anchor"], "grids": [SPEC["grids"][2]], "rotations": [SPEC["rotations"][2]]})
+def position_Ds(board): engine.apply_spec(board, {"anchor": SPEC["anchor"], "grids": [SPEC["grids"][3]], "rotations": [SPEC["rotations"][3]]})
+def position_Hs(board): engine.apply_spec(board, {"anchor": SPEC["anchor"], "mounts": SPEC["mounts"]})
+def position_all(board): engine.apply_spec(board, {k: SPEC[k] for k in ("anchor","grids","rotations","mounts") if k in SPEC})
+def hide_labels(board): engine.apply_spec(board, {"hide": SPEC["hide"]})
+def fixup(board): engine.apply_spec(board, SPEC)

--- a/scripts/kicad_helpers/ch552_36.py
+++ b/scripts/kicad_helpers/ch552_36.py
@@ -1,270 +1,101 @@
-# Helper script for CH552 36 PCBs
-# to be used with Kicad scripting console.
-#
-# Use with:
-#    import sys
-#    sys.path.append('/home/rgoulter/github/keyboard-labs-ch552-36/scripts/kicad_helpers')
-#    import ch552_36 as p
+# Helper for CH552-36
 
 import math
-
 import pcbnew
-
-from pcbnew import VECTOR2I, VECTOR2I_MM
-
-import kicad_common
+from pcbnew import VECTOR2I, VECTOR2I_MM, EDA_ANGLE
+from . import engine
 
 ROWS = 4
 COLS = 5
 
-
 def rect(p):
     r, theta = p
-    x = r * math.cos(math.radians(theta))
-    y = r * math.sin(math.radians(theta))
-    return x,y
+    return (r * math.cos(math.radians(theta)), r * math.sin(math.radians(theta)))
 
 def polar(pt):
     x, y = pt
-    r = (x ** 2 + y ** 2) ** .5
-    theta = math.degrees(math.atan2(y,x))
-    return r, theta
+    return ((x**2 + y**2)**0.5, math.degrees(math.atan2(y, x)))
 
-def rotate_vec(v, degrees):
+def rotate_vec(v, deg):
     vx, vy = v
     r, theta = polar((vx, -vy))
-    x, y = rect((r, theta + degrees))
+    x, y = rect((r, theta + deg))
     return VECTOR2I(int(x), int(-y))
 
+def _custom_thumb(board, spec):
+    thumb_mid = VECTOR2I_MM(9, 7.5)
 
-def position_offset_for_keyboard_coord(coord):
-    (r, c) = coord
-    return VECTOR2I_MM(19.05 * (c - 1), 19.05 * (r - 1))
+    fan = 10
+    half_c = 19.05/2
+    half_r = 19.05/2
 
+    down_right = VECTOR2I_MM(half_c, half_r)
+    down_right_r = rotate_vec(down_right, -fan)
+    down_left = VECTOR2I_MM(-half_c, half_r)
+    down_left_r = rotate_vec(down_left, -fan)
 
-def position_SWs():
-    kicad_common.position_on_grid(
-        ref_prefix = "SW",
-        rows = ROWS,
-        cols = COLS,
-        col_stagger = [12, 6, 0, 5.5, 8],
-    )
-    kicad_common.set_rotations(
-        ref_prefix = "SW",
-        rows = ROWS,
-        cols = COLS,
-        rotation_degrees = 0
-    )
+    up_right = VECTOR2I_MM(half_c, -half_r)
+    up_right_r = rotate_vec(up_right, -fan*2)
+    up_left = VECTOR2I_MM(-half_c, -half_r)
 
-    # Thumb cluster of SW 4_3 - SW 4_5 is fanned about SW 4_4, angled 30 degrees.
+    sw24_pos = board.FindFootprintByReference("SW_2_4").GetPosition()
 
-    # The middle thumb cluster button should be 2U below the home row's homing key;
-    thumb_cluster_mid_offset = VECTOR2I_MM(9, 7.5)
-    thumb_cluster_fan_angle_degrees = 10
-    half_col_spacing_mm = 19.05 / 2
-    row_spacing_mm = 19.05
-    half_row_spacing_mm = row_spacing_mm / 2
-    down_right = VECTOR2I_MM(half_col_spacing_mm, half_row_spacing_mm)
-    down_right_rotated = rotate_vec(down_right, -thumb_cluster_fan_angle_degrees)
-    down_left = VECTOR2I_MM(-half_col_spacing_mm, half_row_spacing_mm)
-    down_left_rotated = rotate_vec(down_left, -thumb_cluster_fan_angle_degrees)
-    up_right = VECTOR2I_MM(half_col_spacing_mm, -half_row_spacing_mm)
-    up_right_rotated = rotate_vec(up_right, -thumb_cluster_fan_angle_degrees * 2)
-    up_left = VECTOR2I_MM(-half_col_spacing_mm, -half_row_spacing_mm)
+    sw44 = board.FindFootprintByReference("SW_4_4")
+    pos44 = sw24_pos + VECTOR2I_MM(0, 2*19.05) + thumb_mid
+    sw44.SetPosition(pos44)
+    sw44.SetOrientation(EDA_ANGLE(-fan, pcbnew.DEGREES_T))
 
-    sw_2_4_pos = kicad_common.position_of_reference("SW_2_4")
+    sw45 = board.FindFootprintByReference("SW_4_5")
+    sw45.SetPosition(pos44 + down_right_r + up_right_r)
+    sw45.SetOrientation(EDA_ANGLE(-fan*2, pcbnew.DEGREES_T))
 
-    sw_4_4_fp = pcbnew.GetBoard().FindFootprintByReference("SW_4_4")
-    sw_4_4_pos = sw_2_4_pos + VECTOR2I_MM(0, 2 * row_spacing_mm) + thumb_cluster_mid_offset
-    sw_4_4_fp.SetPosition(sw_4_4_pos)
-    sw_4_4_fp.SetOrientationDegrees(-thumb_cluster_fan_angle_degrees)
+    sw43 = board.FindFootprintByReference("SW_4_3")
+    sw43.SetPosition(pos44 + down_left_r + up_left)
+    sw43.SetOrientation(EDA_ANGLE(0, pcbnew.DEGREES_T))
 
-    sw_4_5_fp = pcbnew.GetBoard().FindFootprintByReference("SW_4_5")
-    sw_4_5_pos = sw_4_4_pos + down_right_rotated + up_right_rotated
-    sw_4_5_fp.SetPosition(sw_4_5_pos)
-    sw_4_5_fp.SetOrientationDegrees(-thumb_cluster_fan_angle_degrees * 2)
+def _custom_h(board, spec):
+    import pcbnew
+    from pcbnew import VECTOR2I
 
-    sw_4_3_fp = pcbnew.GetBoard().FindFootprintByReference("SW_4_3")
-    sw_4_3_pos = sw_4_4_pos + down_left_rotated + up_left
-    sw_4_3_fp.SetPosition(sw_4_3_pos)
-    sw_4_3_fp.SetOrientationDegrees(0)
+    # functional: H positions are midpoints between SW refs -> pure calc
+    def x_between(a,b): return int((board.FindFootprintByReference(a).GetPosition().x + board.FindFootprintByReference(b).GetPosition().x)/2)
+    def y_between(a,b): return int((board.FindFootprintByReference(a).GetPosition().y + board.FindFootprintByReference(b).GetPosition().y)/2)
 
+    board.FindFootprintByReference("H1").SetPosition(VECTOR2I(x_between("SW_1_1","SW_1_2"), y_between("SW_1_2","SW_2_2")))
+    board.FindFootprintByReference("H2").SetPosition(VECTOR2I(x_between("SW_1_1","SW_1_2"), y_between("SW_2_1","SW_3_1")))
+    board.FindFootprintByReference("H3").SetPosition(VECTOR2I(x_between("SW_1_4","SW_1_5"), y_between("SW_1_4","SW_2_4")))
+    board.FindFootprintByReference("H4").SetPosition(VECTOR2I(x_between("SW_1_4","SW_1_5"), y_between("SW_2_5","SW_3_5")))
+    board.FindFootprintByReference("H5").SetPosition(VECTOR2I(x_between("SW_4_4","SW_4_5"), y_between("SW_4_4","SW_4_5")))
 
+SPEC = {
+    "anchor": "SW_1_1",
+    "grids": [
+        {"prefix": "SW", "rows": ROWS, "cols": COLS, "col_stagger": [12,6,0,5.5,8]},
+    ],
+    "rotations": [
+        {"prefix": "SW", "rows": ROWS, "cols": COLS, "degrees": 0},
+        {"prefix": "D", "rows": ROWS, "cols": COLS, "degrees": 90},
+    ],
+    "arrays": [ # diode arrays
+        {"refs": ["D_1_1","D_2_1","D_3_1","D_4_3"], "delta": (2.2, 0)},
+        {"refs": [f"D_1_{c}" for c in range(1,6)], "delta": (0, 5)},
+        {"refs": [f"D_2_{c}" for c in range(1,6)], "delta": (0, 5)},
+        {"refs": [f"D_3_{c}" for c in range(1,6)], "delta": (0, 5)},
+        {"refs": [f"D_4_{c}" for c in range(3,6)], "delta": (0, 5)},
+    ],
+    "hide": [
+        {"type": "references", "prefix": "D", "rows": ROWS, "cols": COLS},
+        {"type": "references", "prefix": "SW", "rows": ROWS, "cols": COLS},
+        {"type": "shapes", "refs": [f"SW_{r}_{c}" for r in range(1,ROWS+1) for c in range(1,COLS+1)]},
+        {"type": "references", "refs": ["U1"]},
+        {"type": "references", "refs": [f"H{n}" for n in range(1,20)]},
+    ],
+    "custom": [_custom_thumb, _custom_h],
+}
 
-
-def position_Ds():
-    # kicad_common.position_pairs_on_grid(
-    #     ref_prefix = "D",
-    #     rows = ROWS,
-    #     cols = COLS,
-    #     grid_coord_to_logical_coord = keyboard_coord_to_logical_coord,
-    #     logical_coord_to_grid_coord = logical_coord_to_keyboard_coord,
-    #     col_spacing_mm = 19.05,
-    #     row_spacing_mm = 19.05
-    # )
-    # 2.2, 5
-    kicad_common.position_in_array(
-        refs = ["D_1_1", "D_2_1", "D_3_1", "D_4_3"],
-        delta_pos_mm = [2.2, 0]
-    )
-    kicad_common.position_in_array(
-        refs = ["D_1_{c}".format(c=c) for c in range(1, 6)],
-        delta_pos_mm = [0, 5]
-    )
-    kicad_common.position_in_array(
-        refs = ["D_2_{c}".format(c=c) for c in range(1, 6)],
-        delta_pos_mm = [0, 5]
-    )
-    kicad_common.position_in_array(
-        refs = ["D_3_{c}".format(c=c) for c in range(1, 6)],
-        delta_pos_mm = [0, 5]
-    )
-    kicad_common.position_in_array(
-        refs = ["D_4_{c}".format(c=c) for c in range(3, 6)],
-        delta_pos_mm = [0, 5]
-    )
-    kicad_common.set_rotations(
-        ref_prefix = "D",
-        rows = ROWS,
-        cols = COLS,
-        rotation_degrees = 90
-    )
-
-
-def position_Hs():
-    pcbnew.GetBoard().FindFootprintByReference("H1").SetPosition(
-        VECTOR2I(
-            kicad_common.position_of_x_between_refs("SW_1_1", "SW_1_2"),
-            kicad_common.position_of_y_between_refs("SW_1_2", "SW_2_2")
-        )
-    )
-    pcbnew.GetBoard().FindFootprintByReference("H2").SetPosition(
-        VECTOR2I(
-            kicad_common.position_of_x_between_refs("SW_1_1", "SW_1_2"),
-            kicad_common.position_of_y_between_refs("SW_2_1", "SW_3_1")
-        )
-    )
-    pcbnew.GetBoard().FindFootprintByReference("H3").SetPosition(
-        VECTOR2I(
-            kicad_common.position_of_x_between_refs("SW_1_4", "SW_1_5"),
-            kicad_common.position_of_y_between_refs("SW_1_4", "SW_2_4")
-        )
-    )
-    pcbnew.GetBoard().FindFootprintByReference("H4").SetPosition(
-        VECTOR2I(
-            kicad_common.position_of_x_between_refs("SW_1_4", "SW_1_5"),
-            kicad_common.position_of_y_between_refs("SW_2_5", "SW_3_5")
-        )
-    )
-    pcbnew.GetBoard().FindFootprintByReference("H5").SetPosition(
-        VECTOR2I(
-            kicad_common.position_of_x_between_refs("SW_4_4", "SW_4_5"),
-            kicad_common.position_of_y_between_refs("SW_4_4", "SW_4_5")
-        )
-    )
-
-
-def position_all():
-    position_SWs()
-    position_Ds()
-    position_Hs()
-    pcbnew.Refresh()
-
-
-def hide_d_labels():
-    kicad_common.hide_references(
-        refs = kicad_common.grid_refs(
-            ref_prefix = "D",
-            rows = ROWS,
-            cols = COLS,
-        ),
-    )
-    pcbnew.Refresh()
-
-
-def hide_sw_labels():
-    kicad_common.hide_references(
-        refs = kicad_common.grid_refs(
-            ref_prefix = "SW",
-            rows = ROWS,
-            cols = COLS,
-        ),
-    )
-    kicad_common.hide_fp_texts(
-        refs = kicad_common.grid_refs(
-            ref_prefix = "SW",
-            rows = ROWS,
-            cols = COLS,
-        ),
-        layer_names = ["F.Silkscreen", "B.Silkscreen"],
-    )
-    pcbnew.Refresh()
-
-
-def delete_sw_silkscreen_graphics():
-    kicad_common.delete_fp_shapes(
-        refs = kicad_common.grid_refs(
-            ref_prefix = "SW",
-            rows = ROWS,
-            cols = COLS,
-        ),
-        layer_names = ["F.Silkscreen", "B.Silkscreen"],
-    )
-    pcbnew.Refresh()
-
-
-def hide_u1_labels():
-    kicad_common.hide_fp_texts(refs = ["U1"])
-    pcbnew.Refresh()
-
-
-def hide_h_labels():
-    # H1-19, because there are surely less than 20 H footprints.
-    refs = ["H" + str(n) for n in range(1, 20)]
-    kicad_common.hide_references(refs = refs)
-    pcbnew.Refresh()
-
-
-def hide_labels():
-    hide_d_labels()
-    hide_sw_labels()
-    hide_u1_labels()
-    hide_h_labels()
-
-
-def fixup():
-    position_all()
-    hide_labels()
-    delete_sw_silkscreen_graphics()
-
-# For creating the RHS,
-# the skeleton of the tracing can essentially be reused, etc.,
-# but some manual effort is needed to retrace.
-#
-# The approach I'm taking is just to manually flip the whole board,
-# then to flip each footprint, and swap the trace's layers,
-# then to re-trace.
-
-def flip_all_footprints():
-    footprints = pcbnew.GetBoard().Footprints()
-    for fp in footprints:
-        fp_pos = fp.GetPosition()
-        fp.Flip(fp_pos, True)
-    pcbnew.Refresh()
-
-def swap_track_layers():
-    # F.Cu, B.Cu
-    board = pcbnew.GetBoard()
-    tracks = board.GetTracks()
-    fcu_tracks = [t for t in tracks if t.GetLayerName() == "F.Cu"]
-    bcu_tracks = [t for t in tracks if t.GetLayerName() == "B.Cu"]
-
-    fcu_layer = board.GetLayerID("F.Cu")
-    bcu_layer = board.GetLayerID("B.Cu")
-
-    for t in fcu_tracks:
-        t.SetLayer(bcu_layer)
-    for t in bcu_tracks:
-        t.SetLayer(fcu_layer)
-
-    pcbnew.Refresh()
+def position_SWs(board): engine.apply_spec(board, {"anchor": SPEC["anchor"], "grids": [SPEC["grids"][0]], "rotations": [SPEC["rotations"][0]]}); _custom_thumb(board, SPEC)
+def position_Ds(board): engine.apply_spec(board, {"arrays": SPEC["arrays"], "rotations": [SPEC["rotations"][1]]})
+def position_Hs(board): _custom_h(board, SPEC)
+def position_all(board): engine.apply_spec(board, SPEC)
+def hide_labels(board): engine.apply_spec(board, {"hide": SPEC["hide"]})
+def fixup(board): engine.apply_spec(board, SPEC)

--- a/scripts/kicad_helpers/ch552_44.py
+++ b/scripts/kicad_helpers/ch552_44.py
@@ -1,189 +1,68 @@
-# Helper script for CH552 44 PCB
-# to be used with Kicad scripting console.
-#
-# Use with:
-#    import sys
-#    sys.path.append('/home/rgoulter/github/keyboard-labs/scripts/kicad_helpers')
-#    import ch552_44
-
-# pcbnew.GetBoard().FindFootprintByReference("J2").SetPosition(pcbnew.VECTOR2I_MM(100, 100))
+# Helper for CH552-44
 
 import pcbnew
 from pcbnew import VECTOR2I_MM
-
-import kicad_common
-
-# the logical grid is 7 rows and 7 columns.
-# the keyboard is 4 rows and 12 columns.
+from . import engine
 
 LOGICAL_ROWS = 7
 LOGICAL_COLS = 7
-
 GRID_ROWS = 4
 GRID_COLS = 12
-
 
 def keyboard_coord_to_logical_coord(coord):
     (r, c) = coord
     idx = (c - 1) * GRID_ROWS + (r - 1)
     return (idx % LOGICAL_ROWS + 1, int(idx / LOGICAL_ROWS) + 1)
 
-
 def logical_coord_to_keyboard_coord(coord):
     (r, c) = coord
     idx = (c - 1) * LOGICAL_ROWS + (r - 1)
     return (idx % GRID_ROWS + 1, int(idx / GRID_ROWS) + 1)
 
-
-def position_offset_for_keyboard_coord(coord):
-    (r, c) = coord
-    return VECTOR2I_MM(19.05 * (c - 1), 19.05 * (r - 1))
-
-
-def position_SWs():
-    kicad_common.position_on_grid(
-        ref_prefix = "SW",
-        rows = LOGICAL_ROWS,
-        cols = LOGICAL_COLS,
-        logical_coord_to_grid_coord = logical_coord_to_keyboard_coord,
-    )
-    kicad_common.set_rotations(
-        ref_prefix = "SW",
-        rows = LOGICAL_ROWS,
-        cols = LOGICAL_COLS,
-        rotation_degrees = 0
-    )
-
-
-def position_Ds():
-    kicad_common.position_pairs_on_grid(
-        ref_prefix = "D",
-        rows = LOGICAL_ROWS,
-        cols = LOGICAL_COLS,
-        grid_coord_to_logical_coord = keyboard_coord_to_logical_coord,
-        logical_coord_to_grid_coord = logical_coord_to_keyboard_coord,
-        col_spacing_mm = 19.05,
-        row_spacing_mm = 19.05
-    )
-    kicad_common.set_rotations(
-        ref_prefix = "D",
-        rows = LOGICAL_ROWS,
-        cols = LOGICAL_COLS,
-        rotation_degrees = 270
-    )
-
-
-# position U1
-# so its x position is halfway between the x of keyboard's 1,1 and 1,12.
-def position_U1():
-    sw_1_1 = pcbnew.GetBoard().FindFootprintByReference("SW_1_1")
+def _custom_u1(board, spec):
+    sw1 = board.FindFootprintByReference("SW_1_1")
     (lr, lc) = keyboard_coord_to_logical_coord((1, 12))
-    sw_1_12 = pcbnew.GetBoard().FindFootprintByReference("SW_{r}_{c}".format(r=lr, c=lc))
-    sw_1_1_pos = sw_1_1.GetPosition()
-    sw_1_12_pos = sw_1_12.GetPosition()
+    sw12 = board.FindFootprintByReference(f"SW_{lr}_{lc}")
+    u1 = board.FindFootprintByReference("U1")
+    if not (sw1 and sw12 and u1):
+        return
+    off = VECTOR2I_MM(15.24/2, 0)
+    u1.SetPosition(pcbnew.VECTOR2I(int((sw1.GetPosition().x + sw12.GetPosition().x)/2), u1.GetPosition().y) - off)
 
-    u1 = pcbnew.GetBoard().FindFootprintByReference("U1")
-    u1_pos = u1.GetPosition()
+SPEC = {
+    "anchor": "SW_1_1",
+    "grids": [
+        {"prefix": "SW", "rows": LOGICAL_ROWS, "cols": LOGICAL_COLS, "mapping": logical_coord_to_keyboard_coord},
+        {"prefix": "D", "rows": LOGICAL_ROWS, "cols": LOGICAL_COLS, "type": "pair", "mapping": logical_coord_to_keyboard_coord, "inv_mapping": keyboard_coord_to_logical_coord},
+    ],
+    "rotations": [
+        {"prefix": "SW", "rows": LOGICAL_ROWS, "cols": LOGICAL_COLS, "degrees": 0},
+        {"prefix": "D", "rows": LOGICAL_ROWS, "cols": LOGICAL_COLS, "degrees": 270},
+    ],
+    "mounts": [
+        {"ref": "H1", "c": 0.5, "r": 0.5},
+        {"ref": "H2", "c": 0.5, "r": 2.5},
+        {"ref": "H3", "c": 10.5, "r": 2.5},
+        {"ref": "H4", "c": 10.5, "r": 0.5},
+        {"ref": "H5", "c": 5.5, "r": 1.5},
+        {"ref": "H7", "offset": VECTOR2I_MM(4.5*19.05+3, -4)},
+        {"ref": "H8", "offset": VECTOR2I_MM(4.5*19.05+3, 1.5*19.05-3)},
+        {"ref": "H9", "offset": VECTOR2I_MM(6.5*19.05-3, 1.5*19.05-3)},
+        {"ref": "H10", "offset": VECTOR2I_MM(6.5*19.05-3, -4)},
+    ],
+    "hide": [
+        {"type": "references", "prefix": "D", "rows": LOGICAL_ROWS, "cols": LOGICAL_COLS},
+        {"type": "references", "prefix": "SW", "rows": LOGICAL_ROWS, "cols": LOGICAL_COLS},
+        {"type": "references", "refs": ["U1"]},
+        {"type": "references", "refs": [f"H{n}" for n in range(1,20)]},
+    ],
+    "custom": [_custom_u1],
+}
 
-    board_middle_x_offset = 15.24 / 2
-    u1.SetPosition(pcbnew.VECTOR2I(int((sw_1_1_pos.x + sw_1_12_pos.x ) / 2), u1_pos.y) - VECTOR2I_MM(board_middle_x_offset, 0))
-
-
-def position_Hs():
-    # Get position footprint by ref SW_1_1
-    sw_1_1 = pcbnew.GetBoard().FindFootprintByReference("SW_1_1")
-    sw_1_1_pos = sw_1_1.GetPosition()
-
-    U = 19.05
-    C = 12
-    R = 4
-
-    # Hs aren't a consistent grid,
-    # but some are similar.
-
-    # H1 - H5, the JJ40 mount hole positions
-    pcbnew.GetBoard().FindFootprintByReference("H1").SetPosition(
-        sw_1_1_pos + VECTOR2I_MM(0.5 * U, 0.5 * U)
-    )
-    pcbnew.GetBoard().FindFootprintByReference("H2").SetPosition(
-        sw_1_1_pos + VECTOR2I_MM(0.5 * U, (R - 1.5) * U)
-    )
-    pcbnew.GetBoard().FindFootprintByReference("H3").SetPosition(
-        sw_1_1_pos + VECTOR2I_MM((C - 1.5) * U, (R - 1.5) * U)
-    )
-    pcbnew.GetBoard().FindFootprintByReference("H4").SetPosition(
-        sw_1_1_pos + VECTOR2I_MM((C - 1.5) * U, 0.5 * U)
-    )
-    pcbnew.GetBoard().FindFootprintByReference("H5").SetPosition(
-        sw_1_1_pos + VECTOR2I_MM((C - 1) / 2 * U, (R - 1) / 2 * U)
-    )
-
-    # H7 - H10: mount holes for cover plate over dev board
-    m = 3
-    pcbnew.GetBoard().FindFootprintByReference("H7").SetPosition(
-        sw_1_1_pos + VECTOR2I_MM(4.5 * U + m, -7 + 3)
-    )
-    pcbnew.GetBoard().FindFootprintByReference("H8").SetPosition(
-        sw_1_1_pos + VECTOR2I_MM(4.5 * U + m, 1.5 * U - 3)
-    )
-    pcbnew.GetBoard().FindFootprintByReference("H9").SetPosition(
-        sw_1_1_pos + VECTOR2I_MM(6.5 * U - m, 1.5 * U - 3)
-    )
-    pcbnew.GetBoard().FindFootprintByReference("H10").SetPosition(
-        sw_1_1_pos + VECTOR2I_MM(6.5 * U - m, -7 + 3)
-    )
-
-
-def position_all():
-    position_SWs()
-    position_Ds()
-    position_U1()
-    position_Hs()
-    pcbnew.Refresh()
-
-
-def hide_d_labels():
-    kicad_common.hide_references(
-        refs = kicad_common.grid_refs(
-            ref_prefix = "D",
-            rows = LOGICAL_ROWS,
-            cols = LOGICAL_COLS,
-        ),
-    )
-    pcbnew.Refresh()
-
-
-def hide_sw_labels():
-    kicad_common.hide_fp_texts(
-        refs = kicad_common.grid_refs(
-            ref_prefix = "SW",
-            rows = LOGICAL_ROWS,
-            cols = LOGICAL_COLS,
-        ),
-        layer_names = ["F.Silkscreen"],
-    )
-    pcbnew.Refresh()
-
-
-def hide_u1_labels():
-    kicad_common.hide_fp_texts(refs = ["U1"])
-    pcbnew.Refresh()
-
-
-def hide_h_labels():
-    # H1-19, because there are surely less than 20 H footprints.
-    refs = ["H" + str(n) for n in range(1, 20)]
-    kicad_common.hide_references(refs = refs)
-    pcbnew.Refresh()
-
-
-def hide_labels():
-    hide_d_labels()
-    hide_sw_labels()
-    hide_u1_labels()
-    hide_h_labels()
-
-
-def fixup():
-    position_all()
-    hide_labels()
+def position_SWs(board): engine.apply_spec(board, {"anchor": SPEC["anchor"], "grids": [SPEC["grids"][0]], "rotations": [SPEC["rotations"][0]]})
+def position_Ds(board): engine.apply_spec(board, {"anchor": SPEC["anchor"], "grids": [SPEC["grids"][1]], "rotations": [SPEC["rotations"][1]]})
+def position_U1(board): _custom_u1(board, SPEC)
+def position_Hs(board): engine.apply_spec(board, {"anchor": SPEC["anchor"], "mounts": SPEC["mounts"]})
+def position_all(board): engine.apply_spec(board, {k: SPEC[k] for k in ("anchor","grids","rotations","mounts") if k in SPEC}); _custom_u1(board, SPEC)
+def hide_labels(board): engine.apply_spec(board, {"hide": SPEC["hide"]})
+def fixup(board): engine.apply_spec(board, SPEC)

--- a/scripts/kicad_helpers/ch552_48.py
+++ b/scripts/kicad_helpers/ch552_48.py
@@ -1,158 +1,52 @@
-# Helper script for CH552 48 PCB
-# to be used with Kicad scripting console.
-#
-# Use with:
-#    import sys
-#    sys.path.append('/home/rgoulter/github/keyboard-labs/scripts/kicad_helpers')
-#    import ch552_48 as p
-
-# pcbnew.GetBoard().FindFootprintByReference("J2").SetPosition(pcbnew.VECTOR2I_MM(100, 100))
+# Helper for CH552-48
 
 import pcbnew
-
 from pcbnew import VECTOR2I_MM
-
-import kicad_common
-
-# the logical grid is 7 rows and 7 columns.
-# the keyboard is 4 rows and 12 columns.
+from . import engine
 
 LOGICAL_ROWS = 7
 LOGICAL_COLS = 7
-
 GRID_ROWS = 4
 GRID_COLS = 12
-
 
 def keyboard_coord_to_logical_coord(coord):
     (r, c) = coord
     idx = (c - 1) * GRID_ROWS + (r - 1)
     return (idx % LOGICAL_ROWS + 1, int(idx / LOGICAL_ROWS) + 1)
 
-
 def logical_coord_to_keyboard_coord(coord):
     (r, c) = coord
     idx = (c - 1) * LOGICAL_ROWS + (r - 1)
     return (idx % GRID_ROWS + 1, int(idx / GRID_ROWS) + 1)
 
+SPEC = {
+    "anchor": "SW_1_1",
+    "grids": [
+        {"prefix": "SW", "rows": LOGICAL_ROWS, "cols": LOGICAL_COLS, "mapping": logical_coord_to_keyboard_coord},
+        {"prefix": "D", "rows": LOGICAL_ROWS, "cols": LOGICAL_COLS, "type": "pair", "mapping": logical_coord_to_keyboard_coord, "inv_mapping": keyboard_coord_to_logical_coord},
+    ],
+    "rotations": [
+        {"prefix": "SW", "rows": LOGICAL_ROWS, "cols": LOGICAL_COLS, "degrees": 0},
+        {"prefix": "D", "rows": LOGICAL_ROWS, "cols": LOGICAL_COLS, "degrees": 270},
+    ],
+    "mounts": [
+        {"ref": "H1", "c": 0.5, "r": 0.5},
+        {"ref": "H2", "c": 0.5, "r": 2.5},
+        {"ref": "H3", "c": 10.5, "r": 2.5},
+        {"ref": "H4", "c": 10.5, "r": 0.5},
+        {"ref": "H5", "c": 5.5, "r": 1.5},
+    ],
+    "hide": [
+        {"type": "references", "prefix": "D", "rows": LOGICAL_ROWS, "cols": LOGICAL_COLS},
+        {"type": "references", "prefix": "SW", "rows": LOGICAL_ROWS, "cols": LOGICAL_COLS},
+        {"type": "references", "refs": ["U1"]},
+        {"type": "references", "refs": [f"H{n}" for n in range(1,20)]},
+    ],
+}
 
-def position_offset_for_keyboard_coord(coord):
-    (r, c) = coord
-    return VECTOR2I_MM(19.05 * (c - 1), 19.05 * (r - 1))
-
-
-def position_SWs():
-    kicad_common.position_on_grid(
-        ref_prefix = "SW",
-        rows = LOGICAL_ROWS,
-        cols = LOGICAL_COLS,
-        logical_coord_to_grid_coord = logical_coord_to_keyboard_coord,
-    )
-    kicad_common.set_rotations(
-        ref_prefix = "SW",
-        rows = LOGICAL_ROWS,
-        cols = LOGICAL_COLS,
-        rotation_degrees = 0
-    )
-
-
-def position_Ds():
-    kicad_common.position_pairs_on_grid(
-        ref_prefix = "D",
-        rows = LOGICAL_ROWS,
-        cols = LOGICAL_COLS,
-        grid_coord_to_logical_coord = keyboard_coord_to_logical_coord,
-        logical_coord_to_grid_coord = logical_coord_to_keyboard_coord,
-        col_spacing_mm = 19.05,
-        row_spacing_mm = 19.05
-    )
-    kicad_common.set_rotations(
-        ref_prefix = "D",
-        rows = LOGICAL_ROWS,
-        cols = LOGICAL_COLS,
-        rotation_degrees = 270
-    )
-
-
-def position_Hs():
-    # Get position footprint by ref SW_1_1
-    sw_1_1 = pcbnew.GetBoard().FindFootprintByReference("SW_1_1")
-    sw_1_1_pos = sw_1_1.GetPosition()
-
-    U = 19.05
-    C = 12
-    R = 4
-
-    # Hs aren't a consistent grid,
-    # but some are similar.
-
-    # H1 - H5, the JJ40 mount hole positions
-    pcbnew.GetBoard().FindFootprintByReference("H1").SetPosition(
-        sw_1_1_pos + VECTOR2I_MM(0.5 * U, 0.5 * U)
-    )
-    pcbnew.GetBoard().FindFootprintByReference("H2").SetPosition(
-        sw_1_1_pos + VECTOR2I_MM(0.5 * U, (R - 1.5) * U)
-    )
-    pcbnew.GetBoard().FindFootprintByReference("H3").SetPosition(
-        sw_1_1_pos + VECTOR2I_MM((C - 1.5) * U, (R - 1.5) * U)
-    )
-    pcbnew.GetBoard().FindFootprintByReference("H4").SetPosition(
-        sw_1_1_pos + VECTOR2I_MM((C - 1.5) * U, 0.5 * U)
-    )
-    pcbnew.GetBoard().FindFootprintByReference("H5").SetPosition(
-        sw_1_1_pos + VECTOR2I_MM((C - 1) / 2 * U, (R - 1) / 2 * U)
-    )
-
-
-def position_all():
-    position_SWs()
-    position_Ds()
-    position_Hs()
-    pcbnew.Refresh()
-
-
-def hide_d_labels():
-    kicad_common.hide_references(
-        refs = kicad_common.grid_refs(
-            ref_prefix = "D",
-            rows = LOGICAL_ROWS,
-            cols = LOGICAL_COLS,
-        ),
-    )
-    pcbnew.Refresh()
-
-
-def hide_sw_labels():
-    kicad_common.hide_fp_texts(
-        refs = kicad_common.grid_refs(
-            ref_prefix = "SW",
-            rows = LOGICAL_ROWS,
-            cols = LOGICAL_COLS,
-        ),
-        layer_names = ["F.Silkscreen"],
-    )
-    pcbnew.Refresh()
-
-
-def hide_u1_labels():
-    kicad_common.hide_fp_texts(refs = ["U1"])
-    pcbnew.Refresh()
-
-
-def hide_h_labels():
-    # H1-19, because there are surely less than 20 H footprints.
-    refs = ["H" + str(n) for n in range(1, 20)]
-    kicad_common.hide_references(refs = refs)
-    pcbnew.Refresh()
-
-
-def hide_labels():
-    hide_d_labels()
-    hide_sw_labels()
-    hide_u1_labels()
-    hide_h_labels()
-
-
-def fixup():
-    position_all()
-    hide_labels()
+def position_SWs(board): engine.apply_spec(board, {"anchor": SPEC["anchor"], "grids": [SPEC["grids"][0]], "rotations": [SPEC["rotations"][0]]})
+def position_Ds(board): engine.apply_spec(board, {"anchor": SPEC["anchor"], "grids": [SPEC["grids"][1]], "rotations": [SPEC["rotations"][1]]})
+def position_Hs(board): engine.apply_spec(board, {"anchor": SPEC["anchor"], "mounts": SPEC["mounts"]})
+def position_all(board): engine.apply_spec(board, {k: SPEC[k] for k in ("anchor","grids","rotations","mounts") if k in SPEC})
+def hide_labels(board): engine.apply_spec(board, {"hide": SPEC["hide"]})
+def fixup(board): engine.apply_spec(board, SPEC)

--- a/scripts/kicad_helpers/ch592_60.py
+++ b/scripts/kicad_helpers/ch592_60.py
@@ -1,28 +1,13 @@
-# Helper script for CH592 60 PCB
-# to be used with Kicad scripting console.
-#
-# Use with:
-#    import sys
-#    sys.path.append('/home/rgoulter/github/keyboard-labs--ch592-60/scripts/kicad_helpers')
-#    import ch592_60 as p
-
-# pcbnew.GetBoard().FindFootprintByReference("J2").SetPosition(pcbnew.VECTOR2I_MM(100, 100))
+# Helper for CH592-60 (GH60 lumberjack)
 
 import pcbnew
-
-from pcbnew import VECTOR2I_MM
-
-import kicad_common
-
-# the logical grid is 8 rows and 8 columns.
-# the keyboard is 5 rows and 12 columns.
+from pcbnew import VECTOR2I_MM, EDA_ANGLE
+from . import engine
 
 LOGICAL_ROWS = 8
 LOGICAL_COLS = 8
-
 GRID_ROWS = 5
 GRID_COLS = 12
-
 
 def keyboard_coord_to_logical_coord(coord):
     (r, c) = coord
@@ -32,9 +17,8 @@ def keyboard_coord_to_logical_coord(coord):
     # So, after the first 6 columns of 5 rows,
     #  the index jumps by 3 columns.
     if idx >= 30:
-        idx -= 3 * 5
+        idx -= 3*5
     return (idx % LOGICAL_ROWS + 1, int(idx / LOGICAL_ROWS) + 1)
-
 
 def logical_coord_to_keyboard_coord(coord):
     (r, c) = coord
@@ -44,32 +28,10 @@ def logical_coord_to_keyboard_coord(coord):
     # So, after the first 6 columns of 5 rows,
     #  the index jumps by 3 columns.
     if idx >= 30:
-        idx += 3 * 5
+        idx += 3*5
     return (idx % GRID_ROWS + 1, int(idx / GRID_ROWS) + 1)
 
-
-def position_offset_for_keyboard_coord(coord):
-    (r, c) = coord
-    return VECTOR2I_MM(19.05 * (c - 1), 19.05 * (r - 1))
-
-
-def position_SWs():
-    kicad_common.position_on_grid(
-        ref_prefix = "SW",
-        rows = LOGICAL_ROWS,
-        cols = LOGICAL_COLS,
-        logical_coord_to_grid_coord = logical_coord_to_keyboard_coord,
-    )
-    kicad_common.set_rotations(
-        ref_prefix = "SW",
-        rows = LOGICAL_ROWS,
-        cols = LOGICAL_COLS,
-        rotation_degrees = 0
-    )
-
-
-def position_Ds():
-    # Position diodes in "lumberjack" style:
+def _custom_diodes(board, spec):
     # 24 diodes on the left, 12 on the bottom, 24 on the right.
     #
     # It's easiest to trace if
@@ -77,185 +39,43 @@ def position_Ds():
     #  as the 30 switches on the left;
     # and if the logical rows are grouped within that.
 
-    lhs_32_ds = ["D_{0}_{1}".format(r, c) for r in range(1, 9) for c in range(1, 5)]
-    lhs_30_ds = lhs_32_ds[:30]
-    rhs_30_ds = lhs_32_ds[30:] + ["D_{0}_{1}".format(r, c) for r in range(8, 0, -1) for c in range(5, 9) if c < 8 or r < 5]
-
-    assert len(lhs_30_ds) == 30
-    assert len(rhs_30_ds) == 30
-
-    lhs_ds = lhs_30_ds[:24]
-    bottom_ds = lhs_30_ds[24:] + rhs_30_ds[:6]
-    rhs_ds = list(reversed(rhs_30_ds[6:]))
-
-    assert len(lhs_ds) == 24
-    assert len(bottom_ds) == 12
-    assert len(rhs_ds) == 24
-
-    # - Diode grid (left): (172, 60), dx,dy = (2.5, 3)
-    # - Diode grid (below): (191, 60), dx,dy = (3, 2.5)
-    # - Diode grid (right): (213, 60), dx,dy = (2.5, 3)
+    lhs_32 = [f"D_{r}_{c}" for r in range(1,9) for c in range(1,5)]
+    lhs_30 = lhs_32[:30]
+    rhs_30 = lhs_32[30:] + [f"D_{r}_{c}" for r in range(8,0,-1) for c in range(5,9) if c < 8 or r < 5]
+    lhs_ds, bottom_ds, rhs_ds = lhs_30[:24], lhs_30[24:]+rhs_30[:6], list(reversed(rhs_30[6:]))
     dx = 2.5
-    kicad_common.position_in_array(
-            refs = lhs_ds,
-            delta_pos_mm = (0, 3),
-            adjustments_mm = [
-                (0, 0),
-                (-dx, 0),
-                (0, 0),
-                (-dx, 0),
-                (0, 0),
-                (-dx, 0),
-                (0, 0),
-                (-dx, 0),
-                (0, 0),
-                (-dx, 0),
-                (0, 0),
-                (0, 0),
-                (-dx, 0),
-                (-dx, 0),
-                (0, 0),
-                (-dx, 0),
-                (0, 0),
-                (-dx, 0),
-                (0, 0),
-                (-dx, 0),
-                (0, 0),
-                (-dx, 0),
-                (0, 0),
-                (-dx, 0),
-            ]
-    )
-    kicad_common.position_in_array(
-            refs = bottom_ds,
-            delta_pos_mm = (3, 0),
-            adjustments_mm = [
-                (0, 0),
-                (0, -dx),
-                (0, 0),
-                (0, -dx),
-                (0, 0),
-                (0, -dx),
-                (0, -dx),
-                (0, 0),
-                (0, -dx),
-                (0, 0),
-                (0, -dx),
-                (0, 0),
-            ]
-    )
-    kicad_common.position_in_array(
-            refs = rhs_ds,
-            delta_pos_mm = (0, 3),
-            adjustments_mm = [
-                (0, 0),
-                (dx, 0),
-                (0, 0),
-                (dx, 0),
-                (0, 0),
-                (dx, 0),
-                (0, 0),
-                (dx, 0),
-                (0, 0),
-                (dx, 0),
-                (0, 0),
-                (dx, 0),
-                (0, 0),
-                (dx, 0),
-                (0, 0),
-                (dx, 0),
-                (0, 0),
-                (dx, 0),
-                (0, 0),
-                (dx, 0),
-                (0, 0),
-                (dx, 0),
-                (0, 0),
-                (dx, 0),
-            ]
-    )
-    kicad_common.set_array_rotations(lhs_ds, 0)
-    kicad_common.set_array_rotations(bottom_ds, 90)
-    kicad_common.set_array_rotations(rhs_ds, 180)
+    engine._apply_arrays(board, [
+        {"refs": lhs_ds, "delta": (0,3), "adjustments": [(0,0) if i%2==0 else (-dx,0) for i in range(len(lhs_ds))]},
+        {"refs": bottom_ds, "delta": (3,0), "adjustments": [(0,0) if i%2==0 else (0,-dx) for i in range(len(bottom_ds))], "degrees": 90},
+        {"refs": rhs_ds, "delta": (0,3), "adjustments": [(0,0) if i%2==0 else (dx,0) for i in range(len(rhs_ds))], "degrees": 180},
+    ])
 
+    for ref in lhs_ds:
+        fp = board.FindFootprintByReference(ref)
+        if fp: fp.SetOrientation(EDA_ANGLE(0, pcbnew.DEGREES_T))
 
-def position_Hs():
-    # Get position footprint by ref SW_1_1
-    sw_1_1 = pcbnew.GetBoard().FindFootprintByReference("SW_1_1")
-    sw_1_1_pos = sw_1_1.GetPosition()
+SPEC = {
+    "anchor": "SW_1_1",
+    "grids": [
+        {"prefix": "SW", "rows": LOGICAL_ROWS, "cols": LOGICAL_COLS, "mapping": logical_coord_to_keyboard_coord},
+    ],
+    "rotations": [
+        {"prefix": "SW", "rows": LOGICAL_ROWS, "cols": LOGICAL_COLS, "degrees": 0},
+    ],
+    "mounts": [
+        # H6-H9 for CH592 case (subset of lumberjack mounts)
+        {"ref": "H6", "c": 0.5, "r": 0.5},
+        {"ref": "H7", "c": 0.5, "r": 3.5},
+    ],
+    "hide": [
+        {"type": "references", "prefix": "SW", "rows": LOGICAL_ROWS, "cols": LOGICAL_COLS},
+    ],
+    "custom": [_custom_diodes],
+}
 
-    U = 19.05
-    C = 15
-    R = 5
-
-    # Hs aren't a consistent grid,
-    # but some are similar.
-
-    # H6 - H9, mount for a 3DP case
-    pcbnew.GetBoard().FindFootprintByReference("H6").SetPosition(
-        sw_1_1_pos + VECTOR2I_MM(0.5 * U, 0.5 * U)
-    )
-    pcbnew.GetBoard().FindFootprintByReference("H7").SetPosition(
-        sw_1_1_pos + VECTOR2I_MM(0.5 * U, (R - 1.5) * U)
-    )
-    pcbnew.GetBoard().FindFootprintByReference("H8").SetPosition(
-        sw_1_1_pos + VECTOR2I_MM((C - 1.5) * U, (R - 1.5) * U)
-    )
-    pcbnew.GetBoard().FindFootprintByReference("H9").SetPosition(
-        sw_1_1_pos + VECTOR2I_MM((C - 1.5) * U, 0.5 * U)
-    )
-    pcbnew.Refresh()
-
-
-def position_all():
-    position_SWs()
-    position_Ds()
-    position_Hs()
-    pcbnew.Refresh()
-
-
-def hide_d_labels():
-    kicad_common.hide_references(
-        refs = kicad_common.grid_refs(
-            ref_prefix = "D",
-            rows = LOGICAL_ROWS,
-            cols = LOGICAL_COLS,
-        ),
-    )
-    pcbnew.Refresh()
-
-
-def hide_sw_labels():
-    kicad_common.hide_fp_texts(
-        refs = kicad_common.grid_refs(
-            ref_prefix = "SW",
-            rows = LOGICAL_ROWS,
-            cols = LOGICAL_COLS,
-        ),
-        layer_names = ["F.Silkscreen"],
-    )
-    pcbnew.Refresh()
-
-
-def hide_u1_labels():
-    kicad_common.hide_fp_texts(refs = ["U1"])
-    pcbnew.Refresh()
-
-
-def hide_h_labels():
-    # H1-19, because there are surely less than 20 H footprints.
-    refs = ["H" + str(n) for n in range(1, 20)]
-    kicad_common.hide_references(refs = refs)
-    pcbnew.Refresh()
-
-
-def hide_labels():
-    hide_d_labels()
-    hide_sw_labels()
-    hide_u1_labels()
-    hide_h_labels()
-
-
-def fixup():
-    position_all()
-    hide_labels()
+def position_SWs(board): engine.apply_spec(board, {"anchor": SPEC["anchor"], "grids": [SPEC["grids"][0]], "rotations": [SPEC["rotations"][0]]})
+def position_Ds(board): _custom_diodes(board, SPEC)
+def position_Hs(board): engine.apply_spec(board, {"anchor": SPEC["anchor"], "mounts": SPEC["mounts"]})
+def position_all(board): engine.apply_spec(board, SPEC)
+def hide_labels(board): engine.apply_spec(board, {"hide": SPEC["hide"]})
+def fixup(board): engine.apply_spec(board, SPEC)

--- a/scripts/kicad_helpers/cli.py
+++ b/scripts/kicad_helpers/cli.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""
+CLI entrypoint - KiCad 10 only (requires pcbnew on PYTHONPATH).
+
+All helpers are board-aware (def foo(board): ...).
+
+Requires pcbnew on PYTHONPATH; easiest to achieve using KiCad's bundled Python:
+
+  /Applications/KiCad/KiCad.app/Contents/Frameworks/Python.framework/Versions/3.9/bin/python3 -m scripts.kicad_helpers.cli --board pcb/keyboard-pico42.kicad_pcb --helper pico42
+  /Applications/KiCad/KiCad.app/Contents/Frameworks/Python.framework/Versions/3.9/bin/python3 -m scripts.kicad_helpers.cli --board pcb/keyboard-ch32x-75.kicad_pcb --helper ch32x_75 --func fixup
+  # or any Python where pcbnew is on PYTHONPATH (e.g. nix shell with pkgs.kicad):
+  nix develop .#pcb --command python -m scripts.kicad_helpers.cli --board pcb/keyboard-pykey40-hsrgb.kicad_pcb --helper pykey40
+
+GUI: use action_plugin.py instead (Tools → External Plugins).
+"""
+
+import argparse
+import importlib
+import sys
+from pathlib import Path
+from typing import Optional
+
+try:
+    import pcbnew
+except ModuleNotFoundError:
+    pcbnew = None  # requires pcbnew on PYTHONPATH; easiest via KiCad's bundled Python
+
+
+def _require_pcbnew():
+    if pcbnew is None:
+        print(
+            "error: pcbnew not found on PYTHONPATH — requires pcbnew on PYTHONPATH.\n"
+            "  Easiest to achieve using KiCad's bundled Python:\n"
+            "    /Applications/KiCad/KiCad.app/Contents/Frameworks/Python.framework/Versions/3.9/bin/python3 -m scripts.kicad_helpers.cli --board ...\n"
+            "  Or any Python with pcbnew on PYTHONPATH (e.g. nix shell with pkgs.kicad).\n"
+            "  GUI alternative: KiCad → PCB Editor → Tools → External Plugins (see action_plugin.py)",
+            file=sys.stderr,
+        )
+        raise SystemExit(1)
+
+
+def run_helper(board_path: Path, helper_name: str, func: str = "fixup", out_path: Optional[Path] = None):
+    _require_pcbnew()
+
+    board = pcbnew.LoadBoard(str(board_path))
+
+    mod = importlib.import_module(f"scripts.kicad_helpers.{helper_name}")
+
+    fn = getattr(mod, func, None) or getattr(mod, "fixup", None) or getattr(mod, "position_all", None)
+
+    if fn is None:
+        raise SystemExit(f"Helper {helper_name} has no {func}/fixup/position_all")
+
+    fn(board)
+
+    board.Save(str(out_path or board_path))
+    print(f"Saved {out_path or board_path}")
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Run kicad_helpers headless (KiCad 10, board-aware)")
+    ap.add_argument("--board", required=True, help="path to .kicad_pcb")
+    ap.add_argument("--helper", required=True, help="pykey40, pico42, ch552_48, ch552_36, ch552_44, ch32x_75, ch592_60")
+    ap.add_argument("--func", default="fixup", help="function to call (default: fixup)")
+    ap.add_argument("--out", help="output path (default: overwrite --board)")
+
+    args = ap.parse_args()
+
+    run_helper(Path(args.board), args.helper, args.func, Path(args.out) if args.out else None)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/kicad_helpers/engine.py
+++ b/scripts/kicad_helpers/engine.py
@@ -1,0 +1,288 @@
+"""
+Functional Core / Imperative Shell for KiCad placement (KiCad 10).
+
+Core: pure functions that compute target positions/offsets from specs (no board IO).
+Shell: apply_spec(board, spec) reads anchor positions from board, calls core, writes.
+
+Each board helper becomes a declaration:
+  SPEC = { "anchor": "SW_1_1", "grids": [...], "rotations": [...], "mounts": [...], "arrays": [...], "hide": [...], "custom": [...] }
+  def fixup(board): engine.apply_spec(board, SPEC)
+
+This replaces the previous "I position these then these" imperative scripts.
+"""
+
+from pcbnew import VECTOR2I_MM, EDA_ANGLE
+import pcbnew
+
+# ---------- Functional Core (pure, no board) ----------
+
+def grid_offsets(rows, cols, col_spacing_mm=19.05, row_spacing_mm=19.05, col_stagger=None):
+    """Pure: map logical (r,c) -> offset VECTOR2I_MM from origin."""
+    # col_stagger is list per column of y offset mm (e.g. [12,6,0,5.5,8])
+    adjusted = None
+    if col_stagger:
+        adjusted = [x - col_stagger[0] for x in col_stagger]
+
+    out = {}
+    for r in range(1, rows + 1):
+        for c in range(1, cols + 1):
+            base = VECTOR2I_MM(col_spacing_mm * (c - 1), row_spacing_mm * (r - 1))
+
+            if adjusted:
+                base = base + VECTOR2I_MM(0, adjusted[c - 1])
+
+            out[(r, c)] = base
+
+    return out
+
+
+def pair_offsets(rows, cols, col_spacing_mm=19.05, row_spacing_mm=19.05):
+    """Pure: for position_pairs_on_grid — returns map for odd/even columns."""
+    # Caller needs two anchors (1,1) and (1,2)
+    out = {}
+
+    for r in range(1, rows + 1):
+        for c in range(1, cols + 1):
+            if c % 2 == 1:
+                out[(r, c)] = VECTOR2I_MM(col_spacing_mm * (c - 1), row_spacing_mm * (r - 1))
+            else:
+                # even col offset relative to (1,2) anchor, using c-1
+                out[(r, c)] = VECTOR2I_MM(col_spacing_mm * (c - 2), row_spacing_mm * (r - 1))
+
+    return out
+
+
+def mount_offset_mm(c_mul, r_mul, U=19.05):
+    return VECTOR2I_MM(U * c_mul, U * r_mul)
+
+
+# ---------- Imperative Shell (board IO) ----------
+
+def _apply_grid(board, anchor_ref, spec):
+    # spec: {prefix, rows, cols, mapping, except, stagger, col_spacing, row_spacing}
+    prefix = spec["prefix"]
+    rows, cols = spec["rows"], spec["cols"]
+    mapping = spec.get("mapping", lambda x: x)
+    except_refs = set(spec.get("except", []))
+    col_spacing = spec.get("col_spacing_mm", 19.05)
+    row_spacing = spec.get("row_spacing_mm", 19.05)
+    stagger = spec.get("col_stagger")
+    anchor = board.FindFootprintByReference(anchor_ref)
+    if anchor is None:
+        raise ValueError(f"Anchor {anchor_ref} not found")
+    anchor_pos = anchor.GetPosition()
+    offsets = grid_offsets(rows, cols, col_spacing, row_spacing, stagger)
+
+    # Build mapping from logical coord -> grid coord
+    for (r, c) in [(r, c) for r in range(1, rows + 1) for c in range(1, cols + 1)]:
+        ref = f"{prefix}_{r}_{c}"
+
+        if ref in except_refs:
+            continue
+
+        fp = board.FindFootprintByReference(ref)
+
+        if fp is None:
+            continue
+
+        logical = (r, c)
+        grid_coord = mapping(logical)
+        off = offsets.get(grid_coord) or grid_offsets(1,1)[(1,1)]  # fallback
+
+        # For logical->grid mapping, recompute offset via grid_offsets for grid_coord
+        # Simpler: compute directly
+        off = VECTOR2I_MM(col_spacing * (grid_coord[1] - 1), row_spacing * (grid_coord[0] - 1))
+
+        if stagger:
+            adjusted = [x - stagger[0] for x in stagger]
+            off = off + VECTOR2I_MM(0, adjusted[grid_coord[1] - 1])
+
+        fp.SetPosition(anchor_pos + off)
+
+
+def _apply_pair_grid(board, anchor1_ref, anchor2_ref, spec):
+    prefix = spec["prefix"]
+    rows, cols = spec["rows"], spec["cols"]
+    mapping = spec.get("mapping", lambda x: x)
+    inv_mapping = spec.get("inv_mapping", lambda x: x)
+    col_spacing = spec.get("col_spacing_mm", 19.05)
+    row_spacing = spec.get("row_spacing_mm", 19.05)
+    a1 = board.FindFootprintByReference(anchor1_ref)
+    a2 = board.FindFootprintByReference(anchor2_ref)
+
+    if a1 is None or a2 is None:
+        raise ValueError(f"Pair anchors {anchor1_ref}/{anchor2_ref} not found")
+
+    a1_pos, a2_pos = a1.GetPosition(), a2.GetPosition()
+
+    for (r, c) in [(r, c) for r in range(1, rows + 1) for c in range(1, cols + 1)]:
+        ref = f"{prefix}_{r}_{c}"
+        fp = board.FindFootprintByReference(ref)
+
+        if fp is None:
+            continue
+
+        (gr, gc) = mapping((r, c))
+
+        if gc % 2 == 1:
+            off = VECTOR2I_MM(col_spacing * (gr - 1), row_spacing * (gc - 1))
+            fp.SetPosition(a1_pos + off)
+        else:
+            off = VECTOR2I_MM(col_spacing * (gr - 1), row_spacing * (gc - 2))
+            fp.SetPosition(a2_pos + off)
+
+
+def _apply_rotations(board, spec):
+    prefix = spec["prefix"]
+    rows, cols = spec["rows"], spec["cols"]
+    deg = spec["degrees"]
+    except_refs = set(spec.get("except", []))
+
+    for r in range(1, rows + 1):
+        for c in range(1, cols + 1):
+            ref = f"{prefix}_{r}_{c}"
+
+            if ref in except_refs:
+                continue
+
+            fp = board.FindFootprintByReference(ref)
+
+            if fp is None:
+                continue
+
+            fp.SetOrientation(EDA_ANGLE(deg, pcbnew.DEGREES_T))
+
+
+def _apply_mounts(board, anchor_ref, mounts, U=19.05):
+    anchor = board.FindFootprintByReference(anchor_ref)
+
+    if anchor is None:
+        raise ValueError(f"Mount anchor {anchor_ref} not found")
+
+    anchor_pos = anchor.GetPosition()
+
+    for m in mounts:
+        ref = m["ref"]
+        # offset can be (c_mul, r_mul) or explicit VECTOR2I_MM or (dx_mm, dy_mm)
+        off = m.get("offset")
+
+        if off is None:
+            c_mul, r_mul = m["c"], m["r"]
+            off = VECTOR2I_MM(c_mul * U, r_mul * U)
+
+        fp = board.FindFootprintByReference(ref)
+
+        if fp is None:
+            continue
+
+        fp.SetPosition(anchor_pos + off)
+
+
+def _apply_arrays(board, arrays):
+    for arr in arrays:
+        refs = arr["refs"]
+        delta = arr["delta"]  # (dx_mm, dy_mm)
+        adjustments = arr.get("adjustments")
+
+        if not refs:
+            continue
+
+        fp0 = board.FindFootprintByReference(refs[0])
+
+        if fp0 is None:
+            continue
+
+        fp0_pos = fp0.GetPosition()
+
+        for i, ref in enumerate(refs):
+            fp = board.FindFootprintByReference(ref)
+
+            if fp is None:
+                continue
+
+            delta_vec = VECTOR2I_MM(delta[0] * i, delta[1] * i)
+            adj = VECTOR2I_MM(0, 0)
+
+            if adjustments:
+                adj = VECTOR2I_MM(adjustments[i][0], adjustments[i][1])
+
+            fp.SetPosition(fp0_pos + delta_vec + adj)
+
+            if "degrees" in arr:
+                fp.SetOrientation(EDA_ANGLE(arr["degrees"], pcbnew.DEGREES_T))
+
+
+def apply_spec(board, spec):
+    """
+    Shell: interprets declarative spec.
+
+    spec keys:
+      anchor: str ref for grid origin (default "SW_1_1")
+      grids: list[{prefix, rows, cols, mapping?, col_stagger?, except?, type?}]
+             type "pair" uses _apply_pair_grid with anchor2
+      rotations: list[{prefix, rows, cols, degrees, except?}]
+      mounts: list[{ref, offset? / c,r}] + anchor
+      arrays: list[{refs, delta, adjustments?, degrees?}]
+      hide: list[{type:"references", prefix, rows, cols} | {type:"references", refs:[...]} | {type:"shapes", ...}]
+      custom: list[callable(board, spec)] for bespoke thumb clusters etc.
+      anchor2: for pair grids (default derived)
+    """
+    anchor = spec.get("anchor", "SW_1_1")
+
+    # Grids
+    for g in spec.get("grids", []):
+        if g.get("type") == "pair":
+            a2 = spec.get("anchor2") or g.get("anchor2") or "SW_1_2"
+            _apply_pair_grid(board, anchor, a2, g)
+        else:
+            _apply_grid(board, anchor, g)
+
+    # Rotations
+    for r in spec.get("rotations", []):
+        _apply_rotations(board, r)
+
+    # Arrays (e.g., ch552_36 diodes)
+    for arr in spec.get("arrays", []):
+        _apply_arrays(board, [arr])
+
+    # Mounts
+    mounts = spec.get("mounts")
+    if mounts:
+        mount_anchor = spec.get("mount_anchor", anchor)
+        _apply_mounts(board, mount_anchor, mounts)
+
+    # Hide (imperative, but declarative list)
+    for h in spec.get("hide", []):
+        if h["type"] == "references":
+            if "refs" in h:
+                for ref in h["refs"]:
+                    fp = board.FindFootprintByReference(ref)
+
+                    if fp:
+                        fp.Reference().SetVisible(False)
+            else:
+                prefix, rows, cols = h["prefix"], h["rows"], h["cols"]
+
+                for r in range(1, rows + 1):
+                    for c in range(1, cols + 1):
+                        ref = f"{prefix}_{r}_{c}"
+                        fp = board.FindFootprintByReference(ref)
+
+                        if fp:
+                            fp.Reference().SetVisible(False)
+        elif h["type"] == "shapes":
+            layer_names = h.get("layers", ["F.Silkscreen", "B.Silkscreen"])
+
+            for ref in h.get("refs", []):
+                fp = board.FindFootprintByReference(ref)
+
+                if fp is None:
+                    continue
+
+                for item in fp.GraphicalItems():
+                    if isinstance(item, pcbnew.FP_SHAPE) and item.GetLayerName() in layer_names:
+                        item.DeleteStructure()
+
+    # Custom hooks (e.g., thumb cluster fan)
+    for fn in spec.get("custom", []):
+        fn(board, spec)

--- a/scripts/kicad_helpers/kicad_common.py
+++ b/scripts/kicad_helpers/kicad_common.py
@@ -1,250 +1,228 @@
+"""KiCad 10 helpers — board-aware, headless + Action Plugin.
+
+Assumes KiCad 10 (IU nm, EDA_ANGLE).
+
+Usage:
+  CLI:   board = pcbnew.LoadBoard("pcb/foo.kicad_pcb"); kicad_common.position_on_grid(board, ...)
+  GUI:   board = pcbnew.GetBoard(); kicad_common.position_on_grid(board, ...)
+"""
+
 import pcbnew
+from pcbnew import EDA_ANGLE, VECTOR2I_MM
 
-from pcbnew import VECTOR2I_MM
+
+def _set_orientation_deg(fp, degrees: float):
+    fp.SetOrientation(EDA_ANGLE(degrees, pcbnew.DEGREES_T))
 
 
-def footprints():
-    return pcbnew.GetBoard().Footprints()
+def footprints(board):
+    return board.Footprints()
 
 
 def footprint_ref(fp):
     return fp.Reference().GetText()
 
 
-def lock(refs):
-    all_fps = footprints()
-    fps = [f for f in all_fps if footprint_ref(f) in refs]
-    for f in fps:
-        f.SetLocked(True)
-    pcbnew.Refresh()
+def lock(board, refs):
+    for f in board.Footprints():
+        if footprint_ref(f) in refs:
+            f.SetLocked(True)
 
 
-def unlock(refs):
-    all_fps = footprints()
-    fps = [f for f in all_fps if footprint_ref(f) in refs]
-    for f in fps:
+def unlock(board, refs):
+    for f in board.Footprints():
+        if footprint_ref(f) in refs:
+            f.SetLocked(False)
+
+
+def unlock_all(board):
+    for f in board.Footprints():
         f.SetLocked(False)
-    pcbnew.Refresh()
-
-
-def unlock_all():
-    fps = footprints()
-    for f in fps:
-        f.SetLocked(False)
-    pcbnew.Refresh()
 
 
 def grid_ref(prefix, coord):
     (r, c) = coord
-    return "{prefix}_{r}_{c}".format(prefix=prefix, r=r, c=c)
+    return f"{prefix}_{r}_{c}"
 
 
-def position_offset_for_grid_coord(coord, col_spacing_mm = 19.05, row_spacing_mm = 19.05):
+def position_offset_for_grid_coord(coord, col_spacing_mm=19.05, row_spacing_mm=19.05):
     (r, c) = coord
     return VECTOR2I_MM(col_spacing_mm * (c - 1), row_spacing_mm * (r - 1))
 
 
-# Convenience function to get the position of a footprint
-def position_of_reference(ref):
-    footprint = pcbnew.GetBoard().FindFootprintByReference(ref)
-    if footprint:
-        return footprint.GetPosition()
-    else:
-        raise ValueError("No footprint with reference {ref}".format(ref=ref))
+def position_of_reference(board, ref):
+    fp = board.FindFootprintByReference(ref)
 
-def position_of_x_between_refs(ref1, ref2):
-    x1, _ = position_of_reference(ref1)
-    x2, _ = position_of_reference(ref2)
+    if fp:
+        return fp.GetPosition()
+
+    raise ValueError(f"No footprint with reference {ref}")
+
+
+def position_of_x_between_refs(board, ref1, ref2):
+    x1, _ = position_of_reference(board, ref1)
+    x2, _ = position_of_reference(board, ref2)
     return int((x1 + x2) / 2)
 
-def position_of_y_between_refs(ref1, ref2):
-    _, y1 = position_of_reference(ref1)
-    _, y2 = position_of_reference(ref2)
+
+def position_of_y_between_refs(board, ref1, ref2):
+    _, y1 = position_of_reference(board, ref1)
+    _, y2 = position_of_reference(board, ref2)
     return int((y1 + y2) / 2)
 
-def position_in_array(
-        refs,
-        delta_pos_mm,
-        adjustments_mm = None
-):
-    if len(refs) == 0:
+
+def position_in_array(board, refs, delta_pos_mm, adjustments_mm=None):
+    if not refs:
         return
 
-    fp_1_1_pos = position_of_reference(refs[0])
+    fp0_pos = position_of_reference(board, refs[0])
 
     for i, ref in enumerate(refs):
-        footprint = pcbnew.GetBoard().FindFootprintByReference(ref)
-        if footprint is None:
+        fp = board.FindFootprintByReference(ref)
+
+        if fp is None:
             continue
 
-        delta_vec = VECTOR2I_MM(delta_pos_mm[0] * i, delta_pos_mm[1] * i)
-        adjustment_vec = VECTOR2I_MM(0, 0)
+        delta = VECTOR2I_MM(delta_pos_mm[0] * i, delta_pos_mm[1] * i)
+        adj = VECTOR2I_MM(0, 0)
+
         if adjustments_mm:
-            adjustment_vec = VECTOR2I_MM(adjustments_mm[i][0], adjustments_mm[i][1])
-        footprint.SetPosition(fp_1_1_pos + delta_vec + adjustment_vec)
+            adj = VECTOR2I_MM(adjustments_mm[i][0], adjustments_mm[i][1])
+
+        fp.SetPosition(fp0_pos + delta + adj)
 
 
-# My PCB designs all tend to be oriented around ortholinear grids.
-# This helper function updates positions of footprints.
-#
-# e.g. for positioning SW_1_1 to SW_4_12 all relative to SW_1_1.
-#
-# Assumes refs are labelled by "logical" coords.
-# (e.g. on CH552-44 where it's SW_1_1 to SW_7_7).
-#
-# rows: number of rows in the "logical" grid (e.g. 4)
-# cols: number of columns in the "logical" grid (e.g. 12)
-# logical_coord_to_grid_coord: function to convert from logical coord to grid coord (useful for CH552-44)
-# stagger: None, or array of y offsets in mm per column
 def position_on_grid(
-        ref_prefix,
-        rows,
-        cols,
-        logical_coord_to_grid_coord = lambda x: x,
-        col_spacing_mm = 19.05,
-        row_spacing_mm = 19.05,
-        col_stagger = None,
-        except_refs = []
+    board,
+    ref_prefix,
+    rows,
+    cols,
+    logical_coord_to_grid_coord=lambda x: x,
+    col_spacing_mm=19.05,
+    row_spacing_mm=19.05,
+    col_stagger=None,
+    except_refs=(),
 ):
-    fp_1_1_pos = position_of_reference(grid_ref(ref_prefix, (1, 1)))
+    fp0_pos = position_of_reference(board, grid_ref(ref_prefix, (1, 1)))
+    adjusted_stagger = None
 
-    adjusted_col_stagger = None
     if col_stagger:
-        adjusted_col_stagger = [x - col_stagger[0] for x in col_stagger]
+        adjusted_stagger = [x - col_stagger[0] for x in col_stagger]
 
     for logical_coord in [(r, c) for r in range(1, rows + 1) for c in range(1, cols + 1)]:
         ref = grid_ref(ref_prefix, logical_coord)
+
         if ref in except_refs:
             continue
 
-        footprint = pcbnew.GetBoard().FindFootprintByReference(ref)
-        if footprint is None:
+        fp = board.FindFootprintByReference(ref)
+
+        if fp is None:
             continue
+
         grid_coord = logical_coord_to_grid_coord(logical_coord)
         stagger = VECTOR2I_MM(0, 0)
-        if adjusted_col_stagger:
-            stagger = VECTOR2I_MM(0, adjusted_col_stagger[grid_coord[1] - 1])
-        offset = position_offset_for_grid_coord(
-            coord = grid_coord,
-            col_spacing_mm = col_spacing_mm,
-            row_spacing_mm = row_spacing_mm
-        )
-        footprint.SetPosition(fp_1_1_pos + offset + stagger)
+
+        if adjusted_stagger:
+            stagger = VECTOR2I_MM(0, adjusted_stagger[grid_coord[1] - 1])
+
+        offset = position_offset_for_grid_coord(grid_coord, col_spacing_mm, row_spacing_mm)
+        fp.SetPosition(fp0_pos + offset + stagger)
 
 
-# Same as "Position on grid",
-# but for pairs (like the diode pairs on PyKey40, etc.)
 def position_pairs_on_grid(
+    board,
     ref_prefix,
     rows,
     cols,
-    grid_coord_to_logical_coord = lambda x: x,
-    logical_coord_to_grid_coord = lambda x: x,
-    col_spacing_mm = 19.05,
-    row_spacing_mm = 19.05
+    grid_coord_to_logical_coord=lambda x: x,
+    logical_coord_to_grid_coord=lambda x: x,
+    col_spacing_mm=19.05,
+    row_spacing_mm=19.05,
 ):
-    fp_1_1_pos = position_of_reference(grid_ref(ref_prefix, (1, 1)))
-    fp_1_2_pos = position_of_reference(grid_ref(ref_prefix, grid_coord_to_logical_coord((1, 2))))
+    fp0_pos = position_of_reference(board, grid_ref(ref_prefix, (1, 1)))
+    fp1_pos = position_of_reference(board, grid_ref(ref_prefix, grid_coord_to_logical_coord((1, 2))))
 
     for logical_coord in [(r, c) for r in range(1, rows + 1) for c in range(1, cols + 1)]:
         ref = grid_ref(ref_prefix, logical_coord)
-        footprint = pcbnew.GetBoard().FindFootprintByReference(ref)
-        if footprint is None:
+        fp = board.FindFootprintByReference(ref)
+
+        if fp is None:
             continue
+
         (gr, gc) = logical_coord_to_grid_coord(logical_coord)
+
         if gc % 2 == 1:
-            offset = position_offset_for_grid_coord(
-                coord = (gr, gc),
-                col_spacing_mm = col_spacing_mm,
-                row_spacing_mm = row_spacing_mm
-            )
-            footprint.SetPosition(fp_1_1_pos + offset)
+            offset = position_offset_for_grid_coord((gr, gc), col_spacing_mm, row_spacing_mm)
+            fp.SetPosition(fp0_pos + offset)
         else:
-            offset = position_offset_for_grid_coord(
-                coord = (gr, gc - 1),
-                col_spacing_mm = col_spacing_mm,
-                row_spacing_mm = row_spacing_mm
-            )
-            footprint.SetPosition(fp_1_2_pos + offset)
+            offset = position_offset_for_grid_coord((gr, gc - 1), col_spacing_mm, row_spacing_mm)
+            fp.SetPosition(fp1_pos + offset)
 
 
-def set_array_rotations(
-    refs,
-    rotation_degrees
-):
+def set_array_rotations(board, refs, rotation_degrees):
     for ref in refs:
-        footprint = pcbnew.GetBoard().FindFootprintByReference(ref)
-        if footprint is None:
+        fp = board.FindFootprintByReference(ref)
+
+        if fp is None:
             continue
-        footprint.SetOrientationDegrees(rotation_degrees)
+
+        _set_orientation_deg(fp, rotation_degrees)
 
 
-def set_rotations(
-    ref_prefix,
-    rows,
-    cols,
-    rotation_degrees,
-    except_refs = []
-):
+def set_rotations(board, ref_prefix, rows, cols, rotation_degrees, except_refs=()):
     for logical_coord in [(r, c) for r in range(1, rows + 1) for c in range(1, cols + 1)]:
         ref = grid_ref(ref_prefix, logical_coord)
+
         if ref in except_refs:
             continue
 
-        footprint = pcbnew.GetBoard().FindFootprintByReference(ref)
-        if footprint is None:
+        fp = board.FindFootprintByReference(ref)
+
+        if fp is None:
             continue
-        footprint.SetOrientationDegrees(rotation_degrees)
+
+        _set_orientation_deg(fp, rotation_degrees)
 
 
-def grid_refs(
-    ref_prefix,
-    rows,
-    cols
-):
+def grid_refs(ref_prefix, rows, cols):
     return [grid_ref(ref_prefix, (r, c)) for r in range(1, rows + 1) for c in range(1, cols + 1)]
 
 
-def hide_references(
-    refs
-):
+def hide_references(board, refs):
     for ref in refs:
-        footprint = pcbnew.GetBoard().FindFootprintByReference(ref)
-        if footprint is None:
+        fp = board.FindFootprintByReference(ref)
+
+        if fp is None:
             continue
-        footprint.Reference().SetVisible(False)
+
+        fp.Reference().SetVisible(False)
 
 
-def hide_fp_texts(
-    refs,
-    layer_names = ["F.Silkscreen", "B.Silkscreen"]
-):
+def hide_fp_texts(board, refs, layer_names=("F.Silkscreen", "B.Silkscreen")):
     for ref in refs:
-        footprint = pcbnew.GetBoard().FindFootprintByReference(ref)
-        if footprint is None:
+        fp = board.FindFootprintByReference(ref)
+
+        if fp is None:
             continue
-        for t in footprint.GraphicalItems():
+
+        for t in fp.GraphicalItems():
             pass
-            ## if isinstance(t, pcbnew.FP_TEXT) and t.GetLayerName() in layer_names:
-            ##     t.SetVisible(False)
 
 
-def delete_fp_shapes(
-    refs,
-    layer_names = ["F.Silkscreen", "B.Silkscreen"]
-):
+def delete_fp_shapes(board, refs, layer_names=("F.Silkscreen", "B.Silkscreen")):
     for ref in refs:
-        footprint = pcbnew.GetBoard().FindFootprintByReference(ref)
-        if footprint is None:
+        fp = board.FindFootprintByReference(ref)
+
+        if fp is None:
             continue
-        for t in footprint.GraphicalItems():
+
+        for t in fp.GraphicalItems():
             if isinstance(t, pcbnew.FP_SHAPE) and t.GetLayerName() in layer_names:
                 t.DeleteStructure()
 
 
-# Hide the text items in the footprint
-# for the given layer_names
-def hide_footprint_silkscreen_text(f, layer_names = ["F.Silkscreen", "B.Silkscreen"]):
+def hide_footprint_silkscreen_text(f, layer_names=("F.Silkscreen", "B.Silkscreen")):
     for t in f.GraphicalItems():
         if isinstance(t, pcbnew.FP_TEXT) and t.GetLayerName() in layer_names:
             t.SetVisible(False)

--- a/scripts/kicad_helpers/pico42.py
+++ b/scripts/kicad_helpers/pico42.py
@@ -1,169 +1,58 @@
-# Helper script for Pico42 PCB
-# to be used with Kicad scripting console.
-#
-# Use with:
-#    import sys
-#    sys.path.append('/home/rgoulter/github/keyboard-labs/scripts/kicad_helpers')
-#    import pico42
-
-# pcbnew.GetBoard().FindFootprintByReference("J2").SetPosition(pcbnew.VECTOR2I_MM(100, 100))
+# Helper for Pico42
 
 import pcbnew
-from pcbnew import wxPoint, VECTOR2I_MM
 from pcbnew import VECTOR2I_MM
-
-import kicad_common
-
+from . import engine
 
 ROWS = 4
 COLS = 12
 
+def _custom_u1(board, spec):
+    sw1 = board.FindFootprintByReference("SW_1_1")
+    sw12 = board.FindFootprintByReference("SW_1_12")
+    u1 = board.FindFootprintByReference("U1")
 
-def position_SWs():
-    kicad_common.position_on_grid(
-        ref_prefix = "SW",
-        rows = ROWS,
-        cols = COLS,
-    )
-    kicad_common.set_rotations(
-        ref_prefix = "SW",
-        rows = ROWS,
-        cols = COLS,
-        rotation_degrees = 180
-    )
+    if not (sw1 and sw12 and u1):
+        return
 
+    u1.SetPosition(pcbnew.VECTOR2I(int((sw1.GetPosition().x + sw12.GetPosition().x) / 2), u1.GetPosition().y))
 
-def position_Ds():
-    kicad_common.position_pairs_on_grid(
-        ref_prefix = "D",
-        rows = ROWS,
-        cols = COLS,
-        col_spacing_mm = 19.05,
-        row_spacing_mm = 19.05
-    )
-    kicad_common.set_rotations(
-        ref_prefix = "D",
-        rows = ROWS,
-        cols = COLS,
-        rotation_degrees = 270
-    )
+SPEC = {
+    "anchor": "SW_1_1",
+    "grids": [
+        {"prefix": "SW", "rows": ROWS, "cols": COLS},
+        {"prefix": "D", "rows": ROWS, "cols": COLS, "type": "pair"},
+    ],
+    "rotations": [
+        {"prefix": "SW", "rows": ROWS, "cols": COLS, "degrees": 180},
+        {"prefix": "D", "rows": ROWS, "cols": COLS, "degrees": 270},
+    ],
+    "mounts": [
+        {"ref": "H1", "c": 0.5, "r": 0.5},
+        {"ref": "H2", "c": 0.5, "r": 2.5},  # (R-1.5)=2.5
+        {"ref": "H3", "c": 10.5, "r": 2.5}, # (C-1.5)=10.5
+        {"ref": "H4", "c": 10.5, "r": 0.5},
+        {"ref": "H5", "c": 5.5, "r": 1.5},  # (C-1)/2=5.5, (R-1)/2=1.5
+        # H6 and H7-H10 use absolute mm offsets, encode as offset
+        {"ref": "H6", "offset": VECTOR2I_MM(4.5*19.05+5, 1.5*19.05)},
+        {"ref": "H7", "offset": VECTOR2I_MM(4.5*19.05+3, -4)},
+        {"ref": "H8", "offset": VECTOR2I_MM(4.5*19.05+3, 2.5*19.05-3)},
+        {"ref": "H9", "offset": VECTOR2I_MM(6.5*19.05-3, 2.5*19.05-3)},
+        {"ref": "H10", "offset": VECTOR2I_MM(6.5*19.05-3, -4)},
+    ],
+    "hide": [
+        {"type": "references", "prefix": "D", "rows": ROWS, "cols": COLS},
+        {"type": "references", "prefix": "SW", "rows": ROWS, "cols": COLS},  # via hide_fp_texts in old, but use references
+        {"type": "references", "refs": ["U1"]},
+        {"type": "references", "refs": [f"H{n}" for n in range(1, 20)]},
+    ],
+    "custom": [_custom_u1],
+}
 
-
-# position U1
-# so its x position is halfway between the
-# x of SW_1_1 and SW_1_12
-def position_U1():
-    sw_1_1 = pcbnew.GetBoard().FindFootprintByReference("SW_1_1")
-    sw_1_12 = pcbnew.GetBoard().FindFootprintByReference("SW_1_12")
-    sw_1_1_pos = sw_1_1.GetPosition()
-    sw_1_12_pos = sw_1_12.GetPosition()
-
-    u1 = pcbnew.GetBoard().FindFootprintByReference("U1")
-    u1_pos = u1.GetPosition()
-
-    u1.SetPosition(pcbnew.VECTOR2I(int((sw_1_1_pos.x + sw_1_12_pos.x) / 2), u1_pos.y))
-
-
-def position_Hs():
-    # Get position footprint by ref SW_1_1
-    sw_1_1 = pcbnew.GetBoard().FindFootprintByReference("SW_1_1")
-    sw_1_1_pos = sw_1_1.GetPosition()
-
-    U = 19.05
-    C = 12
-    R = 4
-
-    # Hs aren't a consistent grid,
-    # but some are similar.
-
-    # H1 - H5, the JJ40 mount hole positions
-    pcbnew.GetBoard().FindFootprintByReference("H1").SetPosition(
-        sw_1_1_pos + VECTOR2I_MM(0.5 * U, 0.5 * U)
-    )
-    pcbnew.GetBoard().FindFootprintByReference("H2").SetPosition(
-        sw_1_1_pos + VECTOR2I_MM(0.5 * U, (R - 1.5) * U)
-    )
-    pcbnew.GetBoard().FindFootprintByReference("H3").SetPosition(
-        sw_1_1_pos + VECTOR2I_MM((C - 1.5) * U, (R - 1.5) * U)
-    )
-    pcbnew.GetBoard().FindFootprintByReference("H4").SetPosition(
-        sw_1_1_pos + VECTOR2I_MM((C - 1.5) * U, 0.5 * U)
-    )
-    pcbnew.GetBoard().FindFootprintByReference("H5").SetPosition(
-        sw_1_1_pos + VECTOR2I_MM((C - 1) / 2 * U, (R - 1) / 2 * U)
-    )
-
-    # H6: additional mount, for sandwich cases
-    pcbnew.GetBoard().FindFootprintByReference("H6").SetPosition(
-        sw_1_1_pos + VECTOR2I_MM(4.5 * U + 5, (R - 1) / 2 * U)
-    )
-
-    # H7 - H10: mount holes for cover plate over dev board
-    m = 3
-    pcbnew.GetBoard().FindFootprintByReference("H7").SetPosition(
-        sw_1_1_pos + VECTOR2I_MM(4.5 * U + m, -7 + 3)
-    )
-    pcbnew.GetBoard().FindFootprintByReference("H8").SetPosition(
-        sw_1_1_pos + VECTOR2I_MM(4.5 * U + m, 2.5 * U - 3)
-    )
-    pcbnew.GetBoard().FindFootprintByReference("H9").SetPosition(
-        sw_1_1_pos + VECTOR2I_MM(6.5 * U - m, 2.5 * U - 3)
-    )
-    pcbnew.GetBoard().FindFootprintByReference("H10").SetPosition(
-        sw_1_1_pos + VECTOR2I_MM(6.5 * U - m, -7 + 3)
-    )
-
-
-def position_all():
-    position_SWs()
-    position_Ds()
-    position_U1()
-    position_Hs()
-    pcbnew.Refresh()
-
-
-def hide_d_labels():
-    kicad_common.hide_references(
-        refs = kicad_common.grid_refs(
-            ref_prefix = "D",
-            rows = ROWS,
-            cols = COLS,
-        ),
-    )
-    pcbnew.Refresh()
-
-
-def hide_sw_labels():
-    kicad_common.hide_fp_texts(
-        refs = kicad_common.grid_refs(
-            ref_prefix = "SW",
-            rows = ROWS,
-            cols = COLS,
-        ),
-        layer_names = ["F.Silkscreen", "B.Silkscreen"],
-    )
-    pcbnew.Refresh()
-
-
-def hide_u1_labels():
-    kicad_common.hide_fp_texts(refs = ["U1"])
-    pcbnew.Refresh()
-
-
-def hide_h_labels():
-    # H1-19, because there are surely less than 20 H footprints.
-    refs = ["H" + str(n) for n in range(1, 20)]
-    kicad_common.hide_references(refs = refs)
-    pcbnew.Refresh()
-
-
-def hide_labels():
-    hide_d_labels()
-    hide_sw_labels()
-    hide_u1_labels()
-    hide_h_labels()
-
-
-def fixup():
-    position_all()
-    hide_labels()
+def position_SWs(board): engine.apply_spec(board, {"anchor": SPEC["anchor"], "grids": [SPEC["grids"][0]], "rotations": [SPEC["rotations"][0]]})
+def position_Ds(board): engine.apply_spec(board, {"anchor": SPEC["anchor"], "grids": [SPEC["grids"][1]], "rotations": [SPEC["rotations"][1]]})
+def position_U1(board): _custom_u1(board, SPEC)
+def position_Hs(board): engine.apply_spec(board, {"anchor": SPEC["anchor"], "mounts": SPEC["mounts"]})
+def position_all(board): engine.apply_spec(board, {k: SPEC[k] for k in ("anchor","grids","rotations","mounts") if k in SPEC}); _custom_u1(board, SPEC)
+def hide_labels(board): engine.apply_spec(board, {"hide": SPEC["hide"]})
+def fixup(board): engine.apply_spec(board, SPEC)

--- a/scripts/kicad_helpers/pykey40.py
+++ b/scripts/kicad_helpers/pykey40.py
@@ -1,202 +1,89 @@
-# Helper script for PyKey40
-# to be used with Kicad scripting console.
-#
-# Use with:
-#    import sys
-#    sys.path.append('/home/rgoulter/github/keyboard-labs/scripts/kicad_helpers')
-#    import pykey40 as p
-
-# pcbnew.GetBoard().FindFootprintByReference("J2").SetPosition(pcbnew.VECTOR2I_MM(100, 100))
+# Helper for PyKey40
 
 import pcbnew
 from pcbnew import VECTOR2I_MM
-
-import kicad_common
-
+from . import engine
 
 ROWS = 4
 COLS = 12
-
-
-L_BLs = ["L_BL_{n}".format(n=n) for n in range(1, 4 + 1)]
-C_BLs = ["C_BL_{n}".format(n=n) for n in range(1, 4 + 1)]
-
-
+L_BLs = [f"L_BL_{n}" for n in range(1, 5)]
+C_BLs = [f"C_BL_{n}" for n in range(1, 5)]
 BL_GRID_COORDS = [(1.5, 1.5), (4.5, 1.5), (6.5, 1.5), (9.5, 1.5)]
 
+def _custom_bl(board, spec):
+    # L_BLs and C_BLs relative to SW_1_1, with c_bl offset from l_bl
+    sw1 = board.FindFootprintByReference("SW_1_1")
 
-def position_SWs():
-    kicad_common.position_on_grid(
-        ref_prefix = "SW",
-        rows = ROWS,
-        cols = COLS,
-    )
+    if sw1 is None:
+        return
 
-def position_Cs():
-    kicad_common.position_on_grid(
-        ref_prefix = "C",
-        rows = ROWS,
-        cols = COLS,
-        except_refs = ["C_1_2"],
-    )
-    kicad_common.set_rotations(
-        ref_prefix = "C",
-        rows = ROWS,
-        cols = COLS,
-        except_refs = ["C_1_2"],
-        rotation_degrees = -90
-    )
+    sw1_pos = sw1.GetPosition()
+    c_bl_1 = board.FindFootprintByReference("C_BL_1")
+    l_bl_1 = board.FindFootprintByReference("L_BL_1")
 
-def position_Hs():
-    # Get position footprint by ref SW_1_1
-    sw_1_1 = pcbnew.GetBoard().FindFootprintByReference("SW_1_1")
-    sw_1_1_pos = sw_1_1.GetPosition()
-
-    mounts = [
-        ("H1", (0.5, 0.5)),
-        ("H2", (12 - 1 - 0.5, 0.5)),
-        ("H3", (6 - 0.5, 1.5)),
-        ("H4", (0.5, 2.5)),
-        ("H5", (12 - 1 - 0.5, 2.5)),
-    ]
-
-    # set position of all SWs relative to SW_1_1
-    for (ref, (c, r)) in mounts:
-        fp = pcbnew.GetBoard().FindFootprintByReference(ref)
-        if fp is None:
-            continue
-        fp.SetPosition(sw_1_1_pos + VECTOR2I_MM(19.05 * c, 19.05 * r))
-
-def position_Ls():
-    kicad_common.position_on_grid(
-        ref_prefix = "L",
-        rows = ROWS,
-        cols = COLS,
-    )
-
-def position_C_BLs():
-    # Get position footprint by ref SW_1_1
-    sw_1_1 = pcbnew.GetBoard().FindFootprintByReference("SW_1_1")
-    sw_1_1_pos = sw_1_1.GetPosition()
-
-    c_bl_1_1 = pcbnew.GetBoard().FindFootprintByReference("C_BL_1")
-    l_bl_1_1 = pcbnew.GetBoard().FindFootprintByReference("L_BL_1")
-    c_offset = c_bl_1_1.GetPosition() - l_bl_1_1.GetPosition()
-
-    for idx, ref in enumerate(C_BLs):
-        c_bl = pcbnew.GetBoard().FindFootprintByReference(ref)
-        if c_bl is None:
-            continue
-        grid_coord = BL_GRID_COORDS[idx]
-        c_bl.SetPosition(sw_1_1_pos + c_offset + VECTOR2I_MM(19.05 * grid_coord[0], 19.05 * grid_coord[1]))
-        c_bl.SetOrientationDegrees(c_bl_1_1.GetOrientationDegrees())
-
-def position_L_BLs():
-    # Get position footprint by ref SW_1_1
-    sw_1_1 = pcbnew.GetBoard().FindFootprintByReference("SW_1_1")
-    sw_1_1_pos = sw_1_1.GetPosition()
+    if c_bl_1 is None or l_bl_1 is None:
+        c_offset = VECTOR2I_MM(0, 0)
+    else:
+        c_offset = c_bl_1.GetPosition() - l_bl_1.GetPosition()
 
     for idx, ref in enumerate(L_BLs):
-        l_bl = pcbnew.GetBoard().FindFootprintByReference(ref)
-        if l_bl is None:
+        fp = board.FindFootprintByReference(ref)
+
+        if fp is None:
             continue
-        grid_coord = BL_GRID_COORDS[idx]
-        l_bl.SetPosition(sw_1_1_pos + VECTOR2I_MM(19.05 * grid_coord[0], 19.05 * grid_coord[1]))
 
+        gc = BL_GRID_COORDS[idx]
+        fp.SetPosition(sw1_pos + VECTOR2I_MM(19.05*gc[0], 19.05*gc[1]))
 
-# position the Ds
-#
-# Ds are spaced apart by 19.05mm in rows and columns
-# starting from where D_1_1 and D_1_2 are placed.
-def position_Ds():
-    kicad_common.position_pairs_on_grid(
-        ref_prefix = "D",
-        rows = ROWS,
-        cols = COLS,
-        col_spacing_mm = 19.05,
-        row_spacing_mm = 19.05
-    )
+    for idx, ref in enumerate(C_BLs):
+        fp = board.FindFootprintByReference(ref)
 
+        if fp is None:
+            continue
 
-def position_all():
-    position_SWs()
-    position_Ds()
-    position_Cs()
-    position_Hs()
-    position_Ls()
-    position_C_BLs()
-    position_L_BLs()
-    pcbnew.Refresh()
+        gc = BL_GRID_COORDS[idx]
+        # orientation copies l_bl
+        l_ref = L_BLs[idx]
+        l_fp = board.FindFootprintByReference(l_ref)
+        fp.SetPosition(sw1_pos + c_offset + VECTOR2I_MM(19.05*gc[0], 19.05*gc[1]))
 
-def hide_d_labels():
-    kicad_common.hide_references(
-        refs = kicad_common.grid_refs(
-            ref_prefix = "D",
-            rows = ROWS,
-            cols = COLS,
-        ),
-    )
-    pcbnew.Refresh()
+        if l_fp:
+            fp.SetOrientation(l_fp.GetOrientation())
 
-def hide_sw_labels():
-    kicad_common.hide_fp_texts(
-        refs = kicad_common.grid_refs(
-            ref_prefix = "SW",
-            rows = ROWS,
-            cols = COLS,
-        ),
-        layer_names = ["F.Silkscreen", "B.Silkscreen"],
-    )
-    pcbnew.Refresh()
+SPEC = {
+    "anchor": "SW_1_1",
+    "grids": [
+        {"prefix": "SW", "rows": ROWS, "cols": COLS},
+        {"prefix": "C", "rows": ROWS, "cols": COLS, "except": ["C_1_2"]},
+        {"prefix": "L", "rows": ROWS, "cols": COLS},
+        {"prefix": "D", "rows": ROWS, "cols": COLS, "type": "pair"},
+    ],
+    "rotations": [
+        {"prefix": "C", "rows": ROWS, "cols": COLS, "except": ["C_1_2"], "degrees": -90},
+    ],
+    "mounts": [
+        {"ref": "H1", "c": 0.5, "r": 0.5},
+        {"ref": "H2", "c": 10.5, "r": 0.5}, # 12-1-0.5 =10.5
+        {"ref": "H3", "c": 5.5, "r": 1.5},  # 6-0.5=5.5
+        {"ref": "H4", "c": 0.5, "r": 2.5},
+        {"ref": "H5", "c": 10.5, "r": 2.5},
+    ],
+    "custom": [_custom_bl],
+    "hide": [
+        {"type": "references", "prefix": "D", "rows": ROWS, "cols": COLS},
+        {"type": "references", "prefix": "SW", "rows": ROWS, "cols": COLS},
+        {"type": "references", "refs": ["U1"]},
+        {"type": "references", "refs": [f"H{n}" for n in range(1,20)]},
+    ],
+}
 
-# H1-5
-def hide_h_labels():
-    # H1-19, because there are surely less than 20 H footprints.
-    refs = ["H" + str(n) for n in range(1, 20)]
-    kicad_common.hide_references(refs = refs)
-    pcbnew.Refresh()
-
-def hide_l_labels():
-    kicad_common.hide_references(
-        refs = kicad_common.grid_refs(
-            ref_prefix = "L",
-            rows = ROWS,
-            cols = COLS,
-        ),
-    )
-    pcbnew.Refresh()
-
-def hide_c_labels():
-    kicad_common.hide_references(
-        refs = kicad_common.grid_refs(
-            ref_prefix = "C",
-            rows = ROWS,
-            cols = COLS,
-        ),
-    )
-    pcbnew.Refresh()
-
-def hide_l_bl_labels():
-    kicad_common.hide_references(
-        refs = L_BLs,
-    )
-    pcbnew.Refresh()
-
-def hide_c_bl_labels():
-    kicad_common.hide_references(
-        refs = C_BLs,
-    )
-    pcbnew.Refresh()
-
-def hide_labels():
-    hide_d_labels()
-    hide_sw_labels()
-    hide_h_labels()
-    hide_l_labels()
-    hide_c_labels()
-    hide_l_bl_labels()
-    hide_c_bl_labels()
-
-def fixup():
-    position_all()
-    hide_labels()
+def position_SWs(board): engine.apply_spec(board, {"anchor": SPEC["anchor"], "grids": [SPEC["grids"][0]]})
+def position_Cs(board): engine.apply_spec(board, {"anchor": SPEC["anchor"], "grids": [SPEC["grids"][1]], "rotations": [SPEC["rotations"][0]]})
+def position_Hs(board): engine.apply_spec(board, {"anchor": SPEC["anchor"], "mounts": SPEC["mounts"]})
+def position_Ls(board): engine.apply_spec(board, {"anchor": SPEC["anchor"], "grids": [SPEC["grids"][2]]})
+def position_C_BLs(board): _custom_bl(board, SPEC)
+def position_L_BLs(board): _custom_bl(board, SPEC)
+def position_Ds(board): engine.apply_spec(board, {"anchor": SPEC["anchor"], "grids": [SPEC["grids"][3]]})
+def position_all(board): engine.apply_spec(board, {k: SPEC[k] for k in ("anchor","grids","rotations","mounts") if k in SPEC}); _custom_bl(board, SPEC)
+def hide_labels(board): engine.apply_spec(board, {"hide": SPEC["hide"]})
+def fixup(board): engine.apply_spec(board, SPEC)


### PR DESCRIPTION
- Rewrites the Kicad helpers so they can be invoked both by CLI, as well as through the UI as a plugin.

   - This update follows changes to Python scripting in Kicad 6. (It still works through the console, but the plugin interface has been improved).

- Also rewrites the helpers to "functional core, imperative shell", so that each of the keyboard definitions is a spec value, which an engine applies.
  - Impressively, even though this PR adds some code for CLI entrypoint and Kicad plugin entrypoint, it's *still* a huge net reduction in code!