### PR TITLE
Justfile tidy

### DIFF
--- a/cad/justfile
+++ b/cad/justfile
@@ -1,13 +1,5 @@
 # cad — UX wrappers for cad/*/Makefile (openscad → stl/dxf/svg/png)
 
-# list scad sources
-[doc("list cad sources")]
-list:
-    @echo "keyboard_case (3dp-*.scad → .stl):"
-    @ls {{source_directory()}}/keyboard_case/3dp-*.scad 2>/dev/null | grep -v "3dp-constants.scad" | xargs -n1 basename | sed 's/^/  /' || echo "  (none)"
-    @echo "keyboard_plates (keyboard-pykey40/*.scad → .dxf/.svg):"
-    @ls {{source_directory()}}/keyboard_plates/keyboard-pykey40/*.scad 2>/dev/null | xargs -n1 basename | sed 's/^/  /' || echo "  (none)"
-
 # 3D-print case: `just cad::case` (all) or `just cad::case 3dp-pico42-mx-socketed`
 [doc("build cad case stls (all or single, chooser if no arg)")]
 case file="":
@@ -16,27 +8,32 @@ case file="":
     file="{{file}}"
     dir="{{source_directory()}}/keyboard_case"
     if [ -z "$file" ]; then
-        # no arg: if interactive terminal and fzf, offer chooser, else build all
-        if [ -t 0 ] && command -v fzf >/dev/null 2>&1; then
-            choice=$( (echo "[all]"; ls "$dir"/3dp-*.scad 2>/dev/null | grep -v "3dp-constants.scad" | xargs -n1 basename -s .scad) | fzf --prompt="cad case> " --height=40% --reverse || true)
-            if [ -z "$choice" ]; then exit 1; fi
-            if [ "$choice" = "[all]" ]; then
-                make -C "$dir" 3dp
-                exit 0
-            fi
-            file="$choice"
-        else
-            make -C "$dir" 3dp
-            exit 0
-        fi
+      choice=$(
+        (
+          echo "[all]"
+          ls "$dir"/3dp-*.scad 2>/dev/null \
+            | grep -v "3dp-constants.scad" \
+            | xargs -n1 basename -s .scad
+        ) \
+          | fzf --prompt="cad case> " \
+            --height=40% \
+            --reverse \
+          || true
+      )
+      [ -z "$choice" ] && exit 1
+      if [ "$choice" = "[all]" ]; then
+        make -C "$dir" 3dp
+        exit 0
+      fi
+      file="$choice"
     fi
     # allow with or without extension
     if [[ "$file" == *.stl ]]; then
-        make -C "$dir" "$file"
+      make -C "$dir" "$file"
     elif [[ "$file" == *.scad ]]; then
-        make -C "$dir" "${file%.scad}.stl"
+      make -C "$dir" "${file%.scad}.stl"
     else
-        make -C "$dir" "$file.stl"
+      make -C "$dir" "$file.stl"
     fi
 
 # plates: `just cad::plates` (all) or `just cad::plates jj40_switch_plate`
@@ -47,26 +44,31 @@ plates file="":
     file="{{file}}"
     dir="{{source_directory()}}/keyboard_plates/keyboard-pykey40"
     if [ -z "$file" ]; then
-        if [ -t 0 ] && command -v fzf >/dev/null 2>&1; then
-            choice=$( (echo "[all]"; ls "$dir"/*.scad 2>/dev/null | xargs -n1 basename -s .scad) | fzf --prompt="cad plates> " --height=40% --reverse || true)
-            [ -z "$choice" ] && exit 1
-            if [ "$choice" = "[all]" ]; then
-                make -C "$dir" all
-                exit 0
-            fi
-            file="$choice"
-        else
-            make -C "$dir" all
-            exit 0
-        fi
+      choice=$(
+        (
+          echo "[all]"
+          ls "$dir"/*.scad 2>/dev/null \
+            | xargs -n1 basename -s .scad
+        ) \
+          | fzf --prompt="cad plates> " \
+            --height=40% \
+            --reverse \
+          || true
+      )
+      [ -z "$choice" ] && exit 1
+      if [ "$choice" = "[all]" ]; then
+        make -C "$dir" all
+        exit 0
+      fi
+      file="$choice"
     fi
     # support dxf/svg or bare stem
     if [[ "$file" == *.dxf || "$file" == *.svg ]]; then
-        make -C "$dir" "$file"
+      make -C "$dir" "$file"
     elif [[ "$file" == *.scad ]]; then
-        make -C "$dir" "${file%.scad}.dxf" "${file%.scad}.svg"
+      make -C "$dir" "${file%.scad}.dxf" "${file%.scad}.svg"
     else
-        make -C "$dir" "$file.dxf" "$file.svg"
+      make -C "$dir" "$file.dxf" "$file.svg"
     fi
 
 [doc("clean cad artifacts")]
@@ -77,4 +79,5 @@ clean:
 # filter-out 3dp-constants.scad like the Makefile does
 [doc("interactive chooser for cad recipes")]
 choose:
-    @just --choose --chooser "fzf --prompt='cad> ' --height=40% --reverse" 2>/dev/null || just --choose
+    @just --choose --chooser "fzf --prompt='cad> ' --height=40% --reverse" 2>/dev/null \
+      || just --choose

--- a/firmware/justfile
+++ b/firmware/justfile
@@ -1,20 +1,7 @@
 # firmware — UX wrappers for firmware/keyberon/Makefile
 # Delegates to firmware/keyberon/Makefile (keeps Make for file-deps).
-# `just firmware::list` shows bins; `just firmware::build <bin>` uses chooser.
 
 _kb_dir := source_directory() + "/keyberon"
-
-# list all firmware bins + examples (from wildcard in Makefile)
-[doc("list available firmware bins and examples")]
-list:
-    @echo "RP2040 bins (rp2040/src/bin):"
-    @ls {{_kb_dir}}/rp2040/src/bin/*.rs 2>/dev/null | xargs -n1 basename -s .rs | sed 's/^/  /' || echo "  (none)"
-    @echo "STM32F4 bins (stm32f4/src/bin):"
-    @ls {{_kb_dir}}/stm32f4/src/bin/*.rs 2>/dev/null | xargs -n1 basename -s .rs | sed 's/^/  /' || echo "  (none)"
-    @echo "Examples:"
-    @ls {{_kb_dir}}/rp2040/examples/*.rs {{_kb_dir}}/stm32f4/examples/*.rs 2>/dev/null | xargs -n1 basename -s .rs | sed 's/^/  example-/; s/^/  /' || true
-    @echo ""
-    @echo "Make targets: all, clean, targets.bin, targets.uf2"
 
 # build all (bins + examples → .bin + .uf2 in DEST_DIR)
 [doc("build all firmware (make all → .bin + .uf2)")]
@@ -41,20 +28,31 @@ build bin="":
     bin="{{bin}}"
     kb="{{_kb_dir}}"
     if [ -z "$bin" ]; then
-        if command -v fzf >/dev/null 2>&1; then
-            all=$( (ls "$kb"/rp2040/src/bin/*.rs "$kb"/stm32f4/src/bin/*.rs 2>/dev/null | xargs -n1 basename -s .rs; echo "---"; ls "$kb"/rp2040/examples/*.rs "$kb"/stm32f4/examples/*.rs 2>/dev/null | xargs -n1 basename -s .rs | sed 's/^/example-/') | sort)
-            bin=$(echo "$all" | grep -v "^---$" | fzf --prompt="firmware build> " --height=40% --reverse || true)
-        else
-            echo "Usage: just firmware::build <bin>" >&2
-            just firmware::list >&2
-            exit 1
-        fi
+      all=$(
+        (
+          ls "$kb"/rp2040/src/bin/*.rs "$kb"/stm32f4/src/bin/*.rs 2>/dev/null \
+            | xargs -n1 basename -s .rs
+          echo "---"
+          ls "$kb"/rp2040/examples/*.rs "$kb"/stm32f4/examples/*.rs 2>/dev/null \
+            | xargs -n1 basename -s .rs \
+            | sed 's/^/example-/'
+        ) \
+          | sort
+      )
+      bin=$(
+        echo "$all" \
+          | grep -v "^---$" \
+          | fzf --prompt="firmware build> " \
+            --height=40% \
+            --reverse \
+          || true
+      )
     fi
     [ -z "$bin" ] && exit 1
     if [[ "$bin" == example-* ]]; then
-        make -C "$kb" "example-${bin#example-}.bin" "example-${bin#example-}.uf2"
+      make -C "$kb" "example-${bin#example-}.bin" "example-${bin#example-}.uf2"
     else
-        make -C "$kb" "$bin.bin" "$bin.uf2"
+      make -C "$kb" "$bin.bin" "$bin.uf2"
     fi
 
 [doc("cargo build (no objcopy) — chooser selects package/bin")]
@@ -67,23 +65,34 @@ cargo bin="" release="true":
     flag=""
     if [ "$release" = "true" ]; then flag="--release"; fi
     if [ -z "$bin" ]; then
-        if command -v fzf >/dev/null 2>&1; then
-            all=$(ls "$kb"/rp2040/src/bin/*.rs "$kb"/stm32f4/src/bin/*.rs 2>/dev/null | xargs -n1 basename -s .rs | sort)
-            bin=$(echo "$all" | fzf --prompt="firmware cargo> " --height=40% --reverse || true)
-        else
-            echo "Usage: just firmware::cargo <bin> [release=true|false]" >&2; exit 1
-        fi
+      all=$(
+        ls "$kb"/rp2040/src/bin/*.rs "$kb"/stm32f4/src/bin/*.rs 2>/dev/null \
+          | xargs -n1 basename -s .rs \
+          | sort
+      )
+      bin=$(
+        echo "$all" \
+          | fzf --prompt="firmware cargo> " \
+            --height=40% \
+            --reverse \
+          || true
+      )
     fi
     [ -z "$bin" ] && exit 1
     # try rp2040 first, then stm32f4
     if [ -f "$kb/rp2040/src/bin/$bin.rs" ]; then
-        cargo build --target thumbv6m-none-eabi --package keyboard-labs-keyberon-rp2040 --bin "$bin" $flag
+      cargo build --target thumbv6m-none-eabi \
+        --package keyboard-labs-keyberon-rp2040 \
+        --bin "$bin" $flag
     elif [ -f "$kb/stm32f4/src/bin/$bin.rs" ]; then
-        cargo build --target thumbv7em-none-eabihf --package keyboard-labs-keyberon-stm32f4 --bin "$bin" $flag
+      cargo build --target thumbv7em-none-eabihf \
+        --package keyboard-labs-keyberon-stm32f4 \
+        --bin "$bin" $flag
     else
-        echo "unknown bin: $bin" >&2; exit 1
+      echo "unknown bin: $bin" >&2; exit 1
     fi
 
 [doc("interactive chooser for firmware recipes")]
 choose:
-    @just --choose --chooser "fzf --prompt='firmware> ' --height=40% --reverse" 2>/dev/null || just --choose
+    @just --choose --chooser "fzf --prompt='firmware> ' --height=40% --reverse" 2>/dev/null \
+      || just --choose

--- a/justfile
+++ b/justfile
@@ -6,14 +6,9 @@ mod firmware
 mod cad
 mod nix
 
-# default: interactive chooser if available, else list
+# default: interactive chooser (assumes fzf; non-interactive use `make` directly)
 default:
-    @if command -v fzf >/dev/null 2>&1; then \
-        just --choose; \
-    else \
-        echo "tip: install fzf for interactive chooser (just --choose)"; \
-        just --list --list-submodules; \
-    fi
+    @just --choose
 
 # list all recipes including submodules
 [doc("list all recipes")]
@@ -27,7 +22,11 @@ fmt:
 
 [doc("check formatting without writing")]
 fmt-check:
-    @if command -v treefmt >/dev/null 2>&1; then treefmt --fail-on-change; else nix fmt -- --fail-on-change; fi
+    @if command -v treefmt >/dev/null 2>&1; then \
+      treefmt --fail-on-change; \
+    else \
+      nix fmt -- --fail-on-change; \
+    fi
 
 [doc("nix flake check (pcb + firmware builds)")]
 check:

--- a/nix/justfile
+++ b/nix/justfile
@@ -1,10 +1,5 @@
 # nix — wrappers for `nix build` / `nix flake check`
 
-# list available flake packages (pcb-*, qmk-*, firmware)
-[doc("list flake packages")]
-list:
-    @nix eval .#packages.x86_64-linux --apply 'pkgs: builtins.concatStringsSep "\n" (builtins.attrNames pkgs)' 2>/dev/null | tr -d '"' | tr ',' '\n' | sed 's/^/  /' || nix flake show 2>&1 | sed 's/^/  /'
-
 [doc("nix flake check (pcb + firmware)")]
 check:
     nix flake check --show-trace
@@ -15,16 +10,29 @@ pcb board="":
     set -euo pipefail
     board="{{board}}"
     if [ -z "$board" ]; then
-        if command -v fzf >/dev/null 2>&1; then
-            pkgs=$(nix eval .#packages.x86_64-linux --apply 'pkgs: builtins.concatStringsSep "\n" (builtins.attrNames pkgs)' 2>/dev/null | tr -d '"' | tr ',' '\n' | grep '^pcb-' || true)
-            if [ -z "$pkgs" ]; then pkgs=$(ls pcb/*.kicad_pcb 2>/dev/null | xargs -n1 basename -s .kicad_pcb | sed 's/^/pcb-/'); fi
-            choice=$(echo "$pkgs" | fzf --prompt="nix pcb> " --height=40% --reverse || true)
-            board="${choice#pcb-}"
-        else
-            echo "Usage: just nix::pcb <board>" >&2
-            echo "  e.g. just nix::pcb keyboard-pico42" >&2
-            exit 1
-        fi
+      pkgs=$(
+        nix eval .#packages.x86_64-linux \
+          --apply 'pkgs: builtins.concatStringsSep "\n" (builtins.attrNames pkgs)' 2>/dev/null \
+          | tr -d '"' \
+          | tr ',' '\n' \
+          | grep '^pcb-' \
+          || true
+      )
+      if [ -z "$pkgs" ]; then
+        pkgs=$(
+          ls pcb/*.kicad_pcb 2>/dev/null \
+            | xargs -n1 basename -s .kicad_pcb \
+            | sed 's/^/pcb-/'
+        )
+      fi
+      choice=$(
+        echo "$pkgs" \
+          | fzf --prompt="nix pcb> " \
+            --height=40% \
+            --reverse \
+          || true
+      )
+      board="${choice#pcb-}"
     fi
     [ -z "$board" ] && exit 1
     nix build ".#pcb-$board" --show-trace
@@ -40,13 +48,14 @@ shell target="pcb":
     set -euo pipefail
     t="{{target}}"
     if [ -z "$t" ] || [ "$t" = "pcb" ]; then
-        nix develop .#pcb --command bash -l
+      nix develop .#pcb --command bash -l
     elif [ "$t" = "firmware" ] || [ "$t" = "firmware-keyberon" ]; then
-        nix develop .#firmware-keyberon --command bash -l
+      nix develop .#firmware-keyberon --command bash -l
     else
-        echo "unknown shell: $t (try pcb|firmware)" >&2; exit 1
+      echo "unknown shell: $t (try pcb|firmware)" >&2; exit 1
     fi
 
 [doc("interactive chooser for nix recipes")]
 choose:
-    @just --choose --chooser "fzf --prompt='nix> ' --height=40% --reverse" 2>/dev/null || just --choose
+    @just --choose --chooser "fzf --prompt='nix> ' --height=40% --reverse" 2>/dev/null \
+      || just --choose

--- a/pcb/justfile
+++ b/pcb/justfile
@@ -28,7 +28,10 @@ kibot board="":
     set -euo pipefail
     board="{{ board }}"
     if [ -z "$board" ]; then
-        board=$({{ source_directory() }}/choose-board.sh --prompt "pcb kibot> ") || true
+      board=$(
+        {{ source_directory() }}/choose-board.sh --prompt "pcb kibot> " \
+          || true
+      )
     fi
     [ -z "$board" ] && exit 1
     kibot_bin="${KIBOT:-{{ source_directory() }}/run-kibot.sh}"
@@ -41,7 +44,10 @@ pcba board="":
     set -euo pipefail
     board="{{ board }}"
     if [ -z "$board" ]; then
-        board=$({{ source_directory() }}/choose-board.sh --prompt "pcb pcba> ") || true
+      board=$(
+        {{ source_directory() }}/choose-board.sh --prompt "pcb pcba> " \
+          || true
+      )
     fi
     [ -z "$board" ] && exit 1
     kibot_bin="${KIBOT:-{{ source_directory() }}/run-kibot.sh}"
@@ -55,7 +61,10 @@ ibom board="":
     set -euo pipefail
     board="{{ board }}"
     if [ -z "$board" ]; then
-        board=$({{ source_directory() }}/choose-board.sh --prompt "pcb ibom> " --ibom-only) || true
+      board=$(
+        {{ source_directory() }}/choose-board.sh --prompt "pcb ibom> " --ibom-only \
+          || true
+      )
     fi
     [ -z "$board" ] && exit 1
     kibot_bin="${KIBOT:-{{ source_directory() }}/run-kibot.sh}"


### PR DESCRIPTION
Tidy up the justfiles.

1. `list` recipe was inelegant and not very useful in the various subfolders.
2. Break long lines up with backslashes (indenting continuation).