### PR TITLE
Improve UX for generating PCBA fabrication outputs

### DIFF
--- a/pcb/Makefile
+++ b/pcb/Makefile
@@ -8,6 +8,23 @@ KIBOT ?= kibot
 kicad_pcbs := $(wildcard *.kicad_pcb)
 boards := $(basename $(kicad_pcbs))
 
+# Boards that are hand-solderable only - no PCBA by default.
+# These are intentionally excluded from the `all` PCBA build.
+#  - minif4  : keyboard-100x100-minif4-dual-rgb-reversible
+#  - x2 lumberjack arm (both variants)
+#  - pico42, ch552-44, WABBLE-60
+handsolder_boards := \
+  keyboard-100x100-minif4-dual-rgb-reversible \
+  keyboard-x2-lumberjack-arm \
+  keyboard-x2-lumberjack-arm-hsrgb \
+  keyboard-pico42 \
+  keyboard-ch552-44 \
+  keyboard-wabble-60
+
+# PCBA-capable boards: everything else (minus demo helper).
+# New boards are PCBA-included by default; add to handsolder_boards to opt out.
+pcba_boards := $(filter-out $(handsolder_boards) demo-usb-16pin,$(boards))
+
 ibom_targets := \
   keyboard-x2-lumberjack-arm-ibom \
   keyboard-x2-lumberjack-arm-hsrgb-ibom \
@@ -16,12 +33,16 @@ ibom_targets := \
   keyboard-ch552-36-ibom \
   keyboard-wabble-60-ibom
 kibot_targets := $(foreach board,$(boards),$(board)-kibot)
+pcba_targets := $(foreach board,$(pcba_boards),$(board)-pcba)
 
 .PHONY: all
-all: $(kibot_targets) iboms
+all: $(kibot_targets) $(pcba_targets) iboms
 
 .PHONY: iboms
 iboms: $(ibom_targets)
+
+.PHONY: pcbas
+pcbas: $(pcba_targets)
 
 .PHONY: %-kibot
 %-kibot:

--- a/pcb/justfile
+++ b/pcb/justfile
@@ -1,15 +1,15 @@
 # pcb - UX wrappers for pcb/Makefile (kibot / fab / ibom)
 #
 # `just pcb` opens chooser;
-# `just pcb::fab <board>` builds fabrication outputs.
+# `just pcb::fab <board>` builds fabrication outputs (alias for kibot).
 
 # interactive chooser entrypoint for this module
 [doc("interactive chooser for pcb recipes")]
 choose:
     @just --choose --chooser "fzf --prompt='pcb> ' --height=40% --reverse" 2>/dev/null
 
-# run all kibot + ibom targets (same as `make -C pcb all`)
-[doc("build all kibot + iboms (make all)")]
+# run all kibot + pcba + ibom targets (same as `make -C pcb all`)
+[doc("build all kibot + pcba + iboms (make all)")]
 all:
     #!/usr/bin/env bash
     set -euo pipefail
@@ -21,6 +21,14 @@ all:
 iboms:
     kibot_bin="${KIBOT:-{{ source_directory() }}/run-kibot.sh}"
     make -C "{{ source_directory() }}" iboms
+
+[doc("build all pcba outputs (make pcbas) - PCBA boards only")]
+pcbas:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    kibot_bin="${KIBOT:-{{ source_directory() }}/run-kibot.sh}"
+    echo "→ KIBOT=$kibot_bin make -C {{ source_directory() }} pcbas" >&2
+    KIBOT="$kibot_bin" make -C "{{ source_directory() }}" pcbas
 
 [doc("build default kibot outputs for board (gerbers/docs, no pcba)")]
 kibot board="":
@@ -37,6 +45,12 @@ kibot board="":
     kibot_bin="${KIBOT:-{{ source_directory() }}/run-kibot.sh}"
     echo "→ KIBOT=$kibot_bin make -C {{ source_directory() }} $board-kibot" >&2
     KIBOT="$kibot_bin" make -C "{{ source_directory() }}" "$board-kibot"
+
+[doc("build fabrication outputs for board (gerbers/docs, no pcba) - alias for kibot")]
+fab board="": (kibot board)
+
+[doc("build fabrication outputs for board (gerbers/docs, no pcba) - alias for kibot")]
+fabrication board="": (kibot board)
 
 [doc("generate pcba outputs for board (BOM + CPL, for JLC)")]
 pcba board="":


### PR DESCRIPTION
- The `pcb/` `Makefile`'s `all` target didn't generate PCBA files. This was by choice.. but I think it's not really a good choice. `make all` might as well generate the PCBA outputs.
- The justfile had `kibot` for generating the gerbers etc. using kibot. I think having `fabrication` as the recipe name is clearer.