### PR TITLE
nix: broaden systems to default

### DIFF
--- a/firmware/keyberon/flake-module.nix
+++ b/firmware/keyberon/flake-module.nix
@@ -26,21 +26,25 @@
         targets."thumbv7em-none-eabihf".latest.rust-std
       ];
     uf2conv = pkgs.callPackage ../../nix/pkgs/uf2conv {};
+    isLinux = pkgs.stdenv.hostPlatform.isLinux;
   in {
     devShells.firmware-keyberon = pkgs.mkShell {
-      nativeBuildInputs = [
-        pkgs.cargo-binutils
-        pkgs.elf2uf2-rs
-        pkgs.fzf
-        pkgs.hidrd
-        pkgs.just
-        pkgs.rust-analyzer
-        pkgs.usbutils
-        pkgs.probe-rs-tools
-        pkgs.stlink
-        toolchain
-        uf2conv
-      ];
+      nativeBuildInputs =
+        [
+          pkgs.cargo-binutils
+          pkgs.elf2uf2-rs
+          pkgs.fzf
+          pkgs.just
+          pkgs.rust-analyzer
+          pkgs.probe-rs-tools
+          toolchain
+          uf2conv
+        ]
+        ++ lib.optionals isLinux [
+          pkgs.hidrd
+          pkgs.stlink
+          pkgs.usbutils
+        ];
       RUSTC = "${toolchain}/bin/rustc";
       RUST_SRC_PATH = "${toolchain}/lib/rustlib/src";
     };

--- a/flake.lock
+++ b/flake.lock
@@ -956,16 +956,16 @@
     },
     "systems_6": {
       "locked": {
-        "lastModified": 1680978846,
-        "narHash": "sha256-Gtqg8b/v49BFDpDetjclCYXm8mAnTrUzR0JnE2nv5aw=",
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
         "owner": "nix-systems",
-        "repo": "x86_64-linux",
-        "rev": "2ecfcac5e15790ba6ce360ceccddb15ad16d08a8",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
         "type": "github"
       },
       "original": {
         "owner": "nix-systems",
-        "repo": "x86_64-linux",
+        "repo": "default",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -38,7 +38,7 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
-    systems.url = "github:nix-systems/x86_64-linux";
+    systems.url = "github:nix-systems/default";
 
     treefmt-nix = {
       url = "github:numtide/treefmt-nix";
@@ -54,7 +54,13 @@
     ...
   }:
     flake-parts.lib.mkFlake {inherit inputs;} {
-      systems = import systems;
+      # nixpkgs-unstable 26.11 dropped x86_64-darwin (use 26.05-darwin if needed).
+      # Keep Apple Silicon Darwin; pcb/KiCad stays Linux-only via perSystem guards.
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "aarch64-darwin"
+      ];
 
       imports = [
         devenv.flakeModule

--- a/nix/flake-module.nix
+++ b/nix/flake-module.nix
@@ -7,20 +7,38 @@
   perSystem =
     {
       pkgs,
+      system,
       ...
     }:
     let
+      isLinux = pkgs.stdenv.hostPlatform.isLinux;
+      isX86_64Linux = system == "x86_64-linux";
       qmkPackages =
-        lib.mapAttrs' (name: p: lib.nameValuePair "qmk-${name}" p)
-          (lib.filterAttrs (_: p: lib.isDerivation p) (pkgs.callPackage ./pkgs/qmk {}));
+        if isLinux then
+          lib.mapAttrs' (name: p: lib.nameValuePair "qmk-${name}" p)
+            (lib.filterAttrs (_: p: lib.isDerivation p) (pkgs.callPackage ./pkgs/qmk {}))
+        else {};
     in
     {
       packages =
         {
-          gcc-arm-a-embedded = pkgs.callPackage ./pkgs/gcc-arm-a-embedded {};
           uf2conv = pkgs.callPackage ./pkgs/uf2conv {};
           wchisp = pkgs.callPackage ./pkgs/wchisp {};
         }
+        // lib.optionalAttrs isX86_64Linux {
+          gcc-arm-a-embedded = pkgs.callPackage ./pkgs/gcc-arm-a-embedded {};
+        }
         // qmkPackages;
+
+      devShells = {
+        # Portable shell with basic dev tools (just, make, etc.) — available on Linux and Darwin.
+        # Heavier Linux-only shells (pcb) and Rust firmware shells are defined elsewhere.
+        tools = pkgs.mkShell {
+          packages = [
+            pkgs.just
+            pkgs.gnumake
+          ];
+        };
+      };
     };
 }

--- a/pcb/flake-module.nix
+++ b/pcb/flake-module.nix
@@ -8,17 +8,22 @@
       ...
     }:
     let
+      isLinux = pkgs.stdenv.hostPlatform.isLinux;
       pcbPackages =
-        lib.mapAttrs' (name: p: lib.nameValuePair "pcb-${name}" p)
-          (lib.filterAttrs (_: p: lib.isDerivation p) (pkgs.callPackage ./. {}));
+        if isLinux then
+          lib.mapAttrs' (name: p: lib.nameValuePair "pcb-${name}" p)
+            (lib.filterAttrs (_: p: lib.isDerivation p) (pkgs.callPackage ./. {}))
+        else {};
     in
     {
-      checks.pcb = pkgs.symlinkJoin {
-        name = "keyboard-labs-pcb";
-        paths = builtins.attrValues pcbPackages;
+      checks = lib.optionalAttrs isLinux {
+        pcb = pkgs.symlinkJoin {
+          name = "keyboard-labs-pcb";
+          paths = builtins.attrValues pcbPackages;
+        };
       };
 
-      devShells = {
+      devShells = lib.optionalAttrs isLinux {
         pcb = import ./shell.nix {
           inherit pkgs;
           on-nixos = false;
@@ -30,6 +35,6 @@
         };
       };
 
-      packages = pcbPackages;
+      packages = lib.optionalAttrs isLinux pcbPackages;
     };
 }


### PR DESCRIPTION
- Currently, the `kicad` nix package only works for Linux.
- So the pcb `shell` which provides `kibot` only meaningfully works for Linux.
- Nevertheless, it may be useful to allow Nix to provide other tools. e.g. `just` or so.