### PR TITLE
Pcb kibot bom adjust

### DIFF
--- a/pcb/config.kibot.yaml
+++ b/pcb/config.kibot.yaml
@@ -2,17 +2,6 @@ kibot:
   version: 1
 
 filters:
-  - name: fix_rotation
-    comment: 'Adjust rotation for JLC'
-    type: rot_footprint
-    extend: false
-    invert_bottom: true
-    rotations:
-      - ["^SOIC-8", 90.0]
-      - ["^TSSOP-20", 90.0]
-      - ["^USB_C_Receptacle", 180.0]
-      - ["^SOT-23-6", 0.0]
-      - ["^LED_WS2812B_PLCC4_5.0x5.0mm", 90.0]
   - name: dnp
     comment: 'Exclude DNP / Do Not Populate (KiCad, KiCost, KiBom)'
     type: generic
@@ -125,7 +114,6 @@ outputs:
       format: CSV
       units: millimeters
       separate_files_for_front_and_back: false
-      pre_transform: fix_rotation
       exclude_filter: [_mechanical, dnp, _kibom_dnp, _kicost_dnp]
       only_smd: false
       right_digits: 6

--- a/pcb/config.kibot.yaml
+++ b/pcb/config.kibot.yaml
@@ -104,10 +104,10 @@ outputs:
     dir: "+fabrication/%f/"
     run_by_default: false
     options:
-      output: '%f_cpl_jlc_%i.%x'
+      output: '%f_cpl_jlc.%x'
       format: CSV
       units: millimeters
-      separate_files_for_front_and_back: true
+      separate_files_for_front_and_back: false
       pre_transform: fix_rotation
       exclude_filter: [_mechanical]
       right_digits: 6

--- a/pcb/config.kibot.yaml
+++ b/pcb/config.kibot.yaml
@@ -110,6 +110,7 @@ outputs:
       separate_files_for_front_and_back: false
       pre_transform: fix_rotation
       exclude_filter: [_mechanical]
+      only_smd: false
       right_digits: 6
       columns:
         - id: Ref

--- a/pcb/config.kibot.yaml
+++ b/pcb/config.kibot.yaml
@@ -109,7 +109,6 @@ outputs:
       units: millimeters
       separate_files_for_front_and_back: true
       pre_transform: fix_rotation
-      only_smd: true
       right_digits: 6
       columns:
         - id: Ref

--- a/pcb/config.kibot.yaml
+++ b/pcb/config.kibot.yaml
@@ -109,6 +109,7 @@ outputs:
       units: millimeters
       separate_files_for_front_and_back: true
       pre_transform: fix_rotation
+      exclude_filter: [_mechanical]
       right_digits: 6
       columns:
         - id: Ref
@@ -133,6 +134,7 @@ outputs:
       output: '%f_%i_jlc.%x'
       ref_separator: ','
       sort_style: 'ref'
+      exclude_filter: [_mechanical]
       columns:
         - field: Value
           name: Comment

--- a/pcb/config.kibot.yaml
+++ b/pcb/config.kibot.yaml
@@ -13,6 +13,23 @@ filters:
       - ["^USB_C_Receptacle", 180.0]
       - ["^SOT-23-6", 0.0]
       - ["^LED_WS2812B_PLCC4_5.0x5.0mm", 90.0]
+  - name: dnp
+    comment: 'Exclude DNP / Do Not Populate (KiCad, KiCost, KiBom)'
+    type: generic
+    exclude_kicad_dnp: true
+    exclude_not_in_bom: true
+    exclude_not_on_board: true
+    exclude_virtual: true
+    exclude_any:
+      # 'SolderWire' footprints should be excluded.
+      - column: Footprint
+        regex: SolderWire
+      # 'PinHeaders' should excluded from PCBA BOM
+      - column: Footprint
+        regex: PinHeader
+      # Exclude empty footprint from PCBA BOM.
+      - column: Footprint
+        regex: ^$
 
 outputs:
   - name: "gerber_zip"
@@ -109,7 +126,7 @@ outputs:
       units: millimeters
       separate_files_for_front_and_back: false
       pre_transform: fix_rotation
-      exclude_filter: [_mechanical]
+      exclude_filter: [_mechanical, dnp, _kibom_dnp, _kicost_dnp]
       only_smd: false
       right_digits: 6
       columns:
@@ -135,7 +152,7 @@ outputs:
       output: '%f_%i_jlc.%x'
       ref_separator: ','
       sort_style: 'ref'
-      exclude_filter: [_mechanical]
+      exclude_filter: [_mechanical, dnp, _kibom_dnp, _kicost_dnp]
       columns:
         - field: Value
           name: Comment


### PR DESCRIPTION
- Remove "only smd": JLCPCB PCBA can do some T.H. components. (e.g. PJ-320A for the splits; or even some MX-compatible switches for those who can tolerate plateless).
- Expand DNP. The PCBA BOM/CPL was outputting stuff which shouldn't be placed.
- Remove the rotation fixes. These weren't reliable.

This seems to improve the UX for fabricating PCBA with JLCPCB.