### PR TITLE
pcb: makefile: remove 'iboms' from 'all'

### DIFF
--- a/pcb/Makefile
+++ b/pcb/Makefile
@@ -36,7 +36,7 @@ kibot_targets := $(foreach board,$(boards),$(board)-kibot)
 pcba_targets := $(foreach board,$(pcba_boards),$(board)-pcba)
 
 .PHONY: all
-all: $(kibot_targets) $(pcba_targets) iboms
+all: $(kibot_targets) $(pcba_targets)
 
 .PHONY: iboms
 iboms: $(ibom_targets)

--- a/pcb/justfile
+++ b/pcb/justfile
@@ -8,8 +8,8 @@
 choose:
     @just --choose --chooser "fzf --prompt='pcb> ' --height=40% --reverse" 2>/dev/null
 
-# run all kibot + pcba + ibom targets (same as `make -C pcb all`)
-[doc("build all kibot + pcba + iboms (make all)")]
+# run all kibot + pcba targets (same as `make -C pcb all`)
+[doc("build all kibot + pcba (make all)")]
 all:
     #!/usr/bin/env bash
     set -euo pipefail


### PR DESCRIPTION
Generating iboms requires the InteractiveHtmlBom tool.

The other outputs: I provide these through a kibot docker container, or through a Nix shell.

With ibom, it's easier to just not run by default.